### PR TITLE
added token tracker and openrouter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ log/*
 logs/
 parts/*
 json_results/*
+venv/*

--- a/pageindex/__init__.py
+++ b/pageindex/__init__.py
@@ -1,2 +1,3 @@
 from .page_index import *
 from .page_index_md import md_to_tree
+from .token_tracker import TokenTracker, get_global_tracker, reset_global_tracker

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -5,12 +5,13 @@ import math
 import random
 import re
 from .utils import *
+from .token_tracker import get_global_tracker
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 ################### check title in page #########################################################
-async def check_title_appearance(item, page_list, start_index=1, model=None):    
+async def check_title_appearance(item, page_list, start_index=1, model=None, api_key=None, base_url=None):    
     title=item['title']
     if 'physical_index' not in item or item['physical_index'] is None:
         return {'list_index': item.get('list_index'), 'answer': 'no', 'title':title, 'page_number': None}
@@ -35,8 +36,9 @@ async def check_title_appearance(item, page_list, start_index=1, model=None):
         "answer": "yes or no" (yes if the section appears or starts in the page_text, no otherwise)
     }}
     Directly return the final JSON structure. Do not output anything else."""
-
-    response = await ChatGPT_API_async(model=model, prompt=prompt)
+    
+    response, token_usage = await ChatGPT_API_async(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'check_title_appearance')
     response = extract_json(response)
     if 'answer' in response:
         answer = response['answer']
@@ -45,7 +47,7 @@ async def check_title_appearance(item, page_list, start_index=1, model=None):
     return {'list_index': item['list_index'], 'answer': answer, 'title': title, 'page_number': page_number}
 
 
-async def check_title_appearance_in_start(title, page_text, model=None, logger=None):    
+async def check_title_appearance_in_start(title, page_text, model=None, logger=None, api_key=None, base_url=None):    
     prompt = f"""
     You will be given the current section title and the current page_text.
     Your job is to check if the current section starts in the beginning of the given page_text.
@@ -64,14 +66,15 @@ async def check_title_appearance_in_start(title, page_text, model=None, logger=N
     }}
     Directly return the final JSON structure. Do not output anything else."""
 
-    response = await ChatGPT_API_async(model=model, prompt=prompt)
+    response, token_usage = await ChatGPT_API_async(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'check_title_appearance_in_start')
     response = extract_json(response)
     if logger:
         logger.info(f"Response: {response}")
     return response.get("start_begin", "no")
 
 
-async def check_title_appearance_in_start_concurrent(structure, page_list, model=None, logger=None):
+async def check_title_appearance_in_start_concurrent(structure, page_list, model=None, logger=None, api_key=None, base_url=None):
     if logger:
         logger.info("Checking title appearance in start concurrently")
     
@@ -86,7 +89,7 @@ async def check_title_appearance_in_start_concurrent(structure, page_list, model
     for item in structure:
         if item.get('physical_index') is not None:
             page_text = page_list[item['physical_index'] - 1][0]
-            tasks.append(check_title_appearance_in_start(item['title'], page_text, model=model, logger=logger))
+            tasks.append(check_title_appearance_in_start(item['title'], page_text, model=model, logger=logger, api_key=api_key, base_url=base_url))
             valid_items.append(item)
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -101,7 +104,7 @@ async def check_title_appearance_in_start_concurrent(structure, page_list, model
     return structure
 
 
-def toc_detector_single_page(content, model=None):
+def toc_detector_single_page(content, model=None, api_key=None, base_url=None):
     prompt = f"""
     Your job is to detect if there is a table of content provided in the given text.
 
@@ -116,13 +119,16 @@ def toc_detector_single_page(content, model=None):
     Directly return the final JSON structure. Do not output anything else.
     Please note: abstract,summary, notation list, figure list, table list, etc. are not table of contents."""
 
-    response = ChatGPT_API(model=model, prompt=prompt)
+
+
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'toc_detector_single_page')
     # print('response', response)
     json_content = extract_json(response)    
     return json_content['toc_detected']
 
 
-def check_if_toc_extraction_is_complete(content, toc, model=None):
+def check_if_toc_extraction_is_complete(content, toc, model=None, api_key=None, base_url=None):
     prompt = f"""
     You are given a partial document  and a  table of contents.
     Your job is to check if the  table of contents is complete, which it contains all the main sections in the partial document.
@@ -135,12 +141,13 @@ def check_if_toc_extraction_is_complete(content, toc, model=None):
     Directly return the final JSON structure. Do not output anything else."""
 
     prompt = prompt + '\n Document:\n' + content + '\n Table of contents:\n' + toc
-    response = ChatGPT_API(model=model, prompt=prompt)
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'check_if_toc_extraction_is_complete')
     json_content = extract_json(response)
     return json_content['completed']
 
 
-def check_if_toc_transformation_is_complete(content, toc, model=None):
+def check_if_toc_transformation_is_complete(content, toc, model=None, api_key=None, base_url=None):
     prompt = f"""
     You are given a raw table of contents and a  table of contents.
     Your job is to check if the  table of contents is complete.
@@ -153,11 +160,12 @@ def check_if_toc_transformation_is_complete(content, toc, model=None):
     Directly return the final JSON structure. Do not output anything else."""
 
     prompt = prompt + '\n Raw Table of contents:\n' + content + '\n Cleaned Table of contents:\n' + toc
-    response = ChatGPT_API(model=model, prompt=prompt)
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'check_if_toc_transformation_is_complete')
     json_content = extract_json(response)
     return json_content['completed']
 
-def extract_toc_content(content, model=None):
+def extract_toc_content(content, model=None, api_key=None, base_url=None):
     prompt = f"""
     Your job is to extract the full table of contents from the given text, replace ... with :
 
@@ -165,9 +173,10 @@ def extract_toc_content(content, model=None):
 
     Directly return the full table of contents content. Do not output anything else."""
 
-    response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt)
+    response, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'extract_toc_content')
     
-    if_complete = check_if_toc_transformation_is_complete(content, response, model)
+    if_complete = check_if_toc_transformation_is_complete(content, response, model, api_key=api_key, base_url=base_url)
     if if_complete == "yes" and finish_reason == "finished":
         return response
     
@@ -176,9 +185,10 @@ def extract_toc_content(content, model=None):
         {"role": "assistant", "content": response},    
     ]
     prompt = f"""please continue the generation of table of contents , directly output the remaining part of the structure"""
-    new_response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, chat_history=chat_history)
+    new_response, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, chat_history=chat_history, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'extract_toc_content_continue')
     response = response + new_response
-    if_complete = check_if_toc_transformation_is_complete(content, response, model)
+    if_complete = check_if_toc_transformation_is_complete(content, response, model, api_key=api_key, base_url=base_url)
     
     while not (if_complete == "yes" and finish_reason == "finished"):
         chat_history = [
@@ -186,9 +196,10 @@ def extract_toc_content(content, model=None):
             {"role": "assistant", "content": response},    
         ]
         prompt = f"""please continue the generation of table of contents , directly output the remaining part of the structure"""
-        new_response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, chat_history=chat_history)
+        new_response, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, chat_history=chat_history, api_key=api_key, base_url=base_url)
+        get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'extract_toc_content_loop')
         response = response + new_response
-        if_complete = check_if_toc_transformation_is_complete(content, response, model)
+        if_complete = check_if_toc_transformation_is_complete(content, response, model, api_key=api_key, base_url=base_url)
         
         # Optional: Add a maximum retry limit to prevent infinite loops
         if len(chat_history) > 5:  # Arbitrary limit of 10 attempts
@@ -196,7 +207,7 @@ def extract_toc_content(content, model=None):
     
     return response
 
-def detect_page_index(toc_content, model=None):
+def detect_page_index(toc_content, model=None, api_key=None, base_url=None):
     print('start detect_page_index')
     prompt = f"""
     You will be given a table of contents.
@@ -212,11 +223,12 @@ def detect_page_index(toc_content, model=None):
     }}
     Directly return the final JSON structure. Do not output anything else."""
 
-    response = ChatGPT_API(model=model, prompt=prompt)
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'detect_page_index')
     json_content = extract_json(response)
     return json_content['page_index_given_in_toc']
 
-def toc_extractor(page_list, toc_page_list, model):
+def toc_extractor(page_list, toc_page_list, model, api_key=None, base_url=None):
     def transform_dots_to_colon(text):
         text = re.sub(r'\.{5,}', ': ', text)
         # Handle dots separated by spaces
@@ -227,7 +239,7 @@ def toc_extractor(page_list, toc_page_list, model):
     for page_index in toc_page_list:
         toc_content += page_list[page_index][0]
     toc_content = transform_dots_to_colon(toc_content)
-    has_page_index = detect_page_index(toc_content, model=model)
+    has_page_index = detect_page_index(toc_content, model=model, api_key=api_key, base_url=base_url)
     
     return {
         "toc_content": toc_content,
@@ -237,7 +249,7 @@ def toc_extractor(page_list, toc_page_list, model):
 
 
 
-def toc_index_extractor(toc, content, model=None):
+def toc_index_extractor(toc, content, model=None, api_key=None, base_url=None):
     print('start toc_index_extractor')
     tob_extractor_prompt = """
     You are given a table of contents in a json format and several pages of a document, your job is to add the physical_index to the table of contents in the json format.
@@ -261,13 +273,14 @@ def toc_index_extractor(toc, content, model=None):
     Directly return the final JSON structure. Do not output anything else."""
 
     prompt = tob_extractor_prompt + '\nTable of contents:\n' + str(toc) + '\nDocument pages:\n' + content
-    response = ChatGPT_API(model=model, prompt=prompt)
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'toc_index_extractor')
     json_content = extract_json(response)    
     return json_content
 
 
 
-def toc_transformer(toc_content, model=None):
+def toc_transformer(toc_content, model=None, api_key=None, base_url=None):
     print('start toc_transformer')
     init_prompt = """
     You are given a table of contents, You job is to transform the whole table of content into a JSON format included table_of_contents.
@@ -289,8 +302,10 @@ def toc_transformer(toc_content, model=None):
     Directly return the final JSON structure, do not output anything else. """
 
     prompt = init_prompt + '\n Given table of contents\n:' + toc_content
-    last_complete, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt)
-    if_complete = check_if_toc_transformation_is_complete(toc_content, last_complete, model)
+
+    last_complete, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'toc_transformer')
+    if_complete = check_if_toc_transformation_is_complete(toc_content, last_complete, model, api_key=api_key, base_url=base_url)
     if if_complete == "yes" and finish_reason == "finished":
         last_complete = extract_json(last_complete)
         cleaned_response=convert_page_to_int(last_complete['table_of_contents'])
@@ -313,13 +328,14 @@ def toc_transformer(toc_content, model=None):
 
         Please continue the json structure, directly output the remaining part of the json structure."""
 
-        new_complete, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt)
+        new_complete, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+        get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'toc_transformer_continue')
 
         if new_complete.startswith('```json'):
             new_complete =  get_json_content(new_complete)
             last_complete = last_complete+new_complete
 
-        if_complete = check_if_toc_transformation_is_complete(toc_content, last_complete, model)
+        if_complete = check_if_toc_transformation_is_complete(toc_content, last_complete, model, api_key=api_key, base_url=base_url)
         
 
     last_complete = json.loads(last_complete)
@@ -340,7 +356,7 @@ def find_toc_pages(start_page_index, page_list, opt, logger=None):
         # Only check beyond max_pages if we're still finding TOC pages
         if i >= opt.toc_check_page_num and not last_page_is_yes:
             break
-        detected_result = toc_detector_single_page(page_list[i][0],model=opt.model)
+        detected_result = toc_detector_single_page(page_list[i][0], model=opt.model, api_key=opt.api_key, base_url=opt.base_url)
         if detected_result == 'yes':
             if logger:
                 logger.info(f'Page {i} has toc')
@@ -450,7 +466,7 @@ def page_list_to_group_text(page_contents, token_lengths, max_tokens=20000, over
     print('divide page_list to groups', len(subsets))
     return subsets
 
-def add_page_number_to_toc(part, structure, model=None):
+def add_page_number_to_toc(part, structure, model=None, api_key=None, base_url=None):
     fill_prompt_seq = """
     You are given an JSON structure of a document and a partial part of the document. Your task is to check if the title that is described in the structure is started in the partial given document.
 
@@ -474,7 +490,8 @@ def add_page_number_to_toc(part, structure, model=None):
     Directly return the final JSON structure. Do not output anything else."""
 
     prompt = fill_prompt_seq + f"\n\nCurrent Partial Document:\n{part}\n\nGiven Structure\n{json.dumps(structure, indent=2)}\n"
-    current_json_raw = ChatGPT_API(model=model, prompt=prompt)
+    current_json_raw, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'add_page_number_to_toc')
     json_result = extract_json(current_json_raw)
     
     for item in json_result:
@@ -496,7 +513,7 @@ def remove_first_physical_index_section(text):
     return text
 
 ### add verify completeness
-def generate_toc_continue(toc_content, part, model="gpt-4o-2024-11-20"):
+def generate_toc_continue(toc_content, part, model="openai/gpt-4o-2024-11-20", api_key=None, base_url=None):
     print('start generate_toc_continue')
     prompt = """
     You are an expert in extracting hierarchical tree structure.
@@ -524,14 +541,15 @@ def generate_toc_continue(toc_content, part, model="gpt-4o-2024-11-20"):
     Directly return the additional part of the final JSON structure. Do not output anything else."""
 
     prompt = prompt + '\nGiven text\n:' + part + '\nPrevious tree structure\n:' + json.dumps(toc_content, indent=2)
-    response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt)
+    response, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'generate_toc_continue')
     if finish_reason == 'finished':
         return extract_json(response)
     else:
         raise Exception(f'finish reason: {finish_reason}')
     
 ### add verify completeness
-def generate_toc_init(part, model=None):
+def generate_toc_init(part, model=None, api_key=None, base_url=None):
     print('start generate_toc_init')
     prompt = """
     You are an expert in extracting hierarchical tree structure, your task is to generate the tree structure of the document.
@@ -558,14 +576,15 @@ def generate_toc_init(part, model=None):
     Directly return the final JSON structure. Do not output anything else."""
 
     prompt = prompt + '\nGiven text\n:' + part
-    response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt)
+    response, finish_reason, token_usage = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'generate_toc_init')
 
     if finish_reason == 'finished':
          return extract_json(response)
     else:
         raise Exception(f'finish reason: {finish_reason}')
 
-def process_no_toc(page_list, start_index=1, model=None, logger=None):
+def process_no_toc(page_list, start_index=1, model=None, logger=None, api_key=None, base_url=None):
     page_contents=[]
     token_lengths=[]
     for page_index in range(start_index, start_index+len(page_list)):
@@ -575,9 +594,9 @@ def process_no_toc(page_list, start_index=1, model=None, logger=None):
     group_texts = page_list_to_group_text(page_contents, token_lengths)
     logger.info(f'len(group_texts): {len(group_texts)}')
 
-    toc_with_page_number= generate_toc_init(group_texts[0], model)
+    toc_with_page_number= generate_toc_init(group_texts[0], model, api_key=api_key, base_url=base_url)
     for group_text in group_texts[1:]:
-        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model)    
+        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model, api_key=api_key, base_url=base_url)    
         toc_with_page_number.extend(toc_with_page_number_additional)
     logger.info(f'generate_toc: {toc_with_page_number}')
 
@@ -586,10 +605,10 @@ def process_no_toc(page_list, start_index=1, model=None, logger=None):
 
     return toc_with_page_number
 
-def process_toc_no_page_numbers(toc_content, toc_page_list, page_list,  start_index=1, model=None, logger=None):
+def process_toc_no_page_numbers(toc_content, toc_page_list, page_list,  start_index=1, model=None, logger=None, api_key=None, base_url=None):
     page_contents=[]
     token_lengths=[]
-    toc_content = toc_transformer(toc_content, model)
+    toc_content = toc_transformer(toc_content, model, api_key=api_key, base_url=base_url)
     logger.info(f'toc_transformer: {toc_content}')
     for page_index in range(start_index, start_index+len(page_list)):
         page_text = f"<physical_index_{page_index}>\n{page_list[page_index-start_index][0]}\n<physical_index_{page_index}>\n\n"
@@ -601,7 +620,7 @@ def process_toc_no_page_numbers(toc_content, toc_page_list, page_list,  start_in
 
     toc_with_page_number=copy.deepcopy(toc_content)
     for group_text in group_texts:
-        toc_with_page_number = add_page_number_to_toc(group_text, toc_with_page_number, model)
+        toc_with_page_number = add_page_number_to_toc(group_text, toc_with_page_number, model, api_key=api_key, base_url=base_url)
     logger.info(f'add_page_number_to_toc: {toc_with_page_number}')
 
     toc_with_page_number = convert_physical_index_to_int(toc_with_page_number)
@@ -611,8 +630,8 @@ def process_toc_no_page_numbers(toc_content, toc_page_list, page_list,  start_in
 
 
 
-def process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_check_page_num=None, model=None, logger=None):
-    toc_with_page_number = toc_transformer(toc_content, model)
+def process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_check_page_num=None, model=None, logger=None, api_key=None, base_url=None):
+    toc_with_page_number = toc_transformer(toc_content, model, api_key=api_key, base_url=base_url)
     logger.info(f'toc_with_page_number: {toc_with_page_number}')
 
     toc_no_page_number = remove_page_number(copy.deepcopy(toc_with_page_number))
@@ -622,7 +641,7 @@ def process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_che
     for page_index in range(start_page_index, min(start_page_index + toc_check_page_num, len(page_list))):
         main_content += f"<physical_index_{page_index+1}>\n{page_list[page_index][0]}\n<physical_index_{page_index+1}>\n\n"
 
-    toc_with_physical_index = toc_index_extractor(toc_no_page_number, main_content, model)
+    toc_with_physical_index = toc_index_extractor(toc_no_page_number, main_content, model, api_key=api_key, base_url=base_url)
     logger.info(f'toc_with_physical_index: {toc_with_physical_index}')
 
     toc_with_physical_index = convert_physical_index_to_int(toc_with_physical_index)
@@ -637,7 +656,7 @@ def process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_che
     toc_with_page_number = add_page_offset_to_toc_json(toc_with_page_number, offset)
     logger.info(f'toc_with_page_number: {toc_with_page_number}')
 
-    toc_with_page_number = process_none_page_numbers(toc_with_page_number, page_list, model=model)
+    toc_with_page_number = process_none_page_numbers(toc_with_page_number, page_list, model=model, api_key=api_key, base_url=base_url)
     logger.info(f'toc_with_page_number: {toc_with_page_number}')
 
     return toc_with_page_number
@@ -645,7 +664,7 @@ def process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_che
 
 
 ##check if needed to process none page numbers
-def process_none_page_numbers(toc_items, page_list, start_index=1, model=None):
+def process_none_page_numbers(toc_items, page_list, start_index=1, model=None, api_key=None, base_url=None):
     for i, item in enumerate(toc_items):
         if "physical_index" not in item:
             # logger.info(f"fix item: {item}")
@@ -675,7 +694,7 @@ def process_none_page_numbers(toc_items, page_list, start_index=1, model=None):
 
             item_copy = copy.deepcopy(item)
             del item_copy['page']
-            result = add_page_number_to_toc(page_contents, item_copy, model)
+            result = add_page_number_to_toc(page_contents, item_copy, model, api_key=api_key, base_url=base_url)
             if isinstance(result[0]['physical_index'], str) and result[0]['physical_index'].startswith('<physical_index'):
                 item['physical_index'] = int(result[0]['physical_index'].split('_')[-1].rstrip('>').strip())
                 del item['page']
@@ -692,7 +711,7 @@ def check_toc(page_list, opt=None):
         return {'toc_content': None, 'toc_page_list': [], 'page_index_given_in_toc': 'no'}
     else:
         print('toc found')
-        toc_json = toc_extractor(page_list, toc_page_list, opt.model)
+        toc_json = toc_extractor(page_list, toc_page_list, opt.model, api_key=opt.api_key, base_url=opt.base_url)
 
         if toc_json['page_index_given_in_toc'] == 'yes':
             print('index found')
@@ -713,7 +732,7 @@ def check_toc(page_list, opt=None):
                 if len(additional_toc_pages) == 0:
                     break
 
-                additional_toc_json = toc_extractor(page_list, additional_toc_pages, opt.model)
+                additional_toc_json = toc_extractor(page_list, additional_toc_pages, opt.model, api_key=opt.api_key, base_url=opt.base_url)
                 if additional_toc_json['page_index_given_in_toc'] == 'yes':
                     print('index found')
                     return {'toc_content': additional_toc_json['toc_content'], 'toc_page_list': additional_toc_pages, 'page_index_given_in_toc': 'yes'}
@@ -729,27 +748,18 @@ def check_toc(page_list, opt=None):
 
 
 ################### fix incorrect toc #########################################################
-def single_toc_item_index_fixer(section_title, content, model="gpt-4o-2024-11-20"):
-    tob_extractor_prompt = """
-    You are given a section title and several pages of a document, your job is to find the physical index of the start page of the section in the partial document.
-
-    The provided pages contains tags like <physical_index_X> and <physical_index_X> to indicate the physical location of the page X.
-
-    Reply in a JSON format:
-    {
-        "thinking": <explain which page, started and closed by <physical_index_X>, contains the start of this section>,
-        "physical_index": "<physical_index_X>" (keep the format)
-    }
-    Directly return the final JSON structure. Do not output anything else."""
+def single_toc_item_index_fixer(section_title, content, model="gpt-4o-2024-11-20", api_key=None, base_url=None):
+    tob_extractor_prompt = ""
 
     prompt = tob_extractor_prompt + '\nSection Title:\n' + str(section_title) + '\nDocument pages:\n' + content
-    response = ChatGPT_API(model=model, prompt=prompt)
+    response, token_usage = ChatGPT_API(model=model, prompt=prompt, api_key=api_key, base_url=base_url)
+    get_global_tracker().add_usage(token_usage['prompt_tokens'], token_usage['completion_tokens'], 'single_toc_item_index_fixer')
     json_content = extract_json(response)    
     return convert_physical_index_to_int(json_content['physical_index'])
 
 
 
-async def fix_incorrect_toc(toc_with_page_number, page_list, incorrect_results, start_index=1, model=None, logger=None):
+async def fix_incorrect_toc(toc_with_page_number, page_list, incorrect_results, start_index=1, model=None, logger=None, api_key=None, base_url=None):
     print(f'start fix_incorrect_toc with {len(incorrect_results)} incorrect results')
     incorrect_indices = {result['list_index'] for result in incorrect_results}
     
@@ -812,12 +822,12 @@ async def fix_incorrect_toc(toc_with_page_number, page_list, incorrect_results, 
                 continue
         content_range = ''.join(page_contents)
         
-        physical_index_int = single_toc_item_index_fixer(incorrect_item['title'], content_range, model)
+        physical_index_int = single_toc_item_index_fixer(incorrect_item['title'], content_range, model, api_key=api_key, base_url=base_url)
         
         # Check if the result is correct
         check_item = incorrect_item.copy()
         check_item['physical_index'] = physical_index_int
-        check_result = await check_title_appearance(check_item, page_list, start_index, model)
+        check_result = await check_title_appearance(check_item, page_list, start_index, model, api_key=api_key, base_url=base_url)
 
         return {
             'list_index': list_index,
@@ -867,7 +877,7 @@ async def fix_incorrect_toc(toc_with_page_number, page_list, incorrect_results, 
 
 
 
-async def fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorrect_results, start_index=1, max_attempts=3, model=None, logger=None):
+async def fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorrect_results, start_index=1, max_attempts=3, model=None, logger=None, api_key=None, base_url=None):
     print('start fix_incorrect_toc')
     fix_attempt = 0
     current_toc = toc_with_page_number
@@ -876,7 +886,7 @@ async def fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorr
     while current_incorrect:
         print(f"Fixing {len(current_incorrect)} incorrect results")
         
-        current_toc, current_incorrect = await fix_incorrect_toc(current_toc, page_list, current_incorrect, start_index, model, logger)
+        current_toc, current_incorrect = await fix_incorrect_toc(current_toc, page_list, current_incorrect, start_index, model, logger, api_key=api_key, base_url=base_url)
                 
         fix_attempt += 1
         if fix_attempt >= max_attempts:
@@ -889,7 +899,7 @@ async def fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorr
 
 
 ################### verify toc #########################################################
-async def verify_toc(page_list, list_result, start_index=1, N=None, model=None):
+async def verify_toc(page_list, list_result, start_index=1, N=None, model=None, api_key=None, base_url=None):
     print('start verify_toc')
     # Find the last non-None physical_index
     last_physical_index = None
@@ -923,7 +933,7 @@ async def verify_toc(page_list, list_result, start_index=1, N=None, model=None):
 
     # Run checks concurrently
     tasks = [
-        check_title_appearance(item, page_list, start_index, model)
+        check_title_appearance(item, page_list, start_index, model, api_key=api_key, base_url=base_url)
         for item in indexed_sample_list
     ]
     results = await asyncio.gather(*tasks)
@@ -953,11 +963,11 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
     print(f'start_index: {start_index}')
     
     if mode == 'process_toc_with_page_numbers':
-        toc_with_page_number = process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_check_page_num=opt.toc_check_page_num, model=opt.model, logger=logger)
+        toc_with_page_number = process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_check_page_num=opt.toc_check_page_num, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
     elif mode == 'process_toc_no_page_numbers':
-        toc_with_page_number = process_toc_no_page_numbers(toc_content, toc_page_list, page_list, model=opt.model, logger=logger)
+        toc_with_page_number = process_toc_no_page_numbers(toc_content, toc_page_list, page_list, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
     else:
-        toc_with_page_number = process_no_toc(page_list, start_index=start_index, model=opt.model, logger=logger)
+        toc_with_page_number = process_no_toc(page_list, start_index=start_index, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
             
     toc_with_page_number = [item for item in toc_with_page_number if item.get('physical_index') is not None] 
     
@@ -968,7 +978,7 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
         logger=logger
     )
     
-    accuracy, incorrect_results = await verify_toc(page_list, toc_with_page_number, start_index=start_index, model=opt.model)
+    accuracy, incorrect_results = await verify_toc(page_list, toc_with_page_number, start_index=start_index, model=opt.model, api_key=opt.api_key, base_url=opt.base_url)
         
     logger.info({
         'mode': 'process_toc_with_page_numbers',
@@ -978,7 +988,7 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
     if accuracy == 1.0 and len(incorrect_results) == 0:
         return toc_with_page_number
     if accuracy > 0.6 and len(incorrect_results) > 0:
-        toc_with_page_number, incorrect_results = await fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorrect_results,start_index=start_index, max_attempts=3, model=opt.model, logger=logger)
+        toc_with_page_number, incorrect_results = await fix_incorrect_toc_with_retries(toc_with_page_number, page_list, incorrect_results,start_index=start_index, max_attempts=3, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
         return toc_with_page_number
     else:
         if mode == 'process_toc_with_page_numbers':
@@ -997,7 +1007,7 @@ async def process_large_node_recursively(node, page_list, opt=None, logger=None)
         print('large node:', node['title'], 'start_index:', node['start_index'], 'end_index:', node['end_index'], 'token_num:', token_num)
 
         node_toc_tree = await meta_processor(node_page_list, mode='process_no_toc', start_index=node['start_index'], opt=opt, logger=logger)
-        node_toc_tree = await check_title_appearance_in_start_concurrent(node_toc_tree, page_list, model=opt.model, logger=logger)
+        node_toc_tree = await check_title_appearance_in_start_concurrent(node_toc_tree, page_list, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
         
         # Filter out items with None physical_index before post_processing
         valid_node_toc_items = [item for item in node_toc_tree if item.get('physical_index') is not None]
@@ -1040,7 +1050,7 @@ async def tree_parser(page_list, opt, doc=None, logger=None):
             logger=logger)
 
     toc_with_page_number = add_preface_if_needed(toc_with_page_number)
-    toc_with_page_number = await check_title_appearance_in_start_concurrent(toc_with_page_number, page_list, model=opt.model, logger=logger)
+    toc_with_page_number = await check_title_appearance_in_start_concurrent(toc_with_page_number, page_list, model=opt.model, logger=logger, api_key=opt.api_key, base_url=opt.base_url)
     
     # Filter out items with None physical_index before post_processings
     valid_toc_items = [item for item in toc_with_page_number if item.get('physical_index') is not None]
@@ -1080,13 +1090,13 @@ def page_index_main(doc, opt=None):
         if opt.if_add_node_summary == 'yes':
             if opt.if_add_node_text == 'no':
                 add_node_text(structure, page_list)
-            await generate_summaries_for_structure(structure, model=opt.model)
+            await generate_summaries_for_structure(structure, model=opt.model, api_key=opt.api_key, base_url=opt.base_url)
             if opt.if_add_node_text == 'no':
                 remove_structure_text(structure)
             if opt.if_add_doc_description == 'yes':
                 # Create a clean structure without unnecessary fields for description generation
                 clean_structure = create_clean_structure_for_description(structure)
-                doc_description = generate_doc_description(clean_structure, model=opt.model)
+                doc_description = generate_doc_description(clean_structure, model=opt.model, api_key=opt.api_key, base_url=opt.base_url)
                 return {
                     'doc_name': get_pdf_name(doc),
                     'doc_description': doc_description,
@@ -1112,10 +1122,6 @@ def page_index(doc, model=None, toc_check_page_num=None, max_page_num_each_node=
 
 
 def validate_and_truncate_physical_indices(toc_with_page_number, page_list_length, start_index=1, logger=None):
-    """
-    Validates and truncates physical indices that exceed the actual document length.
-    This prevents errors when TOC references pages that don't exist in the document (e.g. the file is broken or incomplete).
-    """
     if not toc_with_page_number:
         return toc_with_page_number
     

--- a/pageindex/page_index_md.py
+++ b/pageindex/page_index_md.py
@@ -7,18 +7,18 @@ try:
 except:
     from utils import *
 
-async def get_node_summary(node, summary_token_threshold=200, model=None):
+async def get_node_summary(node, summary_token_threshold=200, model=None, api_key=None, base_url=None):
     node_text = node.get('text')
     num_tokens = count_tokens(node_text, model=model)
     if num_tokens < summary_token_threshold:
         return node_text
     else:
-        return await generate_node_summary(node, model=model)
+        return await generate_node_summary(node, model=model, api_key=api_key, base_url=base_url)
 
 
-async def generate_summaries_for_structure_md(structure, summary_token_threshold, model=None):
+async def generate_summaries_for_structure_md(structure, summary_token_threshold, model=None, api_key=None, base_url=None):
     nodes = structure_to_list(structure)
-    tasks = [get_node_summary(node, summary_token_threshold=summary_token_threshold, model=model) for node in nodes]
+    tasks = [get_node_summary(node, summary_token_threshold=summary_token_threshold, model=model, api_key=api_key, base_url=base_url) for node in nodes]
     summaries = await asyncio.gather(*tasks)
     
     for node, summary in zip(nodes, summaries):
@@ -240,7 +240,7 @@ def clean_tree_for_output(tree_nodes):
     return cleaned_nodes
 
 
-async def md_to_tree(md_path, if_thinning=False, min_token_threshold=None, if_add_node_summary='no', summary_token_threshold=None, model=None, if_add_doc_description='no', if_add_node_text='no', if_add_node_id='yes'):
+async def md_to_tree(md_path, if_thinning=False, min_token_threshold=None, if_add_node_summary='no', summary_token_threshold=None, model=None, if_add_doc_description='no', if_add_node_text='no', if_add_node_id='yes', api_key=None, base_url=None):
     with open(md_path, 'r', encoding='utf-8') as f:
         markdown_content = f.read()
     
@@ -268,7 +268,7 @@ async def md_to_tree(md_path, if_thinning=False, min_token_threshold=None, if_ad
         tree_structure = format_structure(tree_structure, order = ['title', 'node_id', 'summary', 'prefix_summary', 'text', 'line_num', 'nodes'])
         
         print(f"Generating summaries for each node...")
-        tree_structure = await generate_summaries_for_structure_md(tree_structure, summary_token_threshold=summary_token_threshold, model=model)
+        tree_structure = await generate_summaries_for_structure_md(tree_structure, summary_token_threshold=summary_token_threshold, model=model, api_key=api_key, base_url=base_url)
         
         if if_add_node_text == 'no':
             # Remove text after summary generation if not requested
@@ -278,7 +278,7 @@ async def md_to_tree(md_path, if_thinning=False, min_token_threshold=None, if_ad
             print(f"Generating document description...")
             # Create a clean structure without unnecessary fields for description generation
             clean_structure = create_clean_structure_for_description(tree_structure)
-            doc_description = generate_doc_description(clean_structure, model=model)
+            doc_description = generate_doc_description(clean_structure, model=model, api_key=api_key, base_url=base_url)
             return {
                 'doc_name': os.path.splitext(os.path.basename(md_path))[0],
                 'doc_description': doc_description,

--- a/pageindex/token_tracker.py
+++ b/pageindex/token_tracker.py
@@ -1,0 +1,104 @@
+"""
+Token usage tracker for monitoring LLM API calls.
+Tracks prompt tokens, completion tokens, and total tokens across all API calls.
+"""
+
+class TokenTracker:
+    """Singleton-style token tracker to accumulate usage across all LLM calls."""
+    
+    def __init__(self):
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        self.total_tokens = 0
+        self.call_count = 0
+    def __init__(self):
+        self.enabled = False
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        self.total_tokens = 0
+        self.call_count = 0
+        self.call_history = []
+    
+    def enable(self):
+        """Enable token tracking."""
+        self.enabled = True
+
+    def disable(self):
+        """Disable token tracking."""
+        self.enabled = False
+    
+    def add_usage(self, prompt_tokens, completion_tokens, call_name="LLM Call"):
+        """
+        Add token usage from a single LLM call.
+        
+        Args:
+            prompt_tokens: Number of tokens in the prompt
+            completion_tokens: Number of tokens in the completion
+            call_name: Name/description of the call for logging
+        """
+        if not self.enabled:
+            return
+            
+        total = prompt_tokens + completion_tokens
+        
+        self.total_prompt_tokens += prompt_tokens
+        self.total_completion_tokens += completion_tokens
+        self.total_tokens += total
+        self.call_count += 1
+        
+        # Store call history
+        call_info = {
+            'call_number': self.call_count,
+            'call_name': call_name,
+            'prompt_tokens': prompt_tokens,
+            'completion_tokens': completion_tokens,
+            'total_tokens': total
+        }
+        self.call_history.append(call_info)
+        
+        # Print to console
+        # Print to console in greppable format
+        print(f"TOKEN_USAGE: call_id={self.call_count} name={call_name} prompt={prompt_tokens} completion={completion_tokens} total={total}")
+    
+    def get_summary(self):
+        """
+        Get summary of total token usage.
+        
+        Returns:
+            dict: Summary with total counts and call count
+        """
+        return {
+            'total_calls': self.call_count,
+            'total_prompt_tokens': self.total_prompt_tokens,
+            'total_completion_tokens': self.total_completion_tokens,
+            'total_tokens': self.total_tokens,
+            'call_history': self.call_history
+        }
+    
+    def print_summary(self):
+        """Print a formatted summary of token usage."""
+        print(f"TOKEN_SUMMARY: total_calls={self.call_count} prompt={self.total_prompt_tokens} completion={self.total_completion_tokens} total={self.total_tokens}")
+    
+    def reset(self):
+        """Reset all counters to zero."""
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        self.total_tokens = 0
+        self.call_count = 0
+        self.call_history = []
+
+
+# Global instance for easy access
+_global_tracker = None
+
+def get_global_tracker():
+    """Get or create the global token tracker instance."""
+    global _global_tracker
+    if _global_tracker is None:
+        _global_tracker = TokenTracker()
+    return _global_tracker
+
+def reset_global_tracker():
+    """Reset the global token tracker."""
+    global _global_tracker
+    _global_tracker = TokenTracker()


### PR DESCRIPTION
- added OpenRouter support via `--use-openrouter` (yes) option (required  `OPENROUTER_API_KEY` env var and defaults to `gpt-4o-mini model` (available in operouter free tier)
- added a token tracker that prints token usage to console (both for each call and for total usage) via the `--enable-token-tracking` (yes) option