### PR TITLE
fix: make ChatGPT_API_with_finish_reason return consistent tuple

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -54,7 +54,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
                 time.sleep(1)  # Wait for 1秒 before retrying
             else:
                 logging.error('Max retries reached for prompt: ' + prompt)
-                return "Error"
+                return "", "error"
 
 
 


### PR DESCRIPTION
## Summary

Fixes #62 - Make `ChatGPT_API_with_finish_reason` return consistent tuple type on error.

## Problem

The function returned `(content, finish_reason)` on success but `"Error"` string when max retries reached, causing unpacking errors.

## Change

- Return `("", "error")` tuple instead of `"Error"` string
- Maintains consistent return type for all code paths

## Test

Manual testing of error scenarios.