### PR TITLE
fix: prevent infinite loop in extract_toc_content

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -180,19 +180,22 @@ def extract_toc_content(content, model=None):
     response = response + new_response
     if_complete = check_if_toc_transformation_is_complete(content, response, model)
     
+    attempt = 0
+    max_attempts = 5
+
     while not (if_complete == "yes" and finish_reason == "finished"):
+        attempt += 1
+        if attempt > max_attempts:
+            raise Exception('Failed to complete table of contents after maximum retries')
+
         chat_history = [
-            {"role": "user", "content": prompt}, 
-            {"role": "assistant", "content": response},    
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": response},
         ]
         prompt = f"""please continue the generation of table of contents , directly output the remaining part of the structure"""
         new_response, finish_reason = ChatGPT_API_with_finish_reason(model=model, prompt=prompt, chat_history=chat_history)
         response = response + new_response
         if_complete = check_if_toc_transformation_is_complete(content, response, model)
-        
-        # Optional: Add a maximum retry limit to prevent infinite loops
-        if len(chat_history) > 5:  # Arbitrary limit of 10 attempts
-            raise Exception('Failed to complete table of contents after maximum retries')
     
     return response
 


### PR DESCRIPTION
Fixes #64

## Summary

Fix broken infinite loop protection in `extract_toc_content()`.

## Problem

The function used `len(chat_history) > 5` to exit the loop, but `chat_history` was rebuilt every iteration with exactly 2 elements, making the check never true.

## Change

- Add explicit `attempt` counter initialized to 0
- Add `max_attempts = 5` constant
- Check `attempt > max_attempts` instead of `len(chat_history) > 5`
- Move check to beginning of loop for earlier exit

## Test

Manual code review - the logic now correctly counts iterations and exits after 5 attempts.