### PR TITLE
fix: use pop() instead of del in process_none_page_numbers

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -674,11 +674,11 @@ def process_none_page_numbers(toc_items, page_list, start_index=1, model=None):
                     continue
 
             item_copy = copy.deepcopy(item)
-            del item_copy['page']
+            item_copy.pop('page', None)
             result = add_page_number_to_toc(page_contents, item_copy, model)
             if isinstance(result[0]['physical_index'], str) and result[0]['physical_index'].startswith('<physical_index'):
                 item['physical_index'] = int(result[0]['physical_index'].split('_')[-1].rstrip('>').strip())
-                del item['page']
+                item.pop('page', None)
     
     return toc_items
 


### PR DESCRIPTION
Fixes #69

## Summary

Replace `del item['page']` with `item.pop('page', None)` to avoid KeyError when 'page' key doesn't exist.

## Change

- Line 677: `del item_copy['page']` → `item_copy.pop('page', None)`
- Line 681: `del item['page']` → `item.pop('page', None)`

## Impact

- Before: `KeyError` crashes the process if 'page' key is missing
- After: Gracefully handles missing 'page' key