### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Preferred reporting channels:
+
+1. **GitHub Security Advisories** (if enabled): use the repository’s “Report a vulnerability” flow.
+2. **Email**: send details to `ray@vectify.ai`.
+
+Include as much of the following as possible:
+- A clear description of the issue and potential impact
+- Steps to reproduce (PoC, request/response samples, screenshots where relevant)
+- Affected versions/commit and environment details
+- Any suggested remediation
+
+## Response Expectations
+
+We aim to acknowledge reports within **3 business days** and will coordinate a fix/patch timeline based on severity and reproducibility.
+
+## Bug Bounty
+
+We do not currently run a formal bug bounty program. Valid reports may still be acknowledged in release notes or the security advisory, at our discretion.


### PR DESCRIPTION
## Summary
Add a minimal `SECURITY.md` so security researchers have a clear, private reporting path.

## Changes
- Add `SECURITY.md` with reporting channels and expected response timelines

Addresses #80
