### PR TITLE
Test: prevent KeyError in physical_index conversion

### DIFF
--- a/tests/test_convert_physical_index_to_int.py
+++ b/tests/test_convert_physical_index_to_int.py
@@ -1,0 +1,13 @@
+import unittest
+
+from pageindex.utils import convert_physical_index_to_int
+
+
+class TestConvertPhysicalIndexToInt(unittest.TestCase):
+    def test_missing_key_does_not_raise(self) -> None:
+        data = [
+            {"title": "no physical index"},
+            {"title": "has physical index", "physical_index": "<physical_index_5>"},
+        ]
+        out = convert_physical_index_to_int(data)
+        self.assertEqual(out[1]["physical_index"], 5)


### PR DESCRIPTION
## Summary
Add a small regression test to ensure `convert_physical_index_to_int()` handles list items without a `physical_index` key (prevents the KeyError reported in #1).

## Changes
- Add `tests/test_convert_physical_index_to_int.py`

Addresses #1
