### PR TITLE
Fix KeyError in process_none_page_numbers (#97)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ log/*
 logs/
 parts/*
 json_results/*
+.idea/*

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 
 <details open>
-<summary><h2>📢 Latest Updates</h2></summary>
+<summary><h3>📢 Latest Updates</h3></summary>
 
  **🔥 Releases:**
 - [**PageIndex Chat**](https://chat.pageindex.ai): The first human-like document-analysis agent [platform](https://chat.pageindex.ai) built for professional long documents. Can also be integrated via [MCP](https://pageindex.ai/mcp) or [API](https://docs.pageindex.ai/quickstart) (beta).
@@ -62,7 +62,7 @@ It simulates how *human experts* navigate and extract knowledge from complex doc
   </a>
 </div>
 
-### 🎯 Features 
+### 🎯 Core Features 
 
 Compared to traditional vector-based RAG, **PageIndex** features:
 - **No Vector DB**: Uses document structure and LLM reasoning for retrieval, instead of vector similarity search.

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -674,11 +674,11 @@ def process_none_page_numbers(toc_items, page_list, start_index=1, model=None):
                     continue
 
             item_copy = copy.deepcopy(item)
-            del item_copy['page']
+            item_copy.pop('page', None)
             result = add_page_number_to_toc(page_contents, item_copy, model)
             if isinstance(result[0]['physical_index'], str) and result[0]['physical_index'].startswith('<physical_index'):
                 item['physical_index'] = int(result[0]['physical_index'].split('_')[-1].rstrip('>').strip())
-                del item['page']
+                item.pop('page', None)
     
     return toc_items
 


### PR DESCRIPTION
Description

This PR addresses issue #97 where process_none_page_numbers raises a KeyError when attempting to delete the 'page' key from TOC items that do not have it. This typically occurs when items are created from generated or cleaned list entries without page numbers.

1. Modified: pageindex/page_index.py, Replaced del item['page'] with item.pop('page', None) to safely remove the key only if it exists. Applied the same safe removal to item_copy.

2. I also added .idea/ in the .gitignore file to ignore my ide's default configs....

Related Issue
Fixes #97