### PR TITLE
 fix(utils): add missing re import for start_index parsing helpers

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -8,6 +8,7 @@ import json
 import PyPDF2
 import copy
 import asyncio
+import re
 import pymupdf
 from io import BytesIO
 from dotenv import load_dotenv


### PR DESCRIPTION
  ## Summary
  - add missing `import re` in `pageindex/utils.py`
  - fix potential runtime error in:
    - `get_first_start_page_from_text`
    - `get_last_start_page_from_text`

  ## Why
  These helpers call `re.search` / `re.finditer`, but `re` was not imported, which can raise `NameError` when the
  functions are used.

  ## Scope
  Minimal fix only, no behavior change beyond preventing the runtime error.