### PR TITLE
Fix typo in header for the step: Extract JSON results

### DIFF
--- a/cookbook/agentic_retrieval.ipynb
+++ b/cookbook/agentic_retrieval.ipynb
@@ -441,7 +441,7 @@
         "id": "d-Y9towQ_CiF"
       },
       "source": [
-        "### Exctarct the JSON retreived results"
+        "### Extract the JSON retreived results"
       ]
     },
     {


### PR DESCRIPTION
Fixed typo in 3-level header in the notebook _Exctarct_ -> _Extract_