### PR TITLE
feat: add Novita AI as optional LLM provider

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -25,7 +25,7 @@ NOVITA_BASE_URL = "https://api.novita.ai/openai"
 def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
     """Get OpenAI client - supports both OpenAI and Novita AI (OpenAI-compatible)."""
     client_cls = openai.AsyncOpenAI if async_client else openai.OpenAI
-    if NOVITA_API_KEY and (api_key in [None, CHATGPT_API_KEY]):
+    if NOVITA_API_KEY and api_key == CHATGPT_API_KEY:
         return client_cls(api_key=NOVITA_API_KEY, base_url=NOVITA_BASE_URL)
     return client_cls(api_key=api_key)
 

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -18,6 +18,15 @@ from pathlib import Path
 from types import SimpleNamespace as config
 
 CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
+# Novita AI - OpenAI-compatible API support
+NOVITA_API_KEY = os.getenv("NOVITA_API_KEY")
+NOVITA_BASE_URL = "https://api.novita.ai/openai"
+
+def get_openai_client():
+    """Get OpenAI client - supports both OpenAI and Novita AI (OpenAI-compatible)."""
+    if NOVITA_API_KEY:
+        return openai.OpenAI(api_key=NOVITA_API_KEY, base_url=NOVITA_BASE_URL)
+    return openai.OpenAI(api_key=CHATGPT_API_KEY)
 
 def count_tokens(text, model=None):
     if not text:
@@ -28,7 +37,7 @@ def count_tokens(text, model=None):
 
 def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
-    client = openai.OpenAI(api_key=api_key)
+    client = get_openai_client()
     for i in range(max_retries):
         try:
             if chat_history:
@@ -60,7 +69,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
 
 def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
-    client = openai.OpenAI(api_key=api_key)
+    client = get_openai_client()
     for i in range(max_retries):
         try:
             if chat_history:

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -21,6 +21,8 @@ CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
 # Novita AI - OpenAI-compatible API support
 NOVITA_API_KEY = os.getenv("NOVITA_API_KEY")
 NOVITA_BASE_URL = "https://api.novita.ai/openai"
+NOVITA_MODEL = os.getenv("NOVITA_MODEL")
+DEFAULT_OPENAI_MODEL = "gpt-4o-2024-11-20"
 
 def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
     """Get OpenAI client - supports both OpenAI and Novita AI (OpenAI-compatible)."""
@@ -28,6 +30,14 @@ def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
     if NOVITA_API_KEY and api_key == CHATGPT_API_KEY:
         return client_cls(api_key=NOVITA_API_KEY, base_url=NOVITA_BASE_URL)
     return client_cls(api_key=api_key)
+
+def resolve_chat_model(model, api_key=CHATGPT_API_KEY):
+    """Resolve model name for OpenAI-compatible providers."""
+    if NOVITA_API_KEY and api_key == CHATGPT_API_KEY and model == DEFAULT_OPENAI_MODEL:
+        if NOVITA_MODEL:
+            return NOVITA_MODEL
+        raise ValueError("NOVITA_MODEL is required when using NOVITA_API_KEY with default model gpt-4o-2024-11-20.")
+    return model
 
 def count_tokens(text, model=None):
     if not text:
@@ -39,6 +49,7 @@ def count_tokens(text, model=None):
 def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
     client = get_openai_client(api_key=api_key)
+    resolved_model = resolve_chat_model(model, api_key=api_key)
     for i in range(max_retries):
         try:
             if chat_history:
@@ -48,7 +59,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
                 messages = [{"role": "user", "content": prompt}]
             
             response = client.chat.completions.create(
-                model=model,
+                model=resolved_model,
                 messages=messages,
                 temperature=0,
             )
@@ -71,6 +82,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
 def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
     client = get_openai_client(api_key=api_key)
+    resolved_model = resolve_chat_model(model, api_key=api_key)
     for i in range(max_retries):
         try:
             if chat_history:
@@ -80,7 +92,7 @@ def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
                 messages = [{"role": "user", "content": prompt}]
             
             response = client.chat.completions.create(
-                model=model,
+                model=resolved_model,
                 messages=messages,
                 temperature=0,
             )
@@ -98,12 +110,13 @@ def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
 
 async def ChatGPT_API_async(model, prompt, api_key=CHATGPT_API_KEY):
     max_retries = 10
+    resolved_model = resolve_chat_model(model, api_key=api_key)
     messages = [{"role": "user", "content": prompt}]
     for i in range(max_retries):
         try:
             async with get_openai_client(api_key=api_key, async_client=True) as client:
                 response = await client.chat.completions.create(
-                    model=model,
+                    model=resolved_model,
                     messages=messages,
                     temperature=0,
                 )

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -22,6 +22,7 @@ CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
 NOVITA_API_KEY = os.getenv("NOVITA_API_KEY")
 NOVITA_BASE_URL = "https://api.novita.ai/openai"
 NOVITA_MODEL = os.getenv("NOVITA_MODEL")
+NOVITA_DEFAULT_MODEL = "deepseek/deepseek-r1"
 DEFAULT_OPENAI_MODEL = "gpt-4o-2024-11-20"
 
 def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
@@ -34,9 +35,7 @@ def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
 def resolve_chat_model(model, api_key=CHATGPT_API_KEY):
     """Resolve model name for OpenAI-compatible providers."""
     if NOVITA_API_KEY and api_key == CHATGPT_API_KEY and model == DEFAULT_OPENAI_MODEL:
-        if NOVITA_MODEL:
-            return NOVITA_MODEL
-        raise ValueError("NOVITA_MODEL is required when using NOVITA_API_KEY with default model gpt-4o-2024-11-20.")
+        return NOVITA_MODEL or NOVITA_DEFAULT_MODEL
     return model
 
 def count_tokens(text, model=None):

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -22,11 +22,12 @@ CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
 NOVITA_API_KEY = os.getenv("NOVITA_API_KEY")
 NOVITA_BASE_URL = "https://api.novita.ai/openai"
 
-def get_openai_client():
+def get_openai_client(api_key=CHATGPT_API_KEY, async_client=False):
     """Get OpenAI client - supports both OpenAI and Novita AI (OpenAI-compatible)."""
-    if NOVITA_API_KEY:
-        return openai.OpenAI(api_key=NOVITA_API_KEY, base_url=NOVITA_BASE_URL)
-    return openai.OpenAI(api_key=CHATGPT_API_KEY)
+    client_cls = openai.AsyncOpenAI if async_client else openai.OpenAI
+    if NOVITA_API_KEY and (api_key in [None, CHATGPT_API_KEY]):
+        return client_cls(api_key=NOVITA_API_KEY, base_url=NOVITA_BASE_URL)
+    return client_cls(api_key=api_key)
 
 def count_tokens(text, model=None):
     if not text:
@@ -37,7 +38,7 @@ def count_tokens(text, model=None):
 
 def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
-    client = get_openai_client()
+    client = get_openai_client(api_key=api_key)
     for i in range(max_retries):
         try:
             if chat_history:
@@ -69,7 +70,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
 
 def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
     max_retries = 10
-    client = get_openai_client()
+    client = get_openai_client(api_key=api_key)
     for i in range(max_retries):
         try:
             if chat_history:
@@ -100,7 +101,7 @@ async def ChatGPT_API_async(model, prompt, api_key=CHATGPT_API_KEY):
     messages = [{"role": "user", "content": prompt}]
     for i in range(max_retries):
         try:
-            async with openai.AsyncOpenAI(api_key=api_key) as client:
+            async with get_openai_client(api_key=api_key, async_client=True) as client:
                 response = await client.chat.completions.create(
                     model=model,
                     messages=messages,


### PR DESCRIPTION
## What this PR does

Adds [Novita AI](https://novita.ai) as an optional, OpenAI-compatible LLM provider.

**Usage:** Set `NOVITA_API_KEY` in your environment to use Novita instead of OpenAI.

Novita provides competitive pricing with the same OpenAI-compatible API endpoint.

## Changes

- Added `get_openai_client()` helper function
- Supports both OpenAI (`CHATGPT_API_KEY`) and Novita (`NOVITA_API_KEY`)
- Added `.env.example` with configuration instructions