### PR TITLE
Improve node summary prompt and add timestamped output filenames

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -603,9 +603,11 @@ def add_node_text_with_labels(node, pdf_pages):
 
 
 async def generate_node_summary(node, model=None):
-    prompt = f"""You are given a part of a document, your task is to generate a description of the partial document about what are main points covered in the partial document.
+    prompt = f"""You are given a section of a document. Your task is to generate a description of ONLY the section titled "{node['title']}".
+    Focus only on the content that belongs to this section, not the entire page text.
 
-    Partial Document Text: {node['text']}
+    Section Title: {node['title']}
+    Page Text: {node['text']}
     
     Directly return the description, do not include any other text.
     """

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -70,7 +70,9 @@ if __name__ == "__main__":
         # Save results
         pdf_name = os.path.splitext(os.path.basename(args.pdf_path))[0]    
         output_dir = './results'
-        output_file = f'{output_dir}/{pdf_name}_structure.json'
+        from datetime import datetime
+        current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_file = f'{output_dir}/{pdf_name}_structure_{current_time}.json'
         os.makedirs(output_dir, exist_ok=True)
         
         with open(output_file, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary

- **Improved node summary generation**: Updated the prompt in `generate_node_summary` to include the section title and instruct the LLM to focus only on that specific section's content, rather than treating the entire page text generically. This produces more accurate, scoped summaries.
- **Timestamped output filenames**: Added a timestamp (`YYYYMMDD_HHMMSS`) to the output JSON filename in `run_pageindex.py`, so multiple runs on the same PDF don't overwrite previous results.

## Motivation

The original summary prompt passed the full page text without any section context, leading to summaries that could drift to cover content from other sections on the same page. By anchoring the prompt to the node's title, the LLM generates more relevant descriptions.

Timestamped filenames are a simple quality-of-life improvement for users who iterate on the same document.

## Files Changed

- `pageindex/utils.py` — Updated prompt in `generate_node_summary()`
- `run_pageindex.py` — Added datetime-based suffix to output filename


Made with [Cursor](https://cursor.com)