### PR TITLE
Add pyproject.toml for pip/uv installability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pageindex"
+version = "0.1.0"
+description = "Vectorless, reasoning-based RAG via hierarchical document tree indexing"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+authors = [
+    {name = "Vectify AI"},
+]
+keywords = ["rag", "retrieval", "llm", "document-indexing", "tree-structure", "pageindex"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+dependencies = [
+    "openai>=1.0.0",
+    "tiktoken",
+    "PyPDF2",
+    "pymupdf",
+    "python-dotenv",
+    "pyyaml",
+]
+
+[project.urls]
+Homepage = "https://vectify.ai/pageindex"
+Documentation = "https://docs.pageindex.ai"
+Repository = "https://github.com/VectifyAI/PageIndex"
+Changelog = "https://github.com/VectifyAI/PageIndex/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Adds a minimal `pyproject.toml` at the repository root so that PageIndex can be installed as a proper Python package:

```bash
pip install git+https://github.com/VectifyAI/PageIndex.git
```

or with [uv](https://docs.astral.sh/uv/):

```bash
uv pip install git+https://github.com/VectifyAI/PageIndex.git
```

It can also be declared as a dependency in downstream projects:

```toml
dependencies = [
    "pageindex @ git+https://github.com/VectifyAI/PageIndex.git@main",
]
```

## Changes

- **New file: `pyproject.toml`** — uses [hatchling](https://hatch.pypa.io/) as the build backend with the same dependencies already listed in `requirements.txt`, but with flexible lower bounds (standard practice for library packages).
- **No other files are modified.** The existing `requirements.txt` with pinned versions is kept for backward compatibility.

## Tested

- `pip install -e .` — ✅ editable install succeeds
- `pip install .` — ✅ non-editable install succeeds
- `import pageindex` — ✅ all public APIs importable
- `config.yaml` included as package data — ✅ `ConfigLoader` works
- `pip show pageindex` — ✅ metadata correct

Closes #103
