### PR TITLE
Allow github-actions bot to trigger claude-code-action

### DIFF
--- a/.github/workflows/issue-dedupe.yml
+++ b/.github/workflows/issue-dedupe.yml
@@ -54,3 +54,4 @@ jobs:
           anthropic_api_key: ${{ secrets.AUTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: "--model claude-sonnet-4-5-20250929"
+          allowed_bots: "github-actions"


### PR DESCRIPTION
Backfill workflow triggers issue-dedupe via gh workflow run, making the actor github-actions (bot). Add allowed_bots to accept backfill-triggered runs.