### PR TITLE
Add MiniMax model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,20 +149,27 @@ pip3 install --upgrade -r requirements.txt
 
 ### 2. Set your API key
 
-Create a `.env` file in the root directory and add your API key:
+Create a `.env` file in the root directory and add your API key for your chosen provider:
 
 ```bash
-# For OpenAI models (default)
+# OpenAI (default)
 CHATGPT_API_KEY=your_openai_key_here
 
-# For MiniMax models
+# MiniMax (optional)
 MINIMAX_API_KEY=your_minimax_key_here
 ```
 
 ### 3. Run PageIndex on your PDF
 
+**OpenAI (default):**
 ```bash
 python3 run_pageindex.py --pdf_path /path/to/your/document.pdf
+```
+
+**MiniMax:**
+```bash
+python3 run_pageindex.py --pdf_path /path/to/your/document.pdf \
+    --provider minimax --model MiniMax-Text-01
 ```
 
 <details>
@@ -171,7 +178,9 @@ python3 run_pageindex.py --pdf_path /path/to/your/document.pdf
 You can customize the processing with additional optional arguments:
 
 ```
---model                 Model to use (default: gpt-4o-2024-11-20, also supports MiniMax-M1, MiniMax-M2.5, etc.)
+--model                 Model to use (default: gpt-4o-2024-11-20)
+--provider              LLM provider: openai or minimax (default: openai)
+--api-base-url          Custom API base URL (e.g. https://api.minimax.io/v1 for MiniMax)
 --toc-check-pages       Pages to check for table of contents (default: 20)
 --max-pages-per-node    Max pages per node (default: 10)
 --max-tokens-per-node   Max tokens per node (default: 20000)
@@ -179,6 +188,24 @@ You can customize the processing with additional optional arguments:
 --if-add-node-summary   Add node summary (yes/no, default: yes)
 --if-add-doc-description Add doc description (yes/no, default: yes)
 ```
+
+You can also set the provider via environment variables instead of CLI flags:
+```bash
+export LLM_PROVIDER=minimax
+export API_BASE_URL=https://api.minimax.io/v1  # optional, for custom endpoints
+```
+</details>
+
+<details>
+<summary><strong>Supported LLM Providers</strong></summary>
+<br>
+
+| Provider | Example Models | API Key Env Var | Notes |
+|----------|---------------|-----------------|-------|
+| **OpenAI** (default) | `gpt-4o-2024-11-20`, `gpt-4o-mini` | `CHATGPT_API_KEY` | Full support, recommended |
+| **MiniMax** | `MiniMax-M2.5 | `MINIMAX_API_KEY` | Full support via OpenAI-compatible API at `https://api.minimax.io/v1` |
+
+**Note:** PageIndex relies on structured JSON output from the LLM. For best results, use capable models (GPT-4o or MiniMax-Text-01). Smaller models may produce lower-quality tree structures.
 </details>
 
 <details>

--- a/pageindex/config.yaml
+++ b/pageindex/config.yaml
@@ -1,4 +1,6 @@
 model: "gpt-4o-2024-11-20"
+provider: "openai"  # "openai" or "minimax"
+api_base_url: null  # Custom API base URL (e.g. https://api.minimax.io/v1 for MiniMax)
 toc_check_page_num: 20
 max_page_num_each_node: 10
 max_token_num_each_node: 20000

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -1057,7 +1057,17 @@ async def tree_parser(page_list, opt, doc=None, logger=None):
 
 def page_index_main(doc, opt=None):
     logger = JsonLogger(doc)
-    
+
+    # Set provider config from opt so all downstream API calls pick it up
+    if hasattr(opt, 'provider') and opt.provider:
+        os.environ['LLM_PROVIDER'] = opt.provider
+        from pageindex import utils
+        utils.LLM_PROVIDER = opt.provider
+    if hasattr(opt, 'api_base_url') and opt.api_base_url:
+        os.environ['API_BASE_URL'] = opt.api_base_url
+        from pageindex import utils
+        utils.API_BASE_URL = opt.api_base_url
+
     is_valid_pdf = (
         (isinstance(doc, str) and os.path.isfile(doc) and doc.lower().endswith(".pdf")) or 
         isinstance(doc, BytesIO)
@@ -1066,7 +1076,7 @@ def page_index_main(doc, opt=None):
         raise ValueError("Unsupported input type. Expected a PDF file path or BytesIO object.")
 
     print('Parsing PDF...')
-    page_list = get_page_tokens(doc)
+    page_list = get_page_tokens(doc, model=opt.model)
 
     logger.info({'total_page_number': len(page_list)})
     logger.info({'total_token': sum([page[1] for page in page_list])})
@@ -1100,7 +1110,8 @@ def page_index_main(doc, opt=None):
     return asyncio.run(page_index_builder())
 
 
-def page_index(doc, model=None, toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
+def page_index(doc, model=None, provider=None, api_base_url=None,
+               toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
                if_add_node_id=None, if_add_node_summary=None, if_add_doc_description=None, if_add_node_text=None):
     
     user_opt = {

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -19,19 +19,65 @@ from types import SimpleNamespace as config
 
 CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
 MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
+LLM_PROVIDER = os.getenv("LLM_PROVIDER", "openai")  # "openai" or "minimax"
+API_BASE_URL = os.getenv("API_BASE_URL")  # Custom API base URL
 
-MINIMAX_BASE_URL = "https://api.minimaxi.com/v1"
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
 
 def _is_minimax_model(model):
-    return model and model.lower().startswith("minimax")
+    """Check if the model is a MiniMax model by name prefix."""
+    if not model:
+        return False
+    model_lower = model.lower()
+    # Support various MiniMax model naming patterns:
+    # - minimax-m1, minimax-m2.5, minimax-m2.5-highspeed
+    # - MiniMax-Text-01, abab6.5s-chat, etc.
+    return model_lower.startswith("minimax") or model_lower.startswith("abab")
 
-def _get_client_kwargs(model, api_key=None):
+
+def _get_provider_config(provider=None, api_key=None, base_url=None):
+    """Resolve provider, api_key, and base_url from args or environment."""
+    provider = provider or LLM_PROVIDER
+    
+    if provider == "minimax":
+        return {
+            "provider": "minimax",
+            "api_key": api_key or MINIMAX_API_KEY,
+            "base_url": base_url or API_BASE_URL or MINIMAX_BASE_URL,
+        }
+    else:  # openai (default)
+        cfg = {
+            "provider": "openai",
+            "api_key": api_key or CHATGPT_API_KEY,
+        }
+        if base_url or API_BASE_URL:
+            cfg["base_url"] = base_url or API_BASE_URL
+        return cfg
+
+
+def _get_client_kwargs(model, api_key=None, provider=None, base_url=None):
+    """Get OpenAI client kwargs based on model name or explicit provider config."""
+    # If provider is explicitly set, use provider config
+    if provider:
+        pcfg = _get_provider_config(provider, api_key, base_url)
+        client_kwargs = {"api_key": pcfg["api_key"]}
+        if "base_url" in pcfg:
+            client_kwargs["base_url"] = pcfg["base_url"]
+        return client_kwargs
+    
+    # Auto-detect based on model name
     if _is_minimax_model(model):
         return {
             "api_key": api_key or MINIMAX_API_KEY,
-            "base_url": MINIMAX_BASE_URL,
+            "base_url": base_url or API_BASE_URL or MINIMAX_BASE_URL,
         }
-    return {"api_key": api_key or CHATGPT_API_KEY}
+    
+    # Default to OpenAI
+    cfg = {"api_key": api_key or CHATGPT_API_KEY}
+    if base_url or API_BASE_URL:
+        cfg["base_url"] = base_url or API_BASE_URL
+    return cfg
 
 def count_tokens(text, model=None):
     if not text:
@@ -43,9 +89,9 @@ def count_tokens(text, model=None):
     tokens = enc.encode(text)
     return len(tokens)
 
-def ChatGPT_API_with_finish_reason(model, prompt, api_key=None, chat_history=None):
+def ChatGPT_API_with_finish_reason(model, prompt, api_key=None, chat_history=None, provider=None, base_url=None):
     max_retries = 10
-    client = openai.OpenAI(**_get_client_kwargs(model, api_key))
+    client = openai.OpenAI(**_get_client_kwargs(model, api_key, provider, base_url))
     for i in range(max_retries):
         try:
             if chat_history:
@@ -75,9 +121,9 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=None, chat_history=Non
 
 
 
-def ChatGPT_API(model, prompt, api_key=None, chat_history=None):
+def ChatGPT_API(model, prompt, api_key=None, chat_history=None, provider=None, base_url=None):
     max_retries = 10
-    client = openai.OpenAI(**_get_client_kwargs(model, api_key))
+    client = openai.OpenAI(**_get_client_kwargs(model, api_key, provider, base_url))
     for i in range(max_retries):
         try:
             if chat_history:
@@ -103,12 +149,12 @@ def ChatGPT_API(model, prompt, api_key=None, chat_history=None):
                 return "Error"
             
 
-async def ChatGPT_API_async(model, prompt, api_key=None):
+async def ChatGPT_API_async(model, prompt, api_key=None, provider=None, base_url=None):
     max_retries = 10
     messages = [{"role": "user", "content": prompt}]
     for i in range(max_retries):
         try:
-            async with openai.AsyncOpenAI(**_get_client_kwargs(model, api_key)) as client:
+            async with openai.AsyncOpenAI(**_get_client_kwargs(model, api_key, provider, base_url)) as client:
                 response = await client.chat.completions.create(
                     model=model,
                     messages=messages,

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -10,7 +10,13 @@ if __name__ == "__main__":
     parser.add_argument('--pdf_path', type=str, help='Path to the PDF file')
     parser.add_argument('--md_path', type=str, help='Path to the Markdown file')
 
-    parser.add_argument('--model', type=str, default='gpt-4o-2024-11-20', help='Model to use')
+    parser.add_argument('--model', type=str, default='gpt-4o-2024-11-20', 
+                      help='Model to use (e.g. gpt-4o-2024-11-20, MiniMax-Text-01, abab6.5s-chat)')
+    parser.add_argument('--provider', type=str, default='openai',
+                      choices=['openai', 'minimax'],
+                      help='LLM provider: openai or minimax (default: openai)')
+    parser.add_argument('--api-base-url', type=str, default=None,
+                      help='Custom API base URL (e.g. https://api.minimax.io/v1 for MiniMax)')
 
     parser.add_argument('--toc-check-pages', type=int, default=20, 
                       help='Number of pages to check for table of contents (PDF only)')
@@ -54,6 +60,8 @@ if __name__ == "__main__":
         # Configure options
         opt = config(
             model=args.model,
+            provider=args.provider,
+            api_base_url=args.api_base_url,
             toc_check_page_num=args.toc_check_pages,
             max_page_num_each_node=args.max_pages_per_node,
             max_token_num_each_node=args.max_tokens_per_node,
@@ -98,6 +106,8 @@ if __name__ == "__main__":
         # Create options dict with user args
         user_opt = {
             'model': args.model,
+            'provider': args.provider,
+            'api_base_url': args.api_base_url,
             'if_add_node_summary': args.if_add_node_summary,
             'if_add_doc_description': args.if_add_doc_description,
             'if_add_node_text': args.if_add_node_text,


### PR DESCRIPTION
## Summary
- Add MiniMax model support via their OpenAI-compatible API (`https://api.minimaxi.com/v1`)
- Auto-detect MiniMax models by name prefix and route to the correct API endpoint
- Fix tiktoken fallback to `cl100k_base` for non-OpenAI models
- Update README with MiniMax API key setup and model options

## Usage
```bash
# Set MiniMax API key in .env
MINIMAX_API_KEY=your_minimax_key_here

# Run with MiniMax model
python3 run_pageindex.py --pdf_path doc.pdf --model MiniMax-M2.5
```

Supported MiniMax models: `MiniMax-M1`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, etc.

## Design
Since MiniMax provides an OpenAI-compatible API, the implementation reuses the existing OpenAI SDK client by passing a custom `base_url`. A helper function `_get_client_kwargs()` selects the right credentials and endpoint based on the model name. No new dependencies required.

## Test plan
- [x] Verified imports and helper functions work correctly
- [x] Verified backward compatibility with OpenAI models (no behavior change)
- [x] Verified token counting fallback for non-OpenAI model names

Relates to #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)