### PR TITLE
Rename CHATGPT_API_KEY to OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ pip3 install --upgrade -r requirements.txt
 Create a `.env` file in the root directory and add your API key:
 
 ```bash
-CHATGPT_API_KEY=your_openai_key_here
+OPENAI_API_KEY=your_openai_key_here
 ```
 
 ### 3. Run PageIndex on your PDF

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -17,7 +17,7 @@ import yaml
 from pathlib import Path
 from types import SimpleNamespace as config
 
-CHATGPT_API_KEY = os.getenv("CHATGPT_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 def count_tokens(text, model=None):
     if not text:
@@ -26,7 +26,7 @@ def count_tokens(text, model=None):
     tokens = enc.encode(text)
     return len(tokens)
 
-def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
+def ChatGPT_API_with_finish_reason(model, prompt, api_key=OPENAI_API_KEY, chat_history=None):
     max_retries = 10
     client = openai.OpenAI(api_key=api_key)
     for i in range(max_retries):
@@ -58,7 +58,7 @@ def ChatGPT_API_with_finish_reason(model, prompt, api_key=CHATGPT_API_KEY, chat_
 
 
 
-def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
+def ChatGPT_API(model, prompt, api_key=OPENAI_API_KEY, chat_history=None):
     max_retries = 10
     client = openai.OpenAI(api_key=api_key)
     for i in range(max_retries):
@@ -86,7 +86,7 @@ def ChatGPT_API(model, prompt, api_key=CHATGPT_API_KEY, chat_history=None):
                 return "Error"
             
 
-async def ChatGPT_API_async(model, prompt, api_key=CHATGPT_API_KEY):
+async def ChatGPT_API_async(model, prompt, api_key=OPENAI_API_KEY):
     max_retries = 10
     messages = [{"role": "user", "content": prompt}]
     for i in range(max_retries):


### PR DESCRIPTION
# Refactor: OpenAI API Key Naming Standard.  "CHATGPT_API_KEY" (Issue #152)

## Overview
This update standardizes the API key naming convention within the **PageIndex** framework. To align with industry standards and the official OpenAI environment variable naming, all instances of `CHATGPT_API_KEY` have been migrated to `OPENAI_API_KEY`.

## 🛠️ Changes

### 1. Source Code ([pageindex/utils.py](cci:7://file:///Users/spurge/Desktop/PAGE_INDEX/PageIndex/pageindex/utils.py:0:0-0:0))
- **Variable Rename**: Updated the global configuration constant from `CHATGPT_API_KEY` to `OPENAI_API_KEY`.
- **Environment Retrieval**: Now fetches the key using `os.getenv("OPENAI_API_KEY")`.
- **Function Defaults**: Updated signature defaults for:
  - [ChatGPT_API_with_finish_reason(...)](cci:1://file:///Users/spurge/Desktop/PAGE_INDEX/PageIndex/pageindex/utils.py:28:0-56:30)
  - [ChatGPT_API(...)](cci:1://file:///Users/spurge/Desktop/PAGE_INDEX/PageIndex/pageindex/utils.py:60:0-85:30)
  - [ChatGPT_API_async(...)](cci:1://file:///Users/spurge/Desktop/PAGE_INDEX/PageIndex/pageindex/utils.py:88:0-107:30)

### 2. Documentation ([README.md](cci:7://file:///Users/spurge/Desktop/PAGE_INDEX/PageIndex/README.md:0:0-0:0))
- **Setup Instructions**: Updated the `.env` configuration example to guide users to use `OPENAI_API_KEY` for local setup.

##  How to Update
If you previously had a `.env` file, please update your variable name:

**Old:**
```bash
CHATGPT_API_KEY=sk-...
