### PR TITLE
Fix list_index variable shadowing in fix_incorrect_toc

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -807,9 +807,9 @@ async def fix_incorrect_toc(toc_with_page_number, page_list, incorrect_results, 
         page_contents=[]
         for page_index in range(prev_correct, next_correct+1):
             # Add bounds checking to prevent IndexError
-            list_index = page_index - start_index
-            if list_index >= 0 and list_index < len(page_list):
-                page_text = f"<physical_index_{page_index}>\n{page_list[list_index][0]}\n<physical_index_{page_index}>\n\n"
+            page_list_idx = page_index - start_index
+            if page_list_idx >= 0 and page_list_idx < len(page_list):
+                page_text = f"<physical_index_{page_index}>\n{page_list[page_list_idx][0]}\n<physical_index_{page_index}>\n\n"
                 page_contents.append(page_text)
             else:
                 continue


### PR DESCRIPTION
## Summary
- Rename loop variable `list_index` to `page_list_idx` in `fix_incorrect_toc` to avoid shadowing the outer `list_index = incorrect_item['list_index']`, which caused results to be written back to wrong index positions.

Closes #66