### PR TITLE
Simplify agentic vectorless RAG demo

### DIFF
--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -25,6 +25,7 @@ import requests
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from agents import Agent, Runner, function_tool
+from agents.model_settings import ModelSettings
 from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
 from openai.types.responses import ResponseTextDeltaEvent, ResponseReasoningSummaryTextDeltaEvent
 
@@ -84,14 +85,30 @@ def query_agent(
         instructions=AGENT_SYSTEM_PROMPT,
         tools=[get_document, get_document_structure, get_page_content],
         model=client.retrieve_model,
+        model_settings=ModelSettings(reasoning={"effort": "medium", "summary": "auto"}),
     )
 
     async def _run():
         streamed_run = Runner.run_streamed(agent, prompt)
         line_has_streamed_text = False
+        current_stream_kind = None
         async for event in streamed_run.stream_events():
             if isinstance(event, RawResponsesStreamEvent):
-                if isinstance(event.data, ResponseTextDeltaEvent):
+                if isinstance(event.data, ResponseReasoningSummaryTextDeltaEvent):
+                    if current_stream_kind != "reasoning":
+                        if line_has_streamed_text:
+                            print()
+                        print("[reasoning] ", end="", flush=True)
+                        current_stream_kind = "reasoning"
+                        line_has_streamed_text = True
+                    delta = event.data.delta
+                    print(delta, end="", flush=True)
+                    line_has_streamed_text = True
+                elif isinstance(event.data, ResponseTextDeltaEvent):
+                    if current_stream_kind == "reasoning":
+                        if line_has_streamed_text:
+                            print()
+                    current_stream_kind = "text"
                     delta = event.data.delta
                     print(delta, end="", flush=True)
                     line_has_streamed_text = True
@@ -101,6 +118,7 @@ def query_agent(
                     if line_has_streamed_text:
                         print()  # end streaming line before tool call
                         line_has_streamed_text = False
+                    current_stream_kind = None
                     raw = item.raw_item
                     args = getattr(raw, "arguments", "{}")
                     args_str = f"({args})" if verbose else ""
@@ -110,6 +128,7 @@ def query_agent(
                     preview = output[:200] + "..." if len(output) > 200 else output
                     print(f"[tool output]: {preview}\n")
                     line_has_streamed_text = False
+                    current_stream_kind = None
         if line_has_streamed_text:
             print()
         return "" if not streamed_run.final_output else str(streamed_run.final_output)

--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -24,15 +24,16 @@ import requests
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from agents import Agent, ItemHelpers, Runner, function_tool
+from agents import Agent, Runner, function_tool
 from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
 from openai.types.responses import ResponseTextDeltaEvent, ResponseReasoningSummaryTextDeltaEvent
 
 from pageindex import PageIndexClient
 import pageindex.utils as utils
 
-_EXAMPLES_DIR = os.path.dirname(os.path.abspath(__file__))
 PDF_URL = "https://arxiv.org/pdf/2603.15031"
+
+_EXAMPLES_DIR = os.path.dirname(os.path.abspath(__file__))
 PDF_PATH = os.path.join(_EXAMPLES_DIR, "documents", "attention-residuals.pdf")
 WORKSPACE = os.path.join(_EXAMPLES_DIR, "workspace")
 
@@ -86,31 +87,20 @@ def query_agent(
     )
 
     async def _run():
-        collected = []
-        result = ""
         streamed_run = Runner.run_streamed(agent, prompt)
+        line_has_streamed_text = False
         async for event in streamed_run.stream_events():
             if isinstance(event, RawResponsesStreamEvent):
-                if isinstance(event.data, ResponseReasoningSummaryTextDeltaEvent):
-                    print(event.data.delta, end="", flush=True)
-                elif isinstance(event.data, ResponseTextDeltaEvent):
+                if isinstance(event.data, ResponseTextDeltaEvent):
                     delta = event.data.delta
                     print(delta, end="", flush=True)
-                    collected.append(delta)
+                    line_has_streamed_text = True
             elif isinstance(event, RunItemStreamEvent):
                 item = event.item
-                if item.type == "message_output_item":
-                    if not collected:
-                        text = ItemHelpers.text_message_output(item)
-                        if text:
-                            print(text)
-                    if collected:
-                        result = "".join(collected)
-                    collected.clear()
-                elif item.type == "tool_call_item":
-                    if collected:
+                if item.type == "tool_call_item":
+                    if line_has_streamed_text:
                         print()  # end streaming line before tool call
-                        collected.clear()
+                        line_has_streamed_text = False
                     raw = item.raw_item
                     args = getattr(raw, "arguments", "{}")
                     args_str = f"({args})" if verbose else ""
@@ -119,7 +109,10 @@ def query_agent(
                     output = str(item.output)
                     preview = output[:200] + "..." if len(output) > 200 else output
                     print(f"[tool output]: {preview}\n")
-        return "".join(collected) if collected else result
+                    line_has_streamed_text = False
+        if line_has_streamed_text:
+            print()
+        return "" if not streamed_run.final_output else str(streamed_run.final_output)
 
     try:
         asyncio.get_running_loop()
@@ -165,7 +158,8 @@ if __name__ == "__main__":
     print("\n" + "=" * 60)
     print("Step 2: Document Metadata (get_document)")
     print("=" * 60)
-    print(client.get_document(doc_id))
+    doc_metadata = client.get_document(doc_id)
+    print(f"\n{doc_metadata}")
 
     # Step 3: Agent Query
     print("\n" + "=" * 60)

--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -119,7 +119,7 @@ def query_agent(
                     output = str(item.output)
                     preview = output[:200] + "..." if len(output) > 200 else output
                     print(f"[tool output]: {preview}\n")
-        return result or "".join(collected)
+        return "".join(collected) if collected else result
 
     try:
         asyncio.get_running_loop()

--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -14,7 +14,6 @@ Steps:
   1 — Index PDF and inspect tree structure
   2 — Inspect document metadata
   3 — Ask a question (agent auto-calls tools)
-  4 — Reload from workspace and verify persistence
 """
 import os
 import sys
@@ -27,7 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from agents import Agent, ItemHelpers, Runner, function_tool
 from agents.stream_events import RawResponsesStreamEvent, RunItemStreamEvent
-from openai.types.responses import ResponseTextDeltaEvent, ResponseReasoningSummaryTextDeltaEvent  # noqa: F401
+from openai.types.responses import ResponseTextDeltaEvent, ResponseReasoningSummaryTextDeltaEvent
 
 from pageindex import PageIndexClient
 import pageindex.utils as utils
@@ -88,7 +87,7 @@ def query_agent(
 
     async def _run():
         collected = []
-        streamed_this_turn = False
+        result = ""
         streamed_run = Runner.run_streamed(agent, prompt)
         async for event in streamed_run.stream_events():
             if isinstance(event, RawResponsesStreamEvent):
@@ -98,19 +97,20 @@ def query_agent(
                     delta = event.data.delta
                     print(delta, end="", flush=True)
                     collected.append(delta)
-                    streamed_this_turn = True
             elif isinstance(event, RunItemStreamEvent):
                 item = event.item
                 if item.type == "message_output_item":
-                    if not streamed_this_turn:
+                    if not collected:
                         text = ItemHelpers.text_message_output(item)
                         if text:
-                            print(f"{text}")
-                    streamed_this_turn = False
+                            print(text)
+                    if collected:
+                        result = "".join(collected)
                     collected.clear()
                 elif item.type == "tool_call_item":
-                    if streamed_this_turn:
+                    if collected:
                         print()  # end streaming line before tool call
+                        collected.clear()
                     raw = item.raw_item
                     args = getattr(raw, "arguments", "{}")
                     args_str = f"({args})" if verbose else ""
@@ -119,7 +119,7 @@ def query_agent(
                     output = str(item.output)
                     preview = output[:200] + "..." if len(output) > 200 else output
                     print(f"[tool output]: {preview}\n")
-        return "".join(collected)
+        return result or "".join(collected)
 
     try:
         asyncio.get_running_loop()
@@ -129,46 +129,48 @@ def query_agent(
         return asyncio.run(_run())
 
 
-# ── Download PDF if needed ─────────────────────────────────────────────────────
-if not os.path.exists(PDF_PATH):
-    print(f"Downloading {PDF_URL} ...")
-    os.makedirs(os.path.dirname(PDF_PATH), exist_ok=True)
-    with requests.get(PDF_URL, stream=True, timeout=30) as r:
-        r.raise_for_status()
-        with open(PDF_PATH, "wb") as f:
-            for chunk in r.iter_content(chunk_size=8192):
-                if chunk:
-                    f.write(chunk)
-    print("Download complete.\n")
+if __name__ == "__main__":
+    
+    # Download PDF if needed
+    if not os.path.exists(PDF_PATH):
+        print(f"Downloading {PDF_URL} ...")
+        os.makedirs(os.path.dirname(PDF_PATH), exist_ok=True)
+        with requests.get(PDF_URL, stream=True, timeout=30) as r:
+            r.raise_for_status()
+            with open(PDF_PATH, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    if chunk:
+                        f.write(chunk)
+        print("Download complete.\n")
 
-# ── Setup ──────────────────────────────────────────────────────────────────────
-client = PageIndexClient(workspace=WORKSPACE)
+    # Setup
+    client = PageIndexClient(workspace=WORKSPACE)
 
-# ── Step 1: Index + Tree ───────────────────────────────────────────────────────
-print("=" * 60)
-print("Step 1: Indexing PDF and inspecting tree structure")
-print("=" * 60)
-doc_id = next((did for did, doc in client.documents.items()
-                if doc.get('doc_name') == os.path.basename(PDF_PATH)), None)
-if doc_id:
-    print(f"\nLoaded cached doc_id: {doc_id}")
-else:
-    doc_id = client.index(PDF_PATH)
-    print(f"\nIndexed. doc_id: {doc_id}")
-print("\nTree Structure (top-level sections):")
-structure = json.loads(client.get_document_structure(doc_id))
-utils.print_tree(structure)
+    # Step 1: Index + Tree
+    print("=" * 60)
+    print("Step 1: Indexing PDF and inspecting tree structure")
+    print("=" * 60)
+    doc_id = next((did for did, doc in client.documents.items()
+                    if doc.get('doc_name') == os.path.basename(PDF_PATH)), None)
+    if doc_id:
+        print(f"\nLoaded cached doc_id: {doc_id}")
+    else:
+        doc_id = client.index(PDF_PATH)
+        print(f"\nIndexed. doc_id: {doc_id}")
+    print("\nTree Structure (top-level sections):")
+    structure = json.loads(client.get_document_structure(doc_id))
+    utils.print_tree(structure)
 
-# ── Step 2: Document Metadata ──────────────────────────────────────────────────
-print("\n" + "=" * 60)
-print("Step 2: Document Metadata (get_document)")
-print("=" * 60)
-print(client.get_document(doc_id))
+    # Step 2: Document Metadata
+    print("\n" + "=" * 60)
+    print("Step 2: Document Metadata (get_document)")
+    print("=" * 60)
+    print(client.get_document(doc_id))
 
-# ── Step 3: Agent Query ────────────────────────────────────────────────────────
-print("\n" + "=" * 60)
-print("Step 3: Agent Query (auto tool-use)")
-print("=" * 60)
-question = "Explain Attention Residuals in simple language."
-print(f"\nQuestion: '{question}'\n")
-query_agent(client, doc_id, question, verbose=True)
+    # Step 3: Agent Query
+    print("\n" + "=" * 60)
+    print("Step 3: Agent Query (auto tool-use)")
+    print("=" * 60)
+    question = "Explain Attention Residuals in simple language."
+    print(f"\nQuestion: '{question}'\n")
+    query_agent(client, doc_id, question, verbose=True)

--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -49,12 +49,7 @@ ANSWERING: Answer based only on tool output. Be concise.
 """
 
 
-def query_agent(
-    client: PageIndexClient,
-    doc_id: str,
-    prompt: str,
-    verbose: bool = False,
-) -> str:
+def query_agent(client: PageIndexClient, doc_id: str, prompt: str, verbose: bool = False) -> str:
     """Run a document QA agent using the OpenAI Agents SDK.
 
     Streams text output token-by-token and returns the full answer string.
@@ -85,51 +80,48 @@ def query_agent(
         instructions=AGENT_SYSTEM_PROMPT,
         tools=[get_document, get_document_structure, get_page_content],
         model=client.retrieve_model,
-        model_settings=ModelSettings(reasoning={"effort": "medium", "summary": "auto"}),
+        model_settings=ModelSettings(reasoning={"effort": "low", "summary": "auto"}),  # Optional; remove if not needed.
     )
 
     async def _run():
         streamed_run = Runner.run_streamed(agent, prompt)
-        line_has_streamed_text = False
         current_stream_kind = None
         async for event in streamed_run.stream_events():
             if isinstance(event, RawResponsesStreamEvent):
                 if isinstance(event.data, ResponseReasoningSummaryTextDeltaEvent):
                     if current_stream_kind != "reasoning":
-                        if line_has_streamed_text:
+                        if current_stream_kind is not None:
                             print()
-                        print("[reasoning] ", end="", flush=True)
-                        current_stream_kind = "reasoning"
-                        line_has_streamed_text = True
+                        print("\n[reasoning]: ", end="", flush=True)
                     delta = event.data.delta
                     print(delta, end="", flush=True)
-                    line_has_streamed_text = True
+                    current_stream_kind = "reasoning"
                 elif isinstance(event.data, ResponseTextDeltaEvent):
-                    if current_stream_kind == "reasoning":
-                        if line_has_streamed_text:
+                    if current_stream_kind != "text":
+                        if current_stream_kind is not None:
                             print()
-                    current_stream_kind = "text"
+                        print("\n[text]: ", end="", flush=True)
                     delta = event.data.delta
                     print(delta, end="", flush=True)
-                    line_has_streamed_text = True
+                    current_stream_kind = "text"
             elif isinstance(event, RunItemStreamEvent):
                 item = event.item
                 if item.type == "tool_call_item":
-                    if line_has_streamed_text:
-                        print()  # end streaming line before tool call
-                        line_has_streamed_text = False
-                    current_stream_kind = None
+                    if current_stream_kind is not None:
+                        print()
                     raw = item.raw_item
                     args = getattr(raw, "arguments", "{}")
                     args_str = f"({args})" if verbose else ""
-                    print(f"[tool call]: {raw.name}{args_str}")
+                    print(f"\n[tool call]: {raw.name}{args_str}", flush=True)
+                    current_stream_kind = None
                 elif item.type == "tool_call_output_item" and verbose:
+                    if current_stream_kind is not None:
+                        print()
                     output = str(item.output)
                     preview = output[:200] + "..." if len(output) > 200 else output
-                    print(f"[tool output]: {preview}\n")
-                    line_has_streamed_text = False
+                    print(f"\n[tool call output]: {preview}", flush=True)
                     current_stream_kind = None
-        if line_has_streamed_text:
+        if current_stream_kind is not None:
             print()
         return "" if not streamed_run.final_output else str(streamed_run.final_output)
 
@@ -162,8 +154,10 @@ if __name__ == "__main__":
     print("=" * 60)
     print("Step 1: Indexing PDF and inspecting tree structure")
     print("=" * 60)
-    doc_id = next((did for did, doc in client.documents.items()
-                    if doc.get('doc_name') == os.path.basename(PDF_PATH)), None)
+    doc_id = next(
+        (did for did, doc in client.documents.items() if doc.get('doc_name') == os.path.basename(PDF_PATH)),
+        None,
+    )
     if doc_id:
         print(f"\nLoaded cached doc_id: {doc_id}")
     else:
@@ -185,5 +179,5 @@ if __name__ == "__main__":
     print("Step 3: Agent Query (auto tool-use)")
     print("=" * 60)
     question = "Explain Attention Residuals in simple language."
-    print(f"\nQuestion: '{question}'\n")
+    print(f"\nQuestion: '{question}'")
     query_agent(client, doc_id, question, verbose=True)


### PR DESCRIPTION
## Summary
- Fix bug where `collected.clear()` discarded streamed answer, causing `query_agent()` to always return empty string
- Add `if __name__ == "__main__":` guard so `query_agent` can be imported without side effects
- Remove stale Step 4 from docstring (never implemented)
- Remove misleading `# noqa: F401` on imports that are actually used
- Replace redundant `streamed_this_turn` flag with direct `collected` truthiness check
- Clean up `f"{text}"` → `print(text)`

## Test plan
- [ ] Run `python examples/agentic_vectorless_rag_demo.py` and verify demo completes normally
- [ ] Verify `query_agent()` returns the actual answer string (not empty)
- [ ] Verify `from examples.agentic_vectorless_rag_demo import query_agent` no longer triggers demo execution