### PR TITLE
Fix AttributeError crashes when LLM returns malformed JSON

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -584,8 +584,14 @@ def process_no_toc(page_list, start_index=1, model=None, logger=None):
     logger.info(f'len(group_texts): {len(group_texts)}')
 
     toc_with_page_number= generate_toc_init(group_texts[0], model)
+    if not isinstance(toc_with_page_number, list):
+        logger.warning(f'generate_toc_init returned {type(toc_with_page_number).__name__} instead of list, resetting to empty list')
+        toc_with_page_number = []
     for group_text in group_texts[1:]:
-        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model)    
+        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model)
+        if not isinstance(toc_with_page_number_additional, list):
+            logger.warning(f'generate_toc_continue returned {type(toc_with_page_number_additional).__name__} instead of list, skipping')
+            continue
         toc_with_page_number.extend(toc_with_page_number_additional)
     logger.info(f'generate_toc: {toc_with_page_number}')
 
@@ -967,7 +973,7 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
     else:
         toc_with_page_number = process_no_toc(page_list, start_index=start_index, model=opt.model, logger=logger)
             
-    toc_with_page_number = [item for item in toc_with_page_number if item.get('physical_index') is not None] 
+    toc_with_page_number = [item for item in toc_with_page_number if isinstance(item, dict) and item.get('physical_index') is not None]
     
     toc_with_page_number = validate_and_truncate_physical_indices(
         toc_with_page_number, 

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -124,10 +124,10 @@ def extract_json(content):
             return json.loads(json_content)
         except:
             logging.error("Failed to parse JSON even after cleanup")
-            return {}
+            return []
     except Exception as e:
         logging.error(f"Unexpected error while extracting JSON: {e}")
-        return {}
+        return []
 
 def write_node_id(data, node_id=0):
     if isinstance(data, dict):


### PR DESCRIPTION
## Summary

Fixes two `AttributeError` crashes that occur when the LLM returns malformed JSON output, causing `extract_json()` to fail and downstream functions to receive wrong types.

Closes #199

## Changes

1. **`pageindex/utils.py`** - `extract_json()` now returns `[]` (empty list) instead of `{}` (empty dict) on parse failure. All callers expect a list of dicts, so the fallback value should match that contract.

2. **`pageindex/page_index.py`** - `process_no_toc()` now validates that `generate_toc_init()` and `generate_toc_continue()` return lists before calling `.extend()`. If they return a non-list type (e.g. dict from failed JSON parsing), the code logs a warning and either resets to an empty list or skips the result.

3. **`pageindex/page_index.py`** - `meta_processor()` list comprehension now filters out non-dict items with `isinstance(item, dict)` before calling `.get()`, preventing `'str' object has no attribute 'get'` errors.

## Reproduction context

These crashes are reliably triggered when using a local vLLM endpoint with smaller models that frequently produce malformed JSON (extra data, empty responses, malformed structure). All 7 test documents (Office docs converted to PDF) failed with these errors.

## Test plan

- [ ] Process PDFs with a model that produces clean JSON output (no regression)
- [ ] Process PDFs with a model that produces malformed JSON output (crashes prevented, graceful degradation)