### PR TITLE
fix: add type checks to prevent AttributeError when LLM returns malformed JSON

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -584,9 +584,12 @@ def process_no_toc(page_list, start_index=1, model=None, logger=None):
     logger.info(f'len(group_texts): {len(group_texts)}')
 
     toc_with_page_number= generate_toc_init(group_texts[0], model)
+    if not isinstance(toc_with_page_number, list):
+        toc_with_page_number = []
     for group_text in group_texts[1:]:
-        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model)    
-        toc_with_page_number.extend(toc_with_page_number_additional)
+        toc_with_page_number_additional = generate_toc_continue(toc_with_page_number, group_text, model)
+        if isinstance(toc_with_page_number_additional, list):
+            toc_with_page_number.extend(toc_with_page_number_additional)
     logger.info(f'generate_toc: {toc_with_page_number}')
 
     toc_with_page_number = convert_physical_index_to_int(toc_with_page_number)
@@ -967,7 +970,7 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
     else:
         toc_with_page_number = process_no_toc(page_list, start_index=start_index, model=opt.model, logger=logger)
             
-    toc_with_page_number = [item for item in toc_with_page_number if item.get('physical_index') is not None] 
+    toc_with_page_number = [item for item in toc_with_page_number if isinstance(item, dict) and item.get('physical_index') is not None]
     
     toc_with_page_number = validate_and_truncate_physical_indices(
         toc_with_page_number, 


### PR DESCRIPTION
Fixes #199

## Problem

When the LLM returns malformed JSON, `extract_json()` in `utils.py` returns `{}` (empty dict) as a fallback. This causes two crashes downstream:

**Crash 1:** `AttributeError: 'dict' object has no attribute 'extend'` in `process_no_toc`
- `generate_toc_init()` can return `{}` on parse failure
- Calling `.extend()` on a dict raises AttributeError

**Crash 2:** `AttributeError: 'str' object has no attribute 'get'` in `meta_processor`
- When LLM returns a list of strings instead of dicts, iterating and calling `.get()` fails

## Solution

Added minimal type guards at the two crash sites:

1. **`process_no_toc`**: Check that `generate_toc_init()` returns a list before using it. Skip non-list results from `generate_toc_continue()` rather than crashing.

2. **`meta_processor`**: Added `isinstance(item, dict)` check in the list comprehension filter so non-dict items (strings, etc.) are safely discarded instead of raising AttributeError.

These are the smallest possible fixes — they don't change the overall flow, just guard against unexpected return types from `extract_json()`.

## Testing

Reproducible with any local vLLM endpoint or small model (e.g. Qwen 7B) that frequently returns malformed JSON. With this fix, the pipeline gracefully handles parse failures instead of crashing with AttributeError.