### PR TITLE
fix: apply regex-based trailing comma removal before JSON parse

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -1,6 +1,7 @@
 import litellm
 import logging
 import os
+import re
 import textwrap
 from datetime import datetime
 import time
@@ -113,18 +114,15 @@ def extract_json(content):
         json_content = json_content.replace('\n', ' ').replace('\r', ' ')  # Remove newlines
         json_content = ' '.join(json_content.split())  # Normalize whitespace
 
+        # Remove any trailing commas before closing brackets/braces (handles whitespace variants)
+        json_content = re.sub(r',\s*([}\]])', r'\1', json_content)
+
         # Attempt to parse and return the JSON object
         return json.loads(json_content)
     except json.JSONDecodeError as e:
         logging.error(f"Failed to extract JSON: {e}")
-        # Try to clean up the content further if initial parsing fails
-        try:
-            # Remove any trailing commas before closing brackets/braces
-            json_content = json_content.replace(',]', ']').replace(',}', '}')
-            return json.loads(json_content)
-        except:
-            logging.error("Failed to parse JSON even after cleanup")
-            return {}
+        logging.error("Failed to parse JSON even after cleanup")
+        return {}
     except Exception as e:
         logging.error(f"Unexpected error while extracting JSON: {e}")
         return {}


### PR DESCRIPTION
Fixes #195

## Problem

`extract_json()` in `pageindex/utils.py` had two issues:

1. **Missing `import re`**: The `re` module was used in `get_first_start_page_from_text` and `get_last_start_page_from_text` but was never imported, causing a `NameError` if those functions were called.

2. **Weak trailing comma cleanup applied too late**: The fallback cleanup only ran _after_ the first `json.loads()` failed, using simple string replacement (`',]'` → `']'`, `','` → `'}'`) that did not handle whitespace between the comma and the closing bracket. Smaller models (e.g. qwen2.5:7B, Qwen-series) frequently produce output like `[..., ]` or `{... , }`, which the old cleanup missed.

## Solution

- Add `import re` to fix the latent `NameError`.
- Move the trailing comma removal to **before** the first `json.loads()` call so that responses that are valid JSON except for trailing commas succeed on the first attempt.
- Replace the two `str.replace()` calls with `re.sub(r',\s*([}\]])', r'\1', json_content)`, which correctly handles any amount of whitespace between the trailing comma and the closing bracket.

## Testing

Verified manually with strings produced by smaller LLMs that previously caused parse failures:

```python
import json, re

# Case 1: trailing comma with no space
s1 = '{"key": "value",}'
# Case 2: trailing comma with whitespace (the previously broken case)
s2 = '{"key": "value" ,  }'
# Case 3: nested trailing commas
s3 = '[{"a": 1,}, {"b": 2,},]'

for s in [s1, s2, s3]:
    cleaned = re.sub(r',\s*([}\]])', r'\1', s)
    print(json.loads(cleaned))  # all three now parse successfully
```