### PR TITLE
fix: poll status=="completed" in cloud add_document

### DIFF
--- a/pageindex/backend/cloud.py
+++ b/pageindex/backend/cloud.py
@@ -141,12 +141,13 @@ class CloudBackend:
 
         doc_id = resp["doc_id"]
 
-        # Poll until retrieval-ready
+        # Poll until indexing completes. The cloud API signals readiness via
+        # status == "completed"; retrieval_ready is not a reliable indicator.
         for _ in range(120):  # 10 min max
             tree_resp = self._request("GET", f"/doc/{self._enc(doc_id)}/", params={"type": "tree"})
-            if tree_resp.get("retrieval_ready"):
-                return doc_id
             status = tree_resp.get("status", "")
+            if status == "completed":
+                return doc_id
             if status == "failed":
                 raise CloudAPIError(f"Document {doc_id} indexing failed")
             time.sleep(5)


### PR DESCRIPTION
## Summary
- `CloudBackend.add_document` polled `tree_resp["retrieval_ready"]` as the ready signal, but empirically that flag isn't reliable — docs can reach `status == "completed"` without `retrieval_ready` flipping, causing `col.add()` to wait out the full 10 min timeout on otherwise-successful uploads.
- Switch the poll to check `status == "completed"`, which is the cloud API's canonical ready signal.

## Test plan
- [x] Upload a PDF via `col.add()` in cloud mode and confirm it returns within the actual indexing time (~30s for a 4-page PDF) instead of timing out.
- [x] Verify downstream calls (`get_document`, `get_page_content`) work immediately after `col.add()` returns.