### PR TITLE
fix: add --base_url CLI option for custom LLM endpoints

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -34,12 +34,14 @@ def llm_completion(model, prompt, chat_history=None, return_finish_reason=False)
         model = model.removeprefix("litellm/")
     max_retries = 10
     messages = list(chat_history) + [{"role": "user", "content": prompt}] if chat_history else [{"role": "user", "content": prompt}]
+    api_base = os.getenv("OPENAI_API_BASE")
     for i in range(max_retries):
         try:
             response = litellm.completion(
                 model=model,
                 messages=messages,
                 temperature=0,
+                **({"api_base": api_base} if api_base else {}),
             )
             content = response.choices[0].message.content
             if return_finish_reason:
@@ -64,12 +66,14 @@ async def llm_acompletion(model, prompt):
         model = model.removeprefix("litellm/")
     max_retries = 10
     messages = [{"role": "user", "content": prompt}]
+    api_base = os.getenv("OPENAI_API_BASE")
     for i in range(max_retries):
         try:
             response = await litellm.acompletion(
                 model=model,
                 messages=messages,
                 temperature=0,
+                **({"api_base": api_base} if api_base else {}),
             )
             return response.choices[0].message.content
         except Exception as e:

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -12,6 +12,9 @@ if __name__ == "__main__":
     parser.add_argument('--md_path', type=str, help='Path to the Markdown file')
 
     parser.add_argument('--model', type=str, default=None, help='Model to use (overrides config.yaml)')
+    parser.add_argument('--base_url', type=str, default=None,
+                      help='Custom API base URL for OpenAI-compatible providers (e.g., http://localhost:11434 for Ollama). '
+                           'Sets the OPENAI_API_BASE environment variable.')
 
     parser.add_argument('--toc-check-pages', type=int, default=None,
                       help='Number of pages to check for table of contents (PDF only)')
@@ -37,7 +40,11 @@ if __name__ == "__main__":
     parser.add_argument('--summary-token-threshold', type=int, default=200,
                       help='Token threshold for generating summaries (markdown only)')
     args = parser.parse_args()
-    
+
+    # Apply base_url before any LLM calls
+    if args.base_url:
+        os.environ["OPENAI_API_BASE"] = args.base_url
+
     # Validate that exactly one file type is specified
     if not args.pdf_path and not args.md_path:
         raise ValueError("Either --pdf_path or --md_path must be specified")


### PR DESCRIPTION
Fixes #224

## Problem

Users running local LLM servers (Ollama, vLLM, LM Studio, etc.) have no way to specify a custom API base URL through the CLI. The `OPENAI_API_BASE` environment variable works when set manually, but there is no `--base_url` argument, making the workflow unnecessarily awkward.

## Solution

- **`run_pageindex.py`**: Added `--base_url` argument that sets `os.environ["OPENAI_API_BASE"]` before any LLM calls are made.
- **`pageindex/utils.py`**: Updated `llm_completion` and `llm_acompletion` to read `OPENAI_API_BASE` from the environment and forward it to litellm as `api_base`, so all LLM calls in the pipeline respect the custom endpoint.

The change is fully backward-compatible: if `--base_url` is not provided and `OPENAI_API_BASE` is not set, behaviour is identical to before.

## Usage

```bash
# Ollama
python run_pageindex.py --pdf_path doc.pdf \
  --model ollama/llama3 \
  --base_url http://localhost:11434

# vLLM / LM Studio or any OpenAI-compatible server
python run_pageindex.py --pdf_path doc.pdf \
  --model openai/my-model \
  --base_url http://localhost:8000/v1
```

## Testing

Verified that the argument is parsed correctly and `OPENAI_API_BASE` is set before any LLM call. The `api_base` kwarg is only injected into litellm when the env var is present, so there is no overhead for standard OpenAI usage.