### PR TITLE
Add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to weekly-scan and open PRs for third-party GitHub Actions used in CI workflows.
- Scope intentionally limited to `github-actions` (pip versions remain pinned; pip vulns are already covered by Dependabot security updates).

## Why
Completes the "Activate Dependabot" item in the repo security checklist. Keeping actions up to date reduces supply-chain risk in CI.

## Test plan
- [ ] GitHub parses the YAML without error (check the Insights → Dependency graph → Dependabot tab after merge).
- [ ] First scheduled run opens PRs only for github-actions, not pip.