### PR TITLE
fix: fix markdown parser edge cases in page_index_md.py

### DIFF
--- a/pageindex/page_index_md.py
+++ b/pageindex/page_index_md.py
@@ -30,25 +30,39 @@ async def generate_summaries_for_structure_md(structure, summary_token_threshold
 
 
 def extract_nodes_from_markdown(markdown_content):
-    header_pattern = r'^(#{1,6})\s+(.+)$'
-    code_block_pattern = r'^```'
+    # Strip optional trailing closing hashes from ATX headers (e.g. "## Title ##" -> "Title")
+    header_pattern = r'^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$'
+    # Match fenced code blocks: backticks (3+) or tildes (3+)
+    code_block_pattern = r'^(`{3,}|~{3,})'
     node_list = []
-    
+
     lines = markdown_content.split('\n')
     in_code_block = False
-    
+    fence_char = None   # fence character: '`' or '~'
+    fence_len = 0       # minimum fence length needed to close the block
+
     for line_num, line in enumerate(lines, 1):
         stripped_line = line.strip()
-        
-        # Check for code block delimiters (triple backticks)
-        if re.match(code_block_pattern, stripped_line):
-            in_code_block = not in_code_block
+
+        # Check for code block delimiters (3+ backticks or tildes)
+        fence_match = re.match(code_block_pattern, stripped_line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if not in_code_block:
+                in_code_block = True
+                fence_char = marker[0]
+                fence_len = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len:
+                # Close only when same fence character with at least the opening length
+                in_code_block = False
+                fence_char = None
+                fence_len = 0
             continue
-        
+
         # Skip empty lines
         if not stripped_line:
             continue
-        
+
         # Only look for headers when not inside a code block
         if not in_code_block:
             match = re.match(header_pattern, stripped_line)
@@ -250,7 +264,18 @@ async def md_to_tree(md_path, if_thinning=False, min_token_threshold=None, if_ad
 
     print(f"Extracting text content from nodes...")
     nodes_with_content = extract_node_text_content(node_list, markdown_lines)
-    
+
+    # Handle headerless documents: treat the entire content as a single node
+    if not nodes_with_content:
+        doc_name = os.path.splitext(os.path.basename(md_path))[0]
+        full_text = '\n'.join(markdown_lines).strip()
+        nodes_with_content = [{
+            'title': doc_name,
+            'line_num': 1,
+            'level': 1,
+            'text': full_text,
+        }]
+
     if if_thinning:
         nodes_with_content = update_node_list_with_text_token_count(nodes_with_content, model=model)
         print(f"Thinning nodes...")


### PR DESCRIPTION
Fixes #245

## Problem

The `extract_nodes_from_markdown` function in `pageindex/page_index_md.py` has three categories of bugs that cause incorrect or missing content when parsing common Markdown patterns:

1. **ATX closing hashes included in title** — `## My Section ##` yields title `"My Section ##"` instead of `"My Section"`.
2. **Tilde code fences and mismatched fence lengths not handled** — `~~~python` blocks are not recognized as code fences, so any `# comment` inside a tilde block is falsely detected as a header. Similarly, a 3-backtick sequence incorrectly closes a 4-backtick fence.
3. **Headerless documents produce zero nodes** — if a Markdown file has no ATX headers, the entire document is silently discarded.

## Solution

### 1. ATX closing hashes
Updated the header regex from `r'^(#{1,6})\s+(.+)$'` to `r'^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$'` to strip optional trailing hash sequences.

### 2. Tilde fences + mismatched lengths
Replaced the simple backtick toggle with proper fence tracking:
- Extended the pattern to `r'^(`{3,}|~{3,})'` to match both `` ``` `` and `~~~` with 3+ characters.
- Records the opening fence character (`\`` or `~`) and length; a closing fence must use the **same character** and be **at least as long** as the opener.

### 3. Headerless documents
In `md_to_tree`, after `extract_node_text_content` returns an empty list, a single root node is created containing the full document text, preventing silent data loss.

## Testing

All three cases verified manually:

```
Case 5 (Tilde fences): PASS  ['Header', 'Real Header']
Case 6 (Mismatched fence lengths): PASS  ['Before', 'After']
Case 7 (ATX closing hashes): PASS  My Section
Case 2 (Headerless file): PASS  1 node returned
Standard ATX headers: PASS
Mixed fence types (~~~, ```): PASS
```

> **Note:** This PR fixes the same cases described in #245 but targets `page_index_md.py` in the `main` branch. PR #246 addresses the same issues in the new `pageindex/parser/markdown.py` module on the `dev` branch — these two fixes are complementary and non-conflicting.