### PR TITLE
Recognize whole-line bold as level-1 heading in markdown parser

### DIFF
--- a/pageindex/page_index_md.py
+++ b/pageindex/page_index_md.py
@@ -31,6 +31,7 @@ async def generate_summaries_for_structure_md(structure, summary_token_threshold
 
 def extract_nodes_from_markdown(markdown_content):
     header_pattern = r'^(#{1,6})\s+(.+)$'
+    bold_heading_pattern = r'^\*\*(.+?)\*\*\s*$'
     code_block_pattern = r'^```'
     node_list = []
     
@@ -54,7 +55,14 @@ def extract_nodes_from_markdown(markdown_content):
             match = re.match(header_pattern, stripped_line)
             if match:
                 title = match.group(2).strip()
-                node_list.append({'node_title': title, 'line_num': line_num})
+                level = len(match.group(1))
+                node_list.append({'node_title': title, 'line_num': line_num, 'level': level})
+                continue
+
+            bold_match = re.match(bold_heading_pattern, stripped_line)
+            if bold_match:
+                title = bold_match.group(1).strip()
+                node_list.append({'node_title': title, 'line_num': line_num, 'level': 1})
 
     return node_list, lines
 
@@ -62,17 +70,10 @@ def extract_nodes_from_markdown(markdown_content):
 def extract_node_text_content(node_list, markdown_lines):    
     all_nodes = []
     for node in node_list:
-        line_content = markdown_lines[node['line_num'] - 1]
-        header_match = re.match(r'^(#{1,6})', line_content)
-        
-        if header_match is None:
-            print(f"Warning: Line {node['line_num']} does not contain a valid header: '{line_content}'")
-            continue
-            
         processed_node = {
             'title': node['node_title'],
             'line_num': node['line_num'],
-            'level': len(header_match.group(1))
+            'level': node['level']
         }
         all_nodes.append(processed_node)
     

--- a/pageindex/page_index_md.py
+++ b/pageindex/page_index_md.py
@@ -62,7 +62,8 @@ def extract_nodes_from_markdown(markdown_content):
             bold_match = re.match(bold_heading_pattern, stripped_line)
             if bold_match:
                 title = bold_match.group(1).strip()
-                node_list.append({'node_title': title, 'line_num': line_num, 'level': 1})
+                if title:
+                    node_list.append({'node_title': title, 'line_num': line_num, 'level': 1})
 
     return node_list, lines
 

--- a/tests/test_page_index_md.py
+++ b/tests/test_page_index_md.py
@@ -1,0 +1,23 @@
+import unittest
+
+from pageindex.page_index_md import extract_nodes_from_markdown
+
+
+class ExtractNodesFromMarkdownTest(unittest.TestCase):
+    def test_skips_bold_heading_with_only_whitespace(self):
+        nodes, _ = extract_nodes_from_markdown("**   **\n**Valid heading**")
+
+        self.assertEqual(
+            nodes,
+            [
+                {
+                    "node_title": "Valid heading",
+                    "line_num": 2,
+                    "level": 1,
+                }
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `extract_nodes_from_markdown` now matches whole-line bold (`**Title**`) as a level-1 heading, in addition to the existing ATX (`#`) headings. Markdown produced by Mistral OCR and similar PDF-to-markdown pipelines often emits visual headings as bold lines, which previously yielded zero nodes and an empty tree.
- The producer attaches the heading `level` onto each `node_list` entry on the way out. `extract_node_text_content` reads `node['level']` instead of re-running the `^(#{1,6})` regex on the source line. The old re-derivation silently dropped any heading whose syntax it did not recognize.
- The bold pattern is anchored to the whole stripped line (`^\*\*(.+?)\*\*\s*$`), so inline emphasis like `Some text with **bold** in the middle` is intentionally not recognized as a heading.

## Mixed-document semantics
- If a document mixes `# Heading` and `**Bold**`, bold maps to level 1, sibling of `# Heading`. CommonMark has no concept of bold-heading depth, so a flat level-1 mapping is the only non-arbitrary rule.
- A subsequent `## Sub` attaches to whichever level-1 ancestor is most recent in source order, which may be the `**Bold**` line rather than the earlier `# Heading`. This is documented heuristic behavior of the bold-as-heading extension and is not a bug.

## Scope
- `pageindex/page_index_md.py` only. The PDF path (`page_index.py`) is fully LLM-driven and does not touch this regex; it is unchanged.
- No new third-party dependencies. No changes to `requirements.txt`.

## Validation
- Verified locally: an all-`**Bold**` markdown that previously returned an empty tree now produces a non-empty tree with one level-1 node per bold line.
- Verified the inline-bold negative case: lines like `Some text with **bold** inside` are not picked up as headings.
- Verified mixed `#` + `**` input attaches the right child nodes under the most recent level-1 ancestor.
- Verified all-`#` regression baseline preserved (level extraction unchanged for ATX headings).