### PR TITLE
docs: fix agentic retrieval cookbook typos

### DIFF
--- a/cookbook/agentic_retrieval.ipynb
+++ b/cookbook/agentic_retrieval.ipynb
@@ -43,7 +43,7 @@
       "source": [
         "# Agentic Retrieval with PageIndex Chat API\n",
         "\n",
-        "Similarity-based RAG based on Vector-DB has shown big limitations in recent AI applications, reasoning-based or agentic retrieval has become important in current developments. However, unlike classic RAG pipeine with embedding input, top-K chunks returns, re-rank, what should a agentic-native retreival API looks like?\n",
+        "Similarity-based RAG based on Vector-DB has shown big limitations in recent AI applications, reasoning-based or agentic retrieval has become important in current developments. However, unlike classic RAG pipeline with embedding input, top-K chunks returns, and re-rank, what should an agentic-native retrieval API look like?\n",
         "\n",
         "For an agentic-native retrieval system, we need the ability to prompt for retrieval just as naturally as you interact with ChatGPT. Below, we provide an example of how the PageIndex Chat API enables this style of prompt-driven retrieval.\n",
         "\n",
@@ -441,7 +441,7 @@
         "id": "d-Y9towQ_CiF"
       },
       "source": [
-        "### Extract the JSON retreived results"
+        "### Extract the JSON retrieved results"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Fix typos in the agentic retrieval cookbook notebook
- Clean up the affected question wording in the markdown cell

## Verification
- `python -m json.tool cookbook\agentic_retrieval.ipynb`
- `python -m compileall pageindex run_pageindex.py examples\agentic_vectorless_rag_demo.py`
- `git diff --check`