### PR TITLE
CLI output path is hardcoded, making scripted usage difficult

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ You can customize the processing with additional optional arguments:
 --if-add-node-summary   Add node summary (yes/no, default: yes)
 --if-add-doc-description Add doc description (yes/no, default: yes)
 --output-dir            Directory to write the output JSON (default: ./results)
---output-file           Full output file path, e.g. /tmp/my_doc.json
+--output-file           Full output file path, e.g. ~/results/my_doc.json (mutually exclusive with --output-dir)
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ You can customize the processing with additional optional arguments:
 --if-add-node-id        Add node ID (yes/no, default: yes)
 --if-add-node-summary   Add node summary (yes/no, default: yes)
 --if-add-doc-description Add doc description (yes/no, default: yes)
+--output-dir            Directory to write the output JSON (default: ./results)
+--output-file           Full output file path, e.g. /tmp/my_doc.json
 ```
 </details>
 

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -29,6 +29,13 @@ if __name__ == "__main__":
     parser.add_argument('--if-add-node-text', type=str, default=None,
                       help='Whether to add text to the node')
                       
+    # Output path arguments (mutually exclusive)
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument('--output-dir', type=str, default=None,
+                              help='Directory to write the output JSON (default: ./results)')
+    output_group.add_argument('--output-file', type=str, default=None,
+                              help='Full output file path, e.g. /tmp/my_doc.json')
+
     # Markdown specific arguments
     parser.add_argument('--if-thinning', type=str, default='no',
                       help='Whether to apply tree thinning for markdown (markdown only)')
@@ -69,11 +76,16 @@ if __name__ == "__main__":
         print('Parsing done, saving to file...')
         
         # Save results
-        pdf_name = os.path.splitext(os.path.basename(args.pdf_path))[0]    
-        output_dir = './results'
-        output_file = f'{output_dir}/{pdf_name}_structure.json'
-        os.makedirs(output_dir, exist_ok=True)
-        
+        pdf_name = os.path.splitext(os.path.basename(args.pdf_path))[0]
+        if args.output_file:
+            output_file = args.output_file
+            parent = os.path.dirname(os.path.abspath(output_file))
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+        else:
+            output_dir = args.output_dir if args.output_dir else './results'
+            os.makedirs(output_dir, exist_ok=True)
+            output_file = os.path.join(output_dir, f'{pdf_name}_structure.json')
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(toc_with_page_number, f, indent=2)
         
@@ -123,10 +135,16 @@ if __name__ == "__main__":
         print('Parsing done, saving to file...')
         
         # Save results
-        md_name = os.path.splitext(os.path.basename(args.md_path))[0]    
-        output_dir = './results'
-        output_file = f'{output_dir}/{md_name}_structure.json'
-        os.makedirs(output_dir, exist_ok=True)
+        md_name = os.path.splitext(os.path.basename(args.md_path))[0]
+        if args.output_file:
+            output_file = args.output_file
+            parent = os.path.dirname(os.path.abspath(output_file))
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+        else:
+            output_dir = args.output_dir if args.output_dir else './results'
+            os.makedirs(output_dir, exist_ok=True)
+            output_file = os.path.join(output_dir, f'{md_name}_structure.json')
         
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(toc_with_page_number, f, indent=2, ensure_ascii=False)

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -5,6 +5,20 @@ from pageindex import *
 from pageindex.page_index_md import md_to_tree
 from pageindex.utils import ConfigLoader
 
+def resolve_output_path(input_path, output_dir_arg, output_file_arg):
+    if output_file_arg:
+        output_file = os.path.abspath(os.path.expandvars(os.path.expanduser(output_file_arg)))
+        parent = os.path.dirname(output_file)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+    else:
+        out_dir = os.path.abspath(os.path.expandvars(os.path.expanduser(output_dir_arg))) if output_dir_arg else './results'
+        os.makedirs(out_dir, exist_ok=True)
+        doc_name = os.path.splitext(os.path.basename(input_path))[0]
+        output_file = os.path.join(out_dir, f'{doc_name}_structure.json')
+    return output_file
+
+
 if __name__ == "__main__":
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Process PDF or Markdown document and generate structure')
@@ -76,16 +90,7 @@ if __name__ == "__main__":
         print('Parsing done, saving to file...')
         
         # Save results
-        pdf_name = os.path.splitext(os.path.basename(args.pdf_path))[0]
-        if args.output_file:
-            output_file = args.output_file
-            parent = os.path.dirname(os.path.abspath(output_file))
-            if parent:
-                os.makedirs(parent, exist_ok=True)
-        else:
-            output_dir = args.output_dir if args.output_dir else './results'
-            os.makedirs(output_dir, exist_ok=True)
-            output_file = os.path.join(output_dir, f'{pdf_name}_structure.json')
+        output_file = resolve_output_path(args.pdf_path, args.output_dir, args.output_file)
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(toc_with_page_number, f, indent=2)
         
@@ -135,17 +140,7 @@ if __name__ == "__main__":
         print('Parsing done, saving to file...')
         
         # Save results
-        md_name = os.path.splitext(os.path.basename(args.md_path))[0]
-        if args.output_file:
-            output_file = args.output_file
-            parent = os.path.dirname(os.path.abspath(output_file))
-            if parent:
-                os.makedirs(parent, exist_ok=True)
-        else:
-            output_dir = args.output_dir if args.output_dir else './results'
-            os.makedirs(output_dir, exist_ok=True)
-            output_file = os.path.join(output_dir, f'{md_name}_structure.json')
-        
+        output_file = resolve_output_path(args.md_path, args.output_dir, args.output_file)
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(toc_with_page_number, f, indent=2, ensure_ascii=False)
         


### PR DESCRIPTION
## Problem

  I've been using `run_pageindex.py` as part of a larger script that processes
  multiple documents. The issue is that the output path is hardcoded to
  `./results/{name}_structure.json` with no way to override it.

  This becomes a problem when:
  - Running the script from a different working directory
  - Processing multiple documents into separate output folders
  - Integrating into a pipeline where the output location needs to be controlled externally

  ## Expected Behavior

  Users should be able to specify where the output file is written via CLI arguments.

  ## Proposed Solution

  Add `--output-dir` and `--output-file` arguments:

  ```bash
  # Write to a custom directory
  python run_pageindex.py --pdf_path doc.pdf --output-dir /path/to/output

  # Write to a specific file
  python run_pageindex.py --pdf_path doc.pdf --output-file /path/to/result.json
  ```
 ## Backward Compatibility

  No breaking changes. If neither argument is provided, the output is still written
  to `./results/{name}_structure.json` — exactly the same as before.