### PR TITLE
Update agentic_retrieval.ipynb

### DIFF
--- a/cookbook/agentic_retrieval.ipynb
+++ b/cookbook/agentic_retrieval.ipynb
@@ -43,7 +43,7 @@
       "source": [
         "# Agentic Retrieval with PageIndex Chat API\n",
         "\n",
-        "Similarity-based RAG based on Vector-DB has shown big limitations in recent AI applications, reasoning-based or agentic retrieval has become important in current developments. However, unlike classic RAG pipeine with embedding input, top-K chunks returns, re-rank, what should a agentic-native retreival API looks like?\n",
+        "Similarity-based RAG based on Vector-DB has shown big limitations in recent AI applications, reasoning-based or agentic retrieval has become important in current developments. However, unlike classic RAG pipeline with embedding input, top-K chunks returns, re-rank, what should a agentic-native retreival API looks like?\n",
         "\n",
         "For an agentic-native retrieval system, we need the ability to prompt for retrieval just as naturally as you interact with ChatGPT. Below, we provide an example of how the PageIndex Chat API enables this style of prompt-driven retrieval.\n",
         "\n",


### PR DESCRIPTION
Fixed spelling mistake from "pipeine" to "pipeline"