### PR TITLE
fix: add missing commas in LLM prompt JSON formats and guard list return types

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -30,8 +30,8 @@ async def check_title_appearance(item, page_list, start_index=1, model=None):
     
     Reply format:
     {{
-        
-        "thinking": <why do you think the section appears or starts in the page_text>
+
+        "thinking": <why do you think the section appears or starts in the page_text>,
         "answer": "yes or no" (yes if the section appears or starts in the page_text, no otherwise)
     }}
     Directly return the final JSON structure. Do not output anything else."""
@@ -59,7 +59,7 @@ async def check_title_appearance_in_start(title, page_text, model=None, logger=N
     
     reply format:
     {{
-        "thinking": <why do you think the section appears or starts in the page_text>
+        "thinking": <why do you think the section appears or starts in the page_text>,
         "start_begin": "yes or no" (yes if the section starts in the beginning of the page_text, no otherwise)
     }}
     Directly return the final JSON structure. Do not output anything else."""
@@ -109,7 +109,7 @@ def toc_detector_single_page(content, model=None):
 
     return the following JSON format:
     {{
-        "thinking": <why do you think there is a table of content in the given text>
+        "thinking": <why do you think there is a table of content in the given text>,
         "toc_detected": "<yes or no>",
     }}
 
@@ -129,7 +129,7 @@ def check_if_toc_extraction_is_complete(content, toc, model=None):
 
     Reply format:
     {{
-        "thinking": <why do you think the table of contents is complete or not>
+        "thinking": <why do you think the table of contents is complete or not>,
         "completed": "yes" or "no"
     }}
     Directly return the final JSON structure. Do not output anything else."""
@@ -147,7 +147,7 @@ def check_if_toc_transformation_is_complete(content, toc, model=None):
 
     Reply format:
     {{
-        "thinking": <why do you think the cleaned table of contents is complete or not>
+        "thinking": <why do you think the cleaned table of contents is complete or not>,
         "completed": "yes" or "no"
     }}
     Directly return the final JSON structure. Do not output anything else."""
@@ -210,7 +210,7 @@ def detect_page_index(toc_content, model=None):
 
     Reply format:
     {{
-        "thinking": <why do you think there are page numbers/indices given within the table of contents>
+        "thinking": <why do you think there are page numbers/indices given within the table of contents>,
         "page_index_given_in_toc": "<yes or no>"
     }}
     Directly return the final JSON structure. Do not output anything else."""
@@ -534,10 +534,11 @@ def generate_toc_continue(toc_content, part, model=None):
     prompt = prompt + '\nGiven text\n:' + part + '\nPrevious tree structure\n:' + json.dumps(toc_content, indent=2)
     response, finish_reason = llm_completion(model=model, prompt=prompt, return_finish_reason=True)
     if finish_reason == 'finished':
-        return extract_json(response)
+        result = extract_json(response)
+        return result if isinstance(result, list) else []
     else:
         raise Exception(f'finish reason: {finish_reason}')
-    
+
 ### add verify completeness
 def generate_toc_init(part, model=None):
     print('start generate_toc_init')
@@ -569,7 +570,8 @@ def generate_toc_init(part, model=None):
     response, finish_reason = llm_completion(model=model, prompt=prompt, return_finish_reason=True)
 
     if finish_reason == 'finished':
-         return extract_json(response)
+        result = extract_json(response)
+        return result if isinstance(result, list) else []
     else:
         raise Exception(f'finish reason: {finish_reason}')
 

--- a/tests/test_llm_response_robustness.py
+++ b/tests/test_llm_response_robustness.py
@@ -1,0 +1,99 @@
+"""Tests for LLM response robustness fixes (issues #257 and #199)."""
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pageindex.utils import extract_json
+
+
+# --- Issue #257: prompt JSON format has commas after "thinking" ---
+
+def _get_prompt_snippets():
+    """Extract reply-format blocks from page_index.py prompts."""
+    src = (Path(__file__).parent.parent / "pageindex" / "page_index.py").read_text()
+    # Find all JSON-like reply format blocks in prompts
+    blocks = re.findall(r'\{\{(.*?)\}\}', src, re.DOTALL)
+    return blocks
+
+
+def test_prompt_thinking_fields_have_trailing_commas():
+    """Every 'thinking' field in prompt reply formats must end with a comma."""
+    blocks = _get_prompt_snippets()
+    assert blocks, "No reply format blocks found in page_index.py"
+    for block in blocks:
+        lines = block.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith('"thinking"') and not stripped.endswith(','):
+                # Check it's not the last field (last field before closing brace)
+                remaining = [l.strip() for l in lines[i+1:] if l.strip()]
+                if remaining:  # there are more fields after this one
+                    raise AssertionError(
+                        f"'thinking' field missing trailing comma in block:\n{block}"
+                    )
+
+
+# --- Issue #199: generate_toc_init / generate_toc_continue return list ---
+
+def test_generate_toc_init_returns_list_when_llm_returns_dict():
+    """generate_toc_init must return [] when extract_json returns a dict, not crash."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"error": "unexpected dict"}'
+    mock_response.choices[0].finish_reason = "stop"
+
+    with patch("pageindex.utils.litellm.completion", return_value=mock_response):
+        from pageindex.page_index import generate_toc_init
+        result = generate_toc_init("some page text", model="gpt-4o")
+        assert isinstance(result, list), f"Expected list, got {type(result)}: {result}"
+
+
+def test_generate_toc_continue_returns_list_when_llm_returns_dict():
+    """generate_toc_continue must return [] when extract_json returns a dict, not crash."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"error": "unexpected dict"}'
+    mock_response.choices[0].finish_reason = "stop"
+
+    with patch("pageindex.utils.litellm.completion", return_value=mock_response):
+        from pageindex.page_index import generate_toc_continue
+        existing_toc = [{"structure": "1", "title": "Intro", "physical_index": "<physical_index_1>"}]
+        result = generate_toc_continue(existing_toc, "next page text", model="gpt-4o")
+        assert isinstance(result, list), f"Expected list, got {type(result)}: {result}"
+
+
+def test_generate_toc_init_returns_list_when_llm_returns_valid_list():
+    """generate_toc_init passes through a valid list unchanged."""
+    toc_list = [{"structure": "1", "title": "Chapter 1", "physical_index": "<physical_index_1>"}]
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = json.dumps(toc_list)
+    mock_response.choices[0].finish_reason = "stop"
+
+    with patch("pageindex.utils.litellm.completion", return_value=mock_response):
+        from pageindex.page_index import generate_toc_init
+        result = generate_toc_init("some page text", model="gpt-4o")
+        assert result == toc_list
+
+
+def test_process_no_toc_does_not_crash_on_dict_response():
+    """process_no_toc must not raise AttributeError when generate_toc_init returns []."""
+    # When generate_toc_init returns [], the for loop over group_texts[1:] is skipped
+    # and toc_with_page_number stays as [], so .extend() is never called on a dict.
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = '{"error": "malformed"}'
+    mock_response.choices[0].finish_reason = "stop"
+
+    logger = MagicMock()
+
+    with patch("pageindex.utils.litellm.completion", return_value=mock_response), \
+         patch("pageindex.utils.litellm.token_counter", return_value=10):
+        from pageindex.page_index import process_no_toc
+        page_list = [("Page one content",)]
+        result = process_no_toc(page_list, start_index=1, model="gpt-4o", logger=logger)
+        assert isinstance(result, list)


### PR DESCRIPTION
## Summary

Two related robustness issues that cause crashes when LLMs return malformed or unexpected JSON responses.

## Changes

### Fix #257 — Missing commas in LLM prompt reply formats

Six prompt templates in `pageindex/page_index.py` were missing a trailing comma after the `"thinking"` field:

- `check_title_appearance` (line 34)
- `check_title_appearance_in_start` (line 62)
- `toc_detector_single_page` (line 112)
- `check_if_toc_extraction_is_complete` (line 132)
- `check_if_toc_transformation_is_complete` (line 150)
- `detect_page_index` (line 213)

When an LLM follows the format literally, it produces invalid JSON (missing comma between keys). `extract_json` then fails and returns `{}`, causing `KeyError` on `toc_detected`, `completed`, or `page_index_given_in_toc`.

### Fix #199 — `generate_toc_init` / `generate_toc_continue` must return a list

When `extract_json` fails on a malformed LLM response it returns `{}` (a dict). Both `generate_toc_init` and `generate_toc_continue` passed this through directly. Callers expect a list:

- `process_no_toc` calls `toc_with_page_number.extend(...)` → `AttributeError: 'dict' object has no attribute 'extend'`
- `meta_processor` calls `item.get('physical_index')` on list items → `AttributeError: 'str' object has no attribute 'get'`

Both functions now return `[]` when `extract_json` returns a non-list, matching the expected contract.

## Testing

Added `tests/test_llm_response_robustness.py` with 5 tests covering:

1. All `"thinking"` fields in prompt reply formats have trailing commas
2. `generate_toc_init` returns `[]` (not a dict) when LLM returns malformed JSON
3. `generate_toc_continue` returns `[]` (not a dict) when LLM returns malformed JSON
4. `generate_toc_init` passes through a valid list unchanged
5. `process_no_toc` does not raise `AttributeError` when `generate_toc_init` returns `[]`

Run with:
```bash
pytest tests/test_llm_response_robustness.py -v
```

![tests pass](https://raw.githubusercontent.com/zhoufengen/PageIndex/pr-media/tests-pass.png)

## Related Issues

Fixes #257
Fixes #199