### PR TITLE
fix: Route TOC-without-page-numbers documents to the correct strategy

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -963,7 +963,7 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
     if mode == 'process_toc_with_page_numbers':
         toc_with_page_number = process_toc_with_page_numbers(toc_content, toc_page_list, page_list, toc_check_page_num=opt.toc_check_page_num, model=opt.model, logger=logger)
     elif mode == 'process_toc_no_page_numbers':
-        toc_with_page_number = process_toc_no_page_numbers(toc_content, toc_page_list, page_list, model=opt.model, logger=logger)
+        toc_with_page_number = process_toc_no_page_numbers(toc_content, toc_page_list, page_list,start_index=start_index, model=opt.model, logger=logger)
     else:
         toc_with_page_number = process_no_toc(page_list, start_index=start_index, model=opt.model, logger=logger)
             
@@ -1034,6 +1034,15 @@ async def tree_parser(page_list, opt, doc=None, logger=None):
         toc_with_page_number = await meta_processor(
             page_list, 
             mode='process_toc_with_page_numbers', 
+            start_index=1, 
+            toc_content=check_toc_result['toc_content'], 
+            toc_page_list=check_toc_result['toc_page_list'], 
+            opt=opt,
+            logger=logger)
+    elif check_toc_result.get("toc_content") and check_toc_result["toc_content"].strip() and check_toc_result["page_index_given_in_toc"] == "no":
+        toc_with_page_number = await meta_processor(
+            page_list, 
+            mode='process_toc_no_page_numbers', 
             start_index=1, 
             toc_content=check_toc_result['toc_content'], 
             toc_page_list=check_toc_result['toc_page_list'], 


### PR DESCRIPTION
## Problem

`tree_parser` only had two dispatch branches: a TOC with page numbers, or everything else. A document with a printed table of contents that lists **no page numbers** fell into the `else` branch and was handled by `process_no_toc` — regenerating the structure from scratch and ignoring the existing TOC entirely.

As a result, `process_toc_no_page_numbers` was unreachable as a primary strategy. It only ever ran as a fallback from `process_toc_with_page_numbers` inside `meta_processor`.

## Fix

- Add the missing `tree_parser` branch so a TOC with no page numbers is dispatched to `process_toc_no_page_numbers` directly, using the TOC instead of discarding it.
- Forward `start_index` from `meta_processor` into `process_toc_no_page_numbers`. It previously relied on the default (`1`), which would index incorrectly when invoked for non-top-level nodes.

The existing fallback chain is preserved: `process_toc_no_page_numbers` still degrades to `process_no_toc` on low verification accuracy.

## Impact

Additive only — no existing branch behavior changes. Documents that previously hit `process_no_toc` despite having a usable TOC now keep their authored structure.
