### PR TITLE
Fix: python-dotenv version conflict with litellm (#286)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ litellm==1.83.7
 # openai-agents  # optional: required for examples/agentic_vectorless_rag_demo.py
 pymupdf==1.26.4
 PyPDF2==3.0.1
-python-dotenv==1.2.2
+python-dotenv==1.0.1
 pyyaml==6.0.2


### PR DESCRIPTION
Fixed python-dotenv version that conflict with litellm while installing from requirements.txt using uv. 