### PR TITLE
fix: use .get() in get_leaf_nodes to avoid KeyError on leaf nodes

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -189,7 +189,7 @@ def structure_to_list(structure):
     
 def get_leaf_nodes(structure):
     if isinstance(structure, dict):
-        if not structure['nodes']:
+        if not structure.get('nodes'):
             structure_node = copy.deepcopy(structure)
             structure_node.pop('nodes', None)
             return [structure_node]


### PR DESCRIPTION
## Summary

- `get_leaf_nodes()` crashed with `KeyError: 'nodes'` when called on a tree built by the standard pipeline
- `list_to_tree()` calls `clean_node()` which **deletes** the `nodes` key entirely from leaf nodes (rather than setting it to `[]`)
- Accessing `structure['nodes']` directly on those nodes raises `KeyError`
- Fix: replace `structure['nodes']` with `structure.get('nodes')` — returns `None` (falsy) safely when the key is absent

## Changes

`pageindex/utils.py` — one-line change in `get_leaf_nodes`:

```python
# Before
if not structure['nodes']:   # KeyError on leaf nodes

# After
if not structure.get('nodes'):   # safe: returns None if key absent
```

## Why this is consistent

Every other `nodes` access in the codebase already uses `.get()`:
- `format_structure` → `structure.get('nodes')`
- `is_leaf_node` → `node.get('nodes')`
- `print_tree` → `node.get('nodes')`

## Test

```python
from pageindex.utils import get_leaf_nodes, list_to_tree

flat = [
    {'structure': '1', 'title': 'Chapter 1', 'start_index': 1, 'end_index': 5},
    {'structure': '2', 'title': 'Chapter 2', 'start_index': 6, 'end_index': 10},
]
tree = list_to_tree(flat)
leaves = get_leaf_nodes(tree)   # previously raised KeyError, now returns both nodes
assert len(leaves) == 2
```

Fixes #330