### PR TITLE
docs: document Windows and LiteLLM provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,10 @@ py -m venv .venv
 pip install --upgrade -r requirements.txt
 ```
 
-If PowerShell blocks `Activate.ps1`, allow scripts for the current user and retry:
+If PowerShell blocks `Activate.ps1`, allow scripts for the current shell session and retry:
 
 ```powershell
-Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 .\.venv\Scripts\Activate.ps1
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,24 @@ You can follow these steps to generate a PageIndex tree from a PDF document.
 ### 1. Install dependencies
 
 ```bash
+python3 -m venv .venv
+source .venv/bin/activate
 pip3 install --upgrade -r requirements.txt
+```
+
+On Windows PowerShell:
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install --upgrade -r requirements.txt
+```
+
+If PowerShell blocks `Activate.ps1`, allow scripts for the current user and retry:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
+.\.venv\Scripts\Activate.ps1
 ```
 
 ### 2. Set your LLM API key
@@ -160,6 +177,18 @@ Create a `.env` file in the root directory with your LLM API key. Multi-LLM is s
 ```bash
 OPENAI_API_KEY=your_openai_key_here
 ```
+
+For non-OpenAI providers, set the provider-specific key required by LiteLLM and pass the matching model name:
+
+```bash
+DASHSCOPE_API_KEY=your_dashscope_key_here
+```
+
+```bash
+python3 run_pageindex.py --pdf_path /path/to/your/document.pdf --model dashscope/qwen-plus
+```
+
+Use the model prefix and environment variable documented by your LiteLLM provider, such as `anthropic/...`, `gemini/...`, `deepseek/...`, or `dashscope/...`.
 
 ### 3. Generate PageIndex structure for your PDF
 


### PR DESCRIPTION
## Summary

This PR adds a small quickstart clarification for local PageIndex setup:

- recommend a Python virtual environment before installing dependencies,
- add Windows PowerShell activation commands,
- document the common `Activate.ps1` execution-policy workaround using only the current shell session,
- show how to use a non-OpenAI LiteLLM provider by setting the provider key and passing `--model`.

## Why

New users can currently follow the README successfully on Unix-like shells, but Windows users may hit PowerShell's script execution policy when activating `.venv`.

The README also mentions multi-LLM support through LiteLLM, but the quickstart only shows `OPENAI_API_KEY`. Adding a provider-key example makes it clearer that users can run PageIndex with other LiteLLM-supported providers without changing code.

## Changes

- Extend the install step with `python3 -m venv .venv` and activation.
- Add equivalent Windows PowerShell commands.
- Add `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` as a current-session workaround for blocked virtualenv activation.
- Add a non-OpenAI provider example using `DASHSCOPE_API_KEY` and `--model dashscope/qwen-plus`.
- Point users back to LiteLLM provider docs for exact model prefixes and environment variables.

## Validation

```powershell
git diff --check
```

Local result:

```text
No whitespace errors.
```