### PR TITLE
fix: bump litellm to 1.84.0 to resolve python-dotenv install conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-litellm==1.83.7
+litellm==1.84.0
 # openai-agents  # optional: required for examples/agentic_vectorless_rag_demo.py
 pymupdf==1.26.4
 PyPDF2==3.0.1


### PR DESCRIPTION
## Problem

Fresh installs from `main` fail. `litellm==1.83.7` hard-pins `python-dotenv==1.0.1`, which conflicts with the `python-dotenv==1.2.2` in `requirements.txt`:

```
ERROR: Cannot install ... and python-dotenv==1.2.2 because these package versions have conflicting dependencies.
    The user requested python-dotenv==1.2.2
    litellm 1.83.7 depends on python-dotenv==1.0.1
ERROR: ResolutionImpossible
```

Reproduced with both `pip` 25.2 and `uv`.

## Why not just pin `python-dotenv==1.0.1` (as in #291)

`python-dotenv < 1.2.2` is affected by [GHSA-mf9w-mj56-hr94](https://github.com/advisories/GHSA-mf9w-mj56-hr94) (moderate: symlink following in `set_key` allows arbitrary file overwrite), fixed in `1.2.2`. Downgrading makes the install resolve but reintroduces the vulnerability and trips the Dependency Review check.

## Fix

Bump `litellm` `1.83.7 → 1.84.0`. litellm 1.84.0 relaxed its pin from `python-dotenv==1.0.1` to `python-dotenv<2.0,>=1.0.0`, allowing the patched `python-dotenv==1.2.2` to stay.

Verified the full `requirements.txt` resolves cleanly under both `pip` and `uv`, with `python-dotenv` staying at `1.2.2`.

Closes #286. Supersedes #291.
