### PR TITLE
fix(filesystem): round-trip scope-qualified file locators

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,56 @@
+# PageIndex FileSystem Context
+
+This context defines the product language for PageIndex FileSystem (PIFS), an
+agent-facing virtual filesystem for navigating document workspaces.
+
+## Language
+
+**PIFS Browse**:
+A relevance-ranked view of files inside one PIFS scope for a required query.
+It returns files only. Browse result `path` values are file locators and must
+round-trip through `stat`, `cat`, and `grep`.
+_Avoid_: search-summary, semantic-grep, display-only browse paths
+
+**PIFS File Locator**:
+An idempotent path-like locator returned by PIFS commands that identifies one
+file for inspection commands.
+_Avoid_: storage_uri, source_path, physical/debug path
+
+**Scope-Qualified File Locator**:
+A file locator formed by appending a concrete file leaf to the current scope,
+for example `/@company/3M/3M_2018_10K.pdf`. The file leaf comes from `tree` or
+`browse`; file commands do not infer it from corpus-specific metadata.
+_Avoid_: treating metadata-qualified file paths as folders
+
+**Round-Trippable File Locator**:
+A locator returned by `tree` or `browse` that can be copied directly into
+`stat`, `cat`, or `grep`. If visible leaves collide inside a scope, discovery
+commands must return a disambiguated locator; inspection commands do not guess.
+_Avoid_: same-looking file leaves, command-specific resolver heuristics
+
+**Scope-Only File Command Error**:
+The error returned when `stat`, `cat`, or `grep` receives a scope path without a
+file leaf. The command fails and points the agent back to `tree <scope>` or
+`browse <scope> "<query>"`.
+_Avoid_: silently selecting one file, returning candidate lists from cat/stat/grep
+
+**PIFS File Inspection Resolver**:
+The shared resolver used by `stat`, `cat`, and `grep`. A scope-qualified file
+locator that works for one file inspection command must work for all three.
+_Avoid_: command-specific path parsing
+
+**PIFS Tree File Leaf**:
+A concrete file child exposed by `tree` when a scope contains visible files.
+Ordinary folder scopes list directly visible file leaves; metadata value scopes
+list matching file leaves.
+_Avoid_: using cat to discover files
+
+**PIFS Tree Depth**:
+The `tree -L` option controls traversal depth only. It does not increase page
+size or bypass pagination.
+_Avoid_: treating depth as page size
+
+**PIFS Tree Pagination**:
+Tree pagination is one global page over displayed child nodes in stable order:
+folders, files, then metadata axes or metadata values.
+_Avoid_: per-group cursors, unstable page ordering

--- a/docs/pifs-core-alignment/ADR-0001-scope-qualified-file-locators.md
+++ b/docs/pifs-core-alignment/ADR-0001-scope-qualified-file-locators.md
@@ -1,0 +1,63 @@
+# ADR-0001: Scope-Qualified File Locators
+
+Status: Accepted
+
+Date: 2026-07-08
+
+## Context
+
+PIFS agents often navigate through metadata scopes before selecting documents,
+for example `/@company/3M`. A failure mode appears when the agent finds the
+right scope, then tries to inspect the scope itself as a file. That makes
+`cat`, `stat`, or `grep` reject the target after discovery already succeeded.
+
+The fix is an agent-facing path contract, not benchmark-specific prompting.
+
+## Decision
+
+`tree` and `browse` are the file discovery commands. Whenever they return a
+file, the returned `path` must be a round-trippable file locator that can be
+copied directly into `stat`, `cat`, or `grep`.
+
+A metadata-scoped file is represented as:
+
+```text
+<scope path>/<file leaf>
+```
+
+Example:
+
+```text
+/@company/3M/3M_2018_10K.pdf
+```
+
+The file leaf is the leaf exposed by `tree` or `browse`; it is not inferred from
+corpus-specific metadata such as `doc_name`.
+
+`tree <metadata value scope>` lists matching file leaves. `tree -L` controls
+only traversal depth; large child sets still use pagination.
+
+`stat`, `cat`, and `grep` share one file inspection resolver. If a target is a
+scope without a file leaf, such as `/@company/3M`, the command fails and points
+the agent back to `tree <scope>` or `browse <scope> "<query>"`. File inspection
+commands do not return candidate files or silently choose one.
+
+Agent-facing command output exposes navigation-local locators only. Physical or
+debug paths may be kept in internal traces, but not shown to the agent.
+
+## Consequences
+
+- Agents can keep their current navigation context from metadata discovery to
+  page reads.
+- `tree` and `browse` own file discovery.
+- `cat`, `stat`, and `grep` stay simple and share one resolver.
+- Tests assert that `tree` and `browse` paths round-trip through `stat`,
+  `cat --structure`, and `grep`.
+
+## Rejected
+
+- Letting `cat /@company/3M` resolve a singleton scope automatically.
+- Showing physical/debug paths to the agent for convenience.
+- Using `doc_name` or any corpus-specific metadata field as the generic file
+  resolver key.
+- Returning browse hits whose `path` cannot be inspected as a file.

--- a/docs/pifs-core-alignment/SPEC.md
+++ b/docs/pifs-core-alignment/SPEC.md
@@ -1,0 +1,90 @@
+# PIFS Core Alignment Spec
+
+## Purpose
+
+Align PageIndex FileSystem (PIFS) core around a small BashLike command surface
+where file discovery and file inspection have separate responsibilities.
+
+## Scope
+
+In scope:
+
+- Keep PIFS BashLike commands as the agent-facing interface.
+- Make `tree` and `browse` the only file discovery commands.
+- Make `stat`, `cat`, and `grep` require a concrete file locator.
+- Ensure metadata scope file locators round-trip through all file inspection
+  commands.
+
+Out of scope:
+
+- Replacing PIFS with typed MCP tools.
+- Adding benchmark-specific prompts, result rows, or scoring logic to PIFS core.
+- Adding a new search/find command.
+
+## Command Surface
+
+| Command | Role |
+|---|---|
+| `tree` | Structural orientation and file leaf discovery |
+| `browse` | Relevance-ranked document discovery |
+| `stat` | Single document identity and metadata |
+| `cat` | Structure and page content reads |
+| `grep` | Single-document lexical evidence fallback |
+
+`ls` remains only as an exact alias for `tree -L 1`.
+
+## `tree`
+
+Syntax:
+
+```text
+tree <scope> [-L depth] [--page N]
+ls <scope>
+```
+
+Rules:
+
+- `tree` returns folders, files, metadata axes, or metadata values.
+- Ordinary folder scopes list directly visible file leaves.
+- Metadata value scopes such as `/@company/3M` list matching file leaves.
+- File leaves returned by `tree` are round-trippable locators for `stat`,
+  `cat`, and `grep`.
+- `-L` controls traversal depth only.
+- Pagination is one global page over displayed children in stable order:
+  folders, files, then metadata axes or metadata values.
+
+## `browse`
+
+Syntax:
+
+```text
+browse <scope> "<query>" [--page N] [--where JSON] [-R]
+```
+
+Rules:
+
+- Query is required.
+- Results are relevance-ranked documents inside the scope.
+- Each result `path` is a round-trippable file locator.
+- Metadata-scoped browse returns navigation-local locators, for example
+  `/@company/3M/3M_2018_10K.pdf`.
+- Browse output does not expose physical/debug paths to the agent.
+
+## File Inspection Commands
+
+`stat`, `cat`, and `grep` inspect exactly one file locator:
+
+```text
+stat <file>
+cat <file> --structure
+cat <file> --page N[-M]
+grep <query> <file>
+```
+
+Rules:
+
+- These commands share one file inspection resolver.
+- Scope-only targets fail and point the agent back to `tree <scope>` or
+  `browse <scope> "<query>"`.
+- File inspection commands do not discover files, return candidate lists, or
+  silently select singleton scopes.

--- a/pageindex/filesystem/commands.py
+++ b/pageindex/filesystem/commands.py
@@ -131,20 +131,36 @@ class PIFSCommandExecutor:
             }
             next_steps = [f'browse {shlex.quote(scope.path)}/<value> "<query>"']
             return data, next_steps
-        if page != 1:
-            raise PIFSCommandError("tree --page is only supported by metadata axis paths like /documents/@field")
+        page_size = self.TREE_VALUE_PAGE_SIZE
+        needed = page * page_size + 1
         folders = self.filesystem.scope_folders(
             scope,
             max_depth=depth,
-            limit=self.MAX_TREE_FOLDERS,
+            limit=max(self.MAX_TREE_FOLDERS, needed),
         )
+        files = self.filesystem.scope_files(scope, limit=needed)
         axes = self.filesystem.scope_metadata_axes(scope)
+        tree, has_more = self._folder_tree(
+            scope,
+            folders,
+            files,
+            axes,
+            page=page,
+            page_size=page_size,
+        )
         data = {
-            "tree": self._folder_tree(scope, folders, axes),
+            "tree": tree,
             "total_folders": len(folders) + len(axes),
             "depth": depth,
-            "truncated": len(folders) >= self.MAX_TREE_FOLDERS,
+            "truncated": has_more or len(folders) >= self.MAX_TREE_FOLDERS,
         }
+        if has_more or page > 1:
+            data["pagination"] = {
+                "page": page,
+                "page_size": page_size,
+                "has_more": has_more,
+                "next_page": page + 1 if has_more else None,
+            }
         next_steps = [f'browse {shlex.quote(scope.path)} "<query>"']
         return data, next_steps
 
@@ -191,14 +207,14 @@ class PIFSCommandExecutor:
         if not self.filesystem.has_semantic_channel("summary"):
             raise PIFSCommandError("browse summary retrieval is not available")
         payload = self.filesystem.browse_semantic_files(
-            scope.folder_path,
+            scope.path,
             query,
             retrieval_query=query,
             recursive=effective_recursive,
             space="summary",
             page=page,
             page_size=self.BROWSE_PAGE_SIZE,
-            metadata_filter=merged_filter,
+            metadata_filter=where,
         )
         documents = [self._document_hit(row) for row in payload.get("data", [])]
         next_steps = []
@@ -240,12 +256,7 @@ class PIFSCommandExecutor:
         if len(args) != 1:
             raise PIFSCommandError("stat accepts exactly one document target")
         target = args[0]
-        try:
-            return {"document": self._document_stat(target)}, []
-        except (KeyError, ValueError):
-            if not target.startswith("/"):
-                raise
-        return {"scope": self.filesystem.scope_stat(target)}, []
+        return {"document": self._document_stat(target)}, []
 
     def _cmd_cat(self, args: list[str]) -> tuple[dict[str, Any], list[str]]:
         if not args:
@@ -300,8 +311,12 @@ class PIFSCommandExecutor:
         self,
         scope: Any,
         folders: list[dict[str, Any]],
+        files: list[dict[str, Any]],
         axes: list[dict[str, Any]],
-    ) -> dict[str, Any]:
+        *,
+        page: int,
+        page_size: int,
+    ) -> tuple[dict[str, Any], bool]:
         root_key = self._normalize_folder_path(scope.folder_path)
         root = self._scope_root(scope, file_count=self.filesystem.scope_file_count(scope))
         nodes = {
@@ -322,7 +337,7 @@ class PIFSCommandExecutor:
                 continue
             parent = folder_path.rsplit("/", 1)[0] or "/"
             nodes.get(parent, nodes[root_key])["folders"].append(node)
-        nodes[root_key]["folders"].extend(
+        axis_nodes = [
             {
                 "path": self._join_scope_path(
                     scope.path,
@@ -334,9 +349,18 @@ class PIFSCommandExecutor:
                 "folders": [],
             }
             for axis in axes
+        ]
+        child_items = (
+            [("folder", node) for node in nodes[root_key]["folders"]]
+            + [("file", file) for file in files]
+            + [("folder", node) for node in axis_nodes]
         )
-        nodes[root_key]["children_count"] = len(nodes[root_key]["folders"])
-        return nodes[root_key]
+        offset = (page - 1) * page_size
+        page_items = child_items[offset : offset + page_size]
+        nodes[root_key]["folders"] = [node for kind, node in page_items if kind == "folder"]
+        nodes[root_key]["files"] = [node for kind, node in page_items if kind == "file"]
+        nodes[root_key]["children_count"] = len(child_items)
+        return nodes[root_key], len(child_items) > offset + page_size
 
     def _document_hit(self, row: dict[str, Any]) -> dict[str, Any]:
         return {
@@ -349,7 +373,7 @@ class PIFSCommandExecutor:
     def _document_stat(self, target: str) -> dict[str, Any]:
         info = dict(self.filesystem._stat(target))
         return {
-            "path": info.get("path"),
+            "path": target if str(target).startswith("/") else info.get("path"),
             "file_ref": info.get("file_ref"),
             "document_id": info.get("external_id") or info.get("document_id"),
             "status": info.get("pageindex_tree_status") or info.get("status"),

--- a/pageindex/filesystem/core.py
+++ b/pageindex/filesystem/core.py
@@ -546,6 +546,69 @@ class PageIndexFileSystem:
         has_more = len(rows) > page_size
         return rows[:page_size], has_more
 
+    def scope_files(self, scope: PIFSQueryScope, *, limit: int) -> list[dict[str, Any]]:
+        leaf_items = self._scope_file_leaf_items(scope, limit=limit)
+        leaf_counts = self._scope_leaf_counts(leaf_items)
+        files = []
+        for row, leaf in leaf_items:
+            locator_leaf = self._disambiguated_scope_leaf(leaf, row["file_ref"], leaf_counts)
+            files.append(
+                {
+                    "path": self._scope_file_locator(scope, locator_leaf),
+                    "name": locator_leaf,
+                    "type": "file",
+                    "file_ref": row["file_ref"],
+                    "document_id": row["document_id"],
+                    "title": leaf,
+                    "metadata": row["metadata"],
+                }
+            )
+        return sorted(files, key=lambda item: (str(item["name"]).lower(), item["path"], item["file_ref"]))
+
+    def scope_file_locator(self, scope: PIFSQueryScope, file_ref: str, leaf: str) -> str:
+        leaf_items = self._scope_file_leaf_items(scope, limit=self.scope_file_count(scope) + 1)
+        leaf_counts = self._scope_leaf_counts(leaf_items)
+        return self._scope_file_locator(
+            scope,
+            self._disambiguated_scope_leaf(leaf, file_ref, leaf_counts),
+        )
+
+    def _scope_file_leaf_items(self, scope: PIFSQueryScope, *, limit: int) -> list[tuple[dict[str, Any], str]]:
+        recursive = bool(scope.metadata_filter)
+        rows = self.store.search_files(
+            None,
+            scope={"folder_path": scope.folder_path, "recursive": recursive},
+            metadata_filter=scope.metadata_filter or None,
+            limit=limit,
+        )
+        items = []
+        for row in rows:
+            folder_paths = [
+                folder["path"]
+                for folder in self.store.folder_memberships(row["file_ref"])
+            ]
+            folder_path = self._preferred_folder_path(
+                folder_paths,
+                scope.folder_path,
+                row["folder_path"],
+            )
+            leaf = self.store.membership_display_name(row["file_ref"], folder_path) or row["title"]
+            items.append((row, leaf))
+        return items
+
+    @staticmethod
+    def _scope_leaf_counts(leaf_items: list[tuple[dict[str, Any], str]]) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for _, leaf in leaf_items:
+            counts[leaf] = counts.get(leaf, 0) + 1
+        return counts
+
+    @staticmethod
+    def _disambiguated_scope_leaf(leaf: str, file_ref: str, leaf_counts: dict[str, int]) -> str:
+        if leaf_counts.get(leaf, 0) <= 1:
+            return leaf
+        return f"{leaf}~{file_ref}"
+
     def scope_stat(self, path: str) -> dict[str, Any]:
         scope = self.resolve_query_scope(path)
         data = {
@@ -652,11 +715,14 @@ class PageIndexFileSystem:
             )
             display_title = self.store.membership_display_name(file_ref, folder_path) or entry.title
             try:
-                stable_path = self._stable_file_locator(
-                    file_ref,
-                    entry,
-                    folder_path=folder_path,
-                )
+                if query_scope.metadata_filter:
+                    stable_path = self.scope_file_locator(query_scope, file_ref, display_title)
+                else:
+                    stable_path = self._stable_file_locator(
+                        file_ref,
+                        entry,
+                        folder_path=folder_path,
+                    )
             except RuntimeError:
                 continue
             seen.add(file_ref)
@@ -1656,7 +1722,49 @@ class PageIndexFileSystem:
         return message or error_type or None
 
     def _resolve_target(self, target: str) -> str:
-        return self.store.resolve_file_ref(target)
+        try:
+            return self.store.resolve_file_ref(target)
+        except KeyError:
+            if not str(target).strip().startswith("/"):
+                raise
+        normalized = normalize_path(target)
+        try:
+            scope = self.resolve_query_scope(normalized)
+        except (KeyError, ValueError):
+            pass
+        else:
+            raise ValueError(self._scope_file_required_message(scope.path))
+        return self._resolve_scope_file_locator(normalized)
+
+    def _resolve_scope_file_locator(self, target: str) -> str:
+        prefix, _, leaf = target.rstrip("/").rpartition("/")
+        if not leaf:
+            raise KeyError(f"Unknown file target: {target}")
+        scope_path = prefix or "/"
+        scope = self.resolve_query_scope(scope_path)
+        if scope.metadata_axis is not None:
+            raise ValueError(self._scope_file_required_message(target))
+        # ponytail: scans the scoped leaf list; add an indexed leaf lookup if huge scoped collisions matter.
+        matches = [
+            item
+            for item in self.scope_files(scope, limit=self.scope_file_count(scope) + 1)
+            if item["name"] == leaf
+        ]
+        if not matches:
+            raise KeyError(f"Unknown file target: {target}")
+        if len(matches) > 1:
+            raise KeyError(
+                f"Ambiguous file target: {target}. Use tree {scope.path} or "
+                f'browse {scope.path} "<query>" to copy a disambiguated file locator.'
+            )
+        return matches[0]["file_ref"]
+
+    @staticmethod
+    def _scope_file_required_message(path: str) -> str:
+        return (
+            f"{path} is a scope, not a file locator; use tree {path} or "
+            f'browse {path} "<query>" to select a file leaf.'
+        )
 
     @staticmethod
     def _semantic_candidate_score(candidate: Any) -> float | None:
@@ -1722,6 +1830,10 @@ class PageIndexFileSystem:
                 f"{target} resolved to {resolved_file_ref}, expected {file_ref}"
             )
         return target
+
+    @staticmethod
+    def _scope_file_locator(scope: PIFSQueryScope, leaf: Any) -> str:
+        return PageIndexFileSystem._join_virtual_file_path(scope.path, str(leaf).strip("/"))
 
     @staticmethod
     def _build_descriptor(title: str, metadata: dict[str, Any]) -> str:

--- a/tests/test_pifs_scope_paths.py
+++ b/tests/test_pifs_scope_paths.py
@@ -102,7 +102,7 @@ class PIFSScopePathTest(unittest.TestCase):
             self.assertTrue(browse["success"])
             self.assertEqual(
                 [item["path"] for item in browse["data"]["documents"]],
-                ["/documents/sec-filings/aapl-2024.md"],
+                ["/documents/@year/2024/@ticker/AAPL/aapl-2024.md"],
             )
             self.assertEqual(browse["data"]["scope"]["path"], "/documents/@year/2024/@ticker/AAPL")
             self.assertEqual(browse["data"]["scope"]["folder_path"], "/documents")
@@ -111,15 +111,162 @@ class PIFSScopePathTest(unittest.TestCase):
                 {"year": "2024", "ticker": "AAPL"},
             )
 
-            stat = _payload(executor.execute("stat /documents/@year/2024/@ticker/AAPL"))
+            locator = browse["data"]["documents"][0]["path"]
+            stat = _payload(executor.execute(f"stat {locator}"))
             self.assertTrue(stat["success"])
-            self.assertEqual(stat["data"]["scope"]["folder_path"], "/documents")
-            self.assertEqual(
-                stat["data"]["scope"]["metadata_filter"],
-                {"year": "2024", "ticker": "AAPL"},
+            self.assertEqual(stat["data"]["document"]["path"], locator)
+            self.assertEqual(stat["data"]["document"]["title"], "aapl-2024.md")
+
+    def test_metadata_scope_file_locators_round_trip_to_file_commands(self):
+        from pageindex.filesystem import PIFSCommandExecutor, PageIndexFileSystem
+
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path
+
+            root = Path(tmp)
+            filesystem = PageIndexFileSystem(workspace=root / "workspace")
+            refs = {
+                "doc_3m_2018": register_markdown(
+                    filesystem,
+                    root,
+                    "doc_3m_2018",
+                    "/docs/filings",
+                    title="3M_2018_10K.md",
+                    text="cash flow evidence\nnet sales evidence",
+                    metadata={"company": "3M"},
+                ),
+                "doc_other": register_markdown(
+                    filesystem,
+                    root,
+                    "doc_other",
+                    "/docs/filings",
+                    title="Other_2018_10K.md",
+                    text="other cash flow",
+                    metadata={"company": "Other"},
+                ),
+            }
+            filesystem.semantic_retrieval_backend = BrowseBackend(
+                ["doc_3m_2018", "doc_other"],
+                file_refs_by_document_id=refs,
             )
-            self.assertEqual(stat["data"]["scope"]["file_count"], 1)
-            self.assertEqual(stat["data"]["scope"]["available_axes"], ["doc_type"])
+            executor = PIFSCommandExecutor(filesystem)
+
+            tree = _payload(executor.execute("tree /docs/@company/3M"))
+            self.assertTrue(tree["success"])
+            self.assertEqual(
+                [item["path"] for item in tree["data"]["tree"]["files"]],
+                ["/docs/@company/3M/3M_2018_10K.md"],
+            )
+
+            browse = _payload(executor.execute('browse /docs/@company/3M "cash flow"'))
+            self.assertTrue(browse["success"])
+            locator = browse["data"]["documents"][0]["path"]
+            self.assertEqual(locator, "/docs/@company/3M/3M_2018_10K.md")
+
+            stat = _payload(executor.execute(f"stat {locator}"))
+            self.assertTrue(stat["success"])
+            self.assertEqual(stat["data"]["document"]["path"], locator)
+            self.assertEqual(stat["data"]["document"]["title"], "3M_2018_10K.md")
+
+            structure = _payload(executor.execute(f"cat {locator} --structure"))
+            self.assertTrue(structure["success"])
+            self.assertEqual(structure["data"]["document"]["path"], locator)
+            self.assertTrue(structure["data"]["structure"])
+
+            grep = _payload(executor.execute(f"grep cash {locator}"))
+            self.assertTrue(grep["success"])
+            self.assertEqual(grep["data"]["document"]["path"], locator)
+            self.assertEqual(grep["data"]["matches"][0]["line"], 1)
+
+            scope_only = _payload(executor.execute("cat /docs/@company/3M --structure"))
+            self.assertFalse(scope_only["success"])
+            self.assertIn("scope, not a file locator", scope_only["error"]["message"])
+            self.assertIn("tree /docs/@company/3M", scope_only["error"]["message"])
+            self.assertIn('browse /docs/@company/3M "<query>"', scope_only["error"]["message"])
+
+    def test_tree_depth_does_not_bypass_file_pagination(self):
+        from pageindex.filesystem import PIFSCommandExecutor, PageIndexFileSystem
+
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path
+
+            root = Path(tmp)
+            filesystem = PageIndexFileSystem(workspace=root / "workspace")
+            for index in range(55):
+                register_markdown(
+                    filesystem,
+                    root,
+                    f"doc_{index:02d}",
+                    "/docs",
+                    title=f"report-{index:02d}.md",
+                    metadata={"company": "3M"},
+                )
+            executor = PIFSCommandExecutor(filesystem)
+
+            first_page = _payload(executor.execute("tree /docs/@company/3M -L 100"))
+            self.assertTrue(first_page["success"])
+            self.assertEqual(len(first_page["data"]["tree"]["files"]), 50)
+            self.assertEqual(
+                first_page["data"]["pagination"],
+                {"page": 1, "page_size": 50, "has_more": True, "next_page": 2},
+            )
+
+            second_page = _payload(executor.execute("tree /docs/@company/3M -L 100 --page 2"))
+            self.assertTrue(second_page["success"])
+            self.assertEqual(len(second_page["data"]["tree"]["files"]), 5)
+            self.assertEqual(
+                second_page["data"]["pagination"],
+                {"page": 2, "page_size": 50, "has_more": False, "next_page": None},
+            )
+
+    def test_duplicate_file_leaves_in_scope_return_disambiguated_locators(self):
+        from pageindex.filesystem import PIFSCommandExecutor, PageIndexFileSystem
+
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path
+
+            root = Path(tmp)
+            filesystem = PageIndexFileSystem(workspace=root / "workspace")
+            refs = {
+                "doc_a": register_markdown(
+                    filesystem,
+                    root,
+                    "doc_a",
+                    "/docs/a",
+                    title="report.md",
+                    metadata={"company": "3M"},
+                ),
+                "doc_b": register_markdown(
+                    filesystem,
+                    root,
+                    "doc_b",
+                    "/docs/b",
+                    title="report.md",
+                    metadata={"company": "3M"},
+                ),
+            }
+            filesystem.semantic_retrieval_backend = BrowseBackend(
+                ["doc_a", "doc_b"],
+                file_refs_by_document_id=refs,
+            )
+            executor = PIFSCommandExecutor(filesystem)
+
+            tree = _payload(executor.execute("tree /docs/@company/3M"))
+            self.assertTrue(tree["success"])
+            paths = [item["path"] for item in tree["data"]["tree"]["files"]]
+            self.assertEqual(len(paths), 2)
+            self.assertEqual(len(set(paths)), 2)
+
+            for path in paths:
+                stat = _payload(executor.execute(f"stat {path}"))
+                self.assertTrue(stat["success"])
+                self.assertEqual(stat["data"]["document"]["path"], path)
+
+            browse = _payload(executor.execute('browse /docs/@company/3M "report"'))
+            self.assertTrue(browse["success"])
+            browse_paths = [item["path"] for item in browse["data"]["documents"]]
+            self.assertEqual(len(browse_paths), 2)
+            self.assertEqual(len(set(browse_paths)), 2)
 
     def test_scope_paths_reject_duplicate_and_unknown_metadata_fields(self):
         from pageindex.filesystem import PIFSCommandExecutor, PageIndexFileSystem
@@ -235,13 +382,18 @@ class PIFSScopePathTest(unittest.TestCase):
             self.assertEqual(sec_node["path"], "/documents/sec/@year/2024")
             self.assertEqual(sec_node["file_count"], 1)
 
-            stat = _payload(executor.execute("stat /documents/sec/@year/2024"))
+            scope_stat = _payload(executor.execute("stat /documents/sec/@year/2024"))
+            self.assertFalse(scope_stat["success"])
+            self.assertIn("scope, not a file locator", scope_stat["error"]["message"])
+
+            scoped_tree = _payload(executor.execute("tree /documents/sec/@year/2024"))
+            self.assertTrue(scoped_tree["success"])
+            locator = scoped_tree["data"]["tree"]["files"][0]["path"]
+            self.assertEqual(locator, "/documents/sec/@year/2024/sec-2024.md")
+
+            stat = _payload(executor.execute(f"stat {locator}"))
             self.assertTrue(stat["success"])
-            self.assertEqual(
-                stat["data"]["scope"]["metadata_filter"],
-                {"year": "2024"},
-            )
-            self.assertEqual(stat["data"]["scope"]["file_count"], 1)
+            self.assertEqual(stat["data"]["document"]["path"], locator)
 
     def test_core_browse_semantic_files_accepts_metadata_scoped_path(self):
         from pageindex.filesystem import PageIndexFileSystem
@@ -376,11 +528,11 @@ class PIFSScopePathTest(unittest.TestCase):
             self.assertTrue(year["success"])
             self.assertEqual(
                 [item["path"] for item in vendor["data"]["documents"]],
-                ["/documents/contracts/apple-renewal.md"],
+                ["/documents/@vendor/Apple/apple-renewal.md"],
             )
             self.assertEqual(
                 [item["path"] for item in year["data"]["documents"]],
-                ["/documents/contracts/apple-renewal.md"],
+                ["/documents/@year/2024/apple-renewal.md"],
             )
             self.assertEqual(
                 vendor["data"]["scope"]["metadata_filter"],


### PR DESCRIPTION
## Summary

实现 PIFS scope-qualified file locator contract：`tree` / `browse` 返回的 metadata scope 文件路径可以直接用于 `stat`、`cat`、`grep`。

## Goal

修复 agent 在 `/@field/value` metadata scope 中找到正确文件集合后，无法继续读取具体文件的问题。文件发现仍由 `tree` / `browse` 负责，文件 inspection 命令不做 discovery。

## What Changed

- `tree` 对普通 folder scope 返回直接 file leaves，对 metadata value scope 返回匹配 file leaves。
- `browse` 在 metadata scope 下返回 navigation-local locator，例如 `/docs/@company/3M/report.pdf`。
- `stat`、`cat`、`grep` 共享 scope-qualified locator resolver。
- scope-only file command target 会失败并提示使用 `tree <scope>` 或 `browse <scope> "<query>"` 选择 file leaf。
- `tree -L` 只控制 depth，不绕过 child pagination。
- 相同 visible leaf 的 scope 结果会返回消歧 locator。
- 新增/更新 PIFS durable docs。

## Command Surface

- `tree <scope> [-L depth] [--page N]`: folder / file / metadata scope discovery。
- `browse <scope> "<query>"`: relevance-ranked file discovery。
- `stat <file>`: single-file identity。
- `cat <file> --structure|--page N[-M]`: single-file reads。
- `grep <query> <file>`: single-file lexical fallback。

## Key Files

- `pageindex/filesystem/core.py`: shared scope file listing and locator resolver。
- `pageindex/filesystem/commands.py`: `tree` file leaves, scoped browse paths, file-only `stat`。
- `tests/test_pifs_scope_paths.py`: round-trip, scope-only error, pagination, duplicate leaf coverage。
- `CONTEXT.md`: PIFS locator vocabulary。
- `docs/pifs-core-alignment/SPEC.md`: command contract。
- `docs/pifs-core-alignment/ADR-0001-scope-qualified-file-locators.md`: accepted locator decision。

## Verification

- [x] `uv run python -m unittest -v tests.test_pifs_scope_paths tests.test_pifs_core_alignment`
- [x] `uv run python -m py_compile pageindex/filesystem/core.py pageindex/filesystem/commands.py tests/test_pifs_scope_paths.py`
- [x] `git diff --check`

Note: `uv run pytest -q tests/test_pifs_path_resolution.py` could not run in this environment because `pytest` is not installed.
