### PR TITLE
ci: publish to PyPI on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,9 @@ jobs:
       id-token: write   # OIDC trusted publishing to PyPI
       contents: write   # create the GitHub Release
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
         with:
           python-version: "3.12"
 
@@ -55,7 +55,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1.14.0
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish to PyPI
+
+# Release flow (the git tag IS the version — nothing to bump in the repo):
+#   1. git tag -a v0.3.0.dev2 -m "Release 0.3.0.dev2"
+#   2. git push origin v0.3.0.dev2
+#   3. This workflow derives the version from the tag, injects it into
+#      pyproject.toml, builds, publishes to PyPI via OIDC trusted publishing
+#      (no stored secret), and creates a GitHub Release with generated notes.
+#
+# The tag must be a PEP 440 version with a leading `v`:
+#   v0.3.0   v0.3.0rc1   v0.3.0.dev2
+# PyPI rejects duplicate version uploads, so each tag must be a new version.
+# `pip install pageindex` skips dev/pre releases — install one with
+# `pip install pageindex==0.3.0.dev2` or `pip install --pre pageindex`.
+#
+# One-time setup this workflow depends on:
+#   - PyPI: add a Trusted Publisher on the `pageindex` project pointing at
+#     repo VectifyAI/PageIndex, workflow `publish.yml`, environment `pypi`.
+#   - GitHub: create an Environment named `pypi` (Settings -> Environments).
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC trusted publishing to PyPI
+      contents: write   # create the GitHub Release
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+
+      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3  # v5.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Set version from tag and build
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade build packaging
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Publishing version: $VERSION"
+          # Fail early on a malformed tag instead of publishing a junk version.
+          python -c "from packaging.version import Version; Version('$VERSION')"
+          # The git tag is the single source of truth; overwrite the static
+          # placeholder in [tool.poetry] so the built artifacts carry $VERSION.
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          grep '^version = ' pyproject.toml
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1.14.0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
Adds a tag-triggered PyPI release workflow, modeled on the OpenKnowledgeBase publish flow.

## What it does
Pushing a PEP 440 tag with a leading `v` (`v0.3.0.dev2`, `v0.3.0`, `v0.3.0rc1`, …) triggers `.github/workflows/publish.yml`, which:
1. derives the version from the tag and injects it into `pyproject.toml`;
2. builds sdist + wheel;
3. publishes to PyPI via **OIDC trusted publishing** (no stored token/secret);
4. creates a GitHub Release with auto-generated notes.

## Design note
OKB uses hatchling + hatch-vcs (version derived from the tag by the build backend). PageIndex stays on `poetry-core` and injects the version **in CI** instead — so the build backend is unchanged and contributors' local `poetry`/`pip install -e .` builds are unaffected (no new versioning plugin to install). The git tag is still the single source of truth for released versions. Action refs are pinned to commit SHAs.

## ⚠️ One-time setup required before the first tag
This workflow will fail until both are done:
1. **PyPI** → `pageindex` project → Settings → Publishing → add a **Trusted Publisher**:
   - Owner/repo: `VectifyAI/PageIndex`
   - Workflow filename: `publish.yml`
   - Environment: `pypi`
2. **GitHub** → repo Settings → Environments → create an environment named **`pypi`** (optionally add reviewers/branch protection).

## How to release after setup
```bash
git tag -a v0.3.0.dev2 -m "Release 0.3.0.dev2"
git push origin v0.3.0.dev2
```
`pip install pageindex` skips dev/pre releases; install with `pip install pageindex==0.3.0.dev2` or `--pre`.

Note: PyPI already has `0.3.0.dev0` and `0.3.0.dev1`, so the next dev snapshot must be `v0.3.0.dev2` (PyPI rejects duplicate versions).

https://claude.ai/code/session_01Kx5DgKbhK1N8autqXH8SmS