### PR TITLE
ci: publish to PyPI on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: Publish to PyPI
+
+# Release flow (the git tag IS the version — nothing to bump in the repo):
+#   1. git tag -a v0.3.0.dev2 -m "Release 0.3.0.dev2"
+#   2. git push origin v0.3.0.dev2
+#   3. This workflow derives the version from the tag, injects it into
+#      pyproject.toml, builds, publishes to PyPI via OIDC trusted publishing
+#      (no stored secret), and creates a GitHub Release with generated notes.
+#
+# The tag must be a PEP 440 version with a leading `v`:
+#   v0.3.0   v0.3.0rc1   v0.3.0.dev2
+# PyPI rejects duplicate version uploads, so each tag must be a new version.
+# `pip install pageindex` skips dev/pre releases — install one with
+# `pip install pageindex==0.3.0.dev2` or `pip install --pre pageindex`.
+#
+# One-time setup this workflow depends on:
+#   - PyPI: add a Trusted Publisher on the `pageindex` project pointing at
+#     repo VectifyAI/PageIndex, workflow `publish.yml`, environment `pypi`.
+#   - GitHub: create an Environment named `pypi` (Settings -> Environments).
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # OIDC trusted publishing to PyPI
+      contents: write   # create the GitHub Release
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Set version from tag and build
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade build packaging
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Publishing version: $VERSION"
+          # Fail early on a malformed tag instead of publishing a junk version.
+          python -c "from packaging.version import Version; Version('$VERSION')"
+          # The git tag is the single source of truth; overwrite the static
+          # placeholder in [tool.poetry] so the built artifacts carry $VERSION.
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          grep '^version = ' pyproject.toml
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1.14.0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: dist/*


### PR DESCRIPTION
Adds a tag-triggered PyPI release workflow directly on `main`, so the stable branch owns the release infrastructure independently of `dev`.

## What it does
Pushing a PEP 440 tag with a leading `v` (`v0.3.0`, `v0.3.0rc1`, `v0.3.0.dev2`, …) triggers `.github/workflows/publish.yml`, which:
1. derives the version from the tag and injects it into `pyproject.toml`;
2. builds sdist + wheel;
3. publishes to PyPI via **OIDC trusted publishing** (no stored token/secret);
4. creates a GitHub Release with auto-generated notes.


## Scope
Single file: `.github/workflows/publish.yml`. No code changes.


Supersedes the dev-based #347 (same workflow, targeted at `main` instead).