### PR TITLE
fix: handle pathlib.Path in get_pdf_name to avoid UnboundLocalError

### DIFF
--- a/pageindex/index/utils.py
+++ b/pageindex/index/utils.py
@@ -741,13 +741,15 @@ def sanitize_filename(filename, replacement='-'):
 
 def get_pdf_name(pdf_path):
     # Extract PDF name
-    if isinstance(pdf_path, str):
+    if isinstance(pdf_path, (str, Path)):
         pdf_name = os.path.basename(pdf_path)
     elif isinstance(pdf_path, BytesIO):
         pdf_reader = PyPDF2.PdfReader(pdf_path)
         meta = pdf_reader.metadata
         pdf_name = meta.title if meta and meta.title else 'Untitled'
         pdf_name = sanitize_filename(pdf_name)
+    else:
+        pdf_name = 'Untitled'
     return pdf_name
 
 

--- a/tests/test_get_pdf_name.py
+++ b/tests/test_get_pdf_name.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from pageindex.index.utils import get_pdf_name
+
+
+def test_get_pdf_name_str():
+    assert get_pdf_name("/some/path/document.pdf") == "document.pdf"
+
+
+def test_get_pdf_name_pathlib_path():
+    # Previously raised UnboundLocalError — Path is neither str nor BytesIO
+    assert get_pdf_name(Path("/some/path/document.pdf")) == "document.pdf"
+
+
+def test_get_pdf_name_pathlib_relative():
+    assert get_pdf_name(Path("reports/annual.pdf")) == "annual.pdf"
+
+
+def test_get_pdf_name_unknown_type_returns_untitled():
+    # Any unrecognised type should not crash — returns a safe fallback
+    assert get_pdf_name(12345) == "Untitled"


### PR DESCRIPTION
## Summary

`get_pdf_name()` in `pageindex/index/utils.py` only handled `str` and `BytesIO` inputs. Passing a `pathlib.Path` — which is idiomatic Python and already imported in the same file — left `pdf_name` unbound and raised `UnboundLocalError` at the `return` statement, crashing `JsonLogger.__init__` before any indexing begins.

## Root cause

```python
# before
def get_pdf_name(pdf_path):
    if isinstance(pdf_path, str):
        pdf_name = os.path.basename(pdf_path)
    elif isinstance(pdf_path, BytesIO):
        ...
    return pdf_name  # UnboundLocalError if pdf_path is a Path or anything else
```

## Fix

```python
# after
def get_pdf_name(pdf_path):
    if isinstance(pdf_path, (str, Path)):   # Path already imported at top of file
        pdf_name = os.path.basename(pdf_path)  # os.path.basename handles Path natively
    elif isinstance(pdf_path, BytesIO):
        ...
    else:
        pdf_name = 'Untitled'   # safe fallback for any unexpected type
    return pdf_name
```

`os.path.basename` handles `pathlib.Path` natively (Python 3.6+), so no extra conversion is needed.

## Tests added (`tests/test_get_pdf_name.py`)

| Test | Trigger |
|------|---------|
| `test_get_pdf_name_str` | existing str path still works |
| `test_get_pdf_name_pathlib_path` | previously raised `UnboundLocalError` |
| `test_get_pdf_name_pathlib_relative` | relative `Path` also works |
| `test_get_pdf_name_unknown_type_returns_untitled` | any other type returns safe fallback |

```
tests/test_get_pdf_name.py::test_get_pdf_name_str                    PASSED
tests/test_get_pdf_name.py::test_get_pdf_name_pathlib_path           PASSED
tests/test_get_pdf_name.py::test_get_pdf_name_pathlib_relative       PASSED
tests/test_get_pdf_name.py::test_get_pdf_name_unknown_type_returns_untitled PASSED
```