### PR TITLE
fix: handle missing nodes key in get_leaf_nodes

### DIFF
--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -173,7 +173,7 @@ def structure_to_list(structure):
     
 def get_leaf_nodes(structure):
     if isinstance(structure, dict):
-        if not structure['nodes']:
+        if not structure.get('nodes'):
             structure_node = copy.deepcopy(structure)
             structure_node.pop('nodes', None)
             return [structure_node]

--- a/tests/test_issue_330.py
+++ b/tests/test_issue_330.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pageindex.utils import get_leaf_nodes, list_to_tree
+
+
+class TestIssue330GetLeafNodes:
+    def test_leaf_node_without_nodes_key(self):
+        leaf = {"title": "Section", "start_index": 1, "end_index": 1}
+        result = get_leaf_nodes(leaf)
+        assert len(result) == 1
+        assert result[0]["title"] == "Section"
+        assert "nodes" not in result[0]
+
+    def test_tree_from_list_to_tree(self):
+        flat = [
+            {"structure": "1", "title": "Root", "start_index": 1, "end_index": 2},
+            {"structure": "1.1", "title": "Child", "start_index": 2, "end_index": 2},
+        ]
+        tree = list_to_tree(flat)
+        leaves = get_leaf_nodes(tree)
+        titles = {node["title"] for node in leaves}
+        assert titles == {"Child"}


### PR DESCRIPTION
Fixes #330

## Problem

`get_leaf_nodes()` crashes with `KeyError: 'nodes'` when traversing trees built by `list_to_tree()`.

`list_to_tree()` runs `clean_node()` on every node. For nodes with no children, `clean_node()` **deletes** the `nodes` key entirely (`del node['nodes']`), rather than leaving it as an empty list. Later, `get_leaf_nodes()` checks leaf status via `structure['nodes']`, which raises `KeyError` on those nodes.

## Fix

Use `.get('nodes')` instead of direct key access:

```python
if not structure.get('nodes'):
```

When the key is absent, `.get('nodes')` returns `None` (falsy), so the node is correctly treated as a leaf. This matches how other helpers in the same file already access `nodes` (e.g. `format_structure`, `is_leaf_node`).

## Tests

Added `tests/test_issue_330.py`:

- leaf dict without a `nodes` key is returned as a leaf
- `list_to_tree()` → `get_leaf_nodes()` end-to-end traversal does not raise

`pytest tests/test_issue_330.py -v` — 2 passed locally.