### PR TITLE
Add SECURITY.md for private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+We welcome security reports for the latest commit on the `main` branch of this repository.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | ✅        |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report privately using one of these channels:
+
+1. **GitHub Private Vulnerability Reporting** — use [Security Advisories](https://github.com/VectifyAI/PageIndex/security/advisories/new) on this repository (preferred when available).
+2. **Contact form** — https://ii2abc2jejf.typeform.com/to/tK3AXl8T
+3. **Discord** — https://discord.com/invite/VuXuf29EUj (ask a maintainer for a private channel; do not post exploit details publicly)
+
+## What to include
+
+- A clear description of the vulnerability and its impact
+- Steps to reproduce (PoC if possible)
+- Affected component / file paths, if known
+- Suggested fix, if you have one
+
+## Response
+
+We aim to acknowledge reports within **7 days** and to share an initial assessment or next steps within **14 days**. Timelines may vary with severity and complexity.
+
+Please give us a reasonable window to investigate and fix before any public disclosure.


### PR DESCRIPTION
Gives researchers a clear private reporting path and expected response timeline, addressing the missing security policy.## Summary
- Add a `SECURITY.md` so researchers have a clear private reporting path
- Documents preferred channels and expected response timelines

Closes #240

## Test plan
- [ ] Confirm `SECURITY.md` appears on the repo root
- [ ] Confirm GitHub shows the Security Policy tab for the repo