### PR TITLE
docs: clarify cookbook Chat API uses PyPI cloud SDK

### DIFF
--- a/cookbook/agentic_retrieval.ipynb
+++ b/cookbook/agentic_retrieval.ipynb
@@ -69,7 +69,14 @@
         "id": "77SQbPoe-LTN"
       },
       "source": [
-        "### Install PageIndex SDK"
+        "### Install PageIndex SDK\n",
+        "\n",
+        "> **Important:** This notebook uses the **PageIndex Cloud SDK** from PyPI (`pip install pageindex`), which includes cloud methods like `submit_document` and `chat_completions`.\n",
+        ">\n",
+        "> That SDK is **not** the same as the local open-source `PageIndexClient` in this GitHub repo (which only supports local `index` / retrieval helpers). If you cloned this repository, importing `pageindex` from the repo can shadow the PyPI package and make `chat_completions` appear missing.\n",
+        ">\n",
+        "> - Cloud Chat API docs: https://docs.pageindex.ai/sdk\n",
+        "> - Self-hosted agentic RAG (no Chat API): [`examples/agentic_vectorless_rag_demo.py`](../examples/agentic_vectorless_rag_demo.py)"
       ]
     },
     {
@@ -104,7 +111,17 @@
         "\n",
         "# Get your PageIndex API key from https://dash.pageindex.ai/api-keys\n",
         "PAGEINDEX_API_KEY = \"YOUR_PAGEINDEX_API_KEY\"\n",
-        "pi_client = PageIndexClient(api_key=PAGEINDEX_API_KEY)"
+        "pi_client = PageIndexClient(api_key=PAGEINDEX_API_KEY)\n",
+        "\n",
+        "# Guard against accidentally importing the local open-source client from this repo\n",
+        "if not hasattr(pi_client, \"chat_completions\"):\n",
+        "    raise ImportError(\n",
+        "        \"This notebook requires the PageIndex Cloud SDK from PyPI \"\n",
+        "        \"(`pip install --upgrade pageindex`), which provides chat_completions. \"\n",
+        "        \"The local open-source PageIndexClient in this repository does not include \"\n",
+        "        \"the Chat API. See https://docs.pageindex.ai/sdk — or use \"\n",
+        "        \"examples/agentic_vectorless_rag_demo.py for self-hosted agentic RAG.\"\n",
+        "    )"
       ]
     },
     {

--- a/cookbook/pageIndex_chat_quickstart.ipynb
+++ b/cookbook/pageIndex_chat_quickstart.ipynb
@@ -63,7 +63,14 @@
         "id": "77SQbPoe-LTN"
       },
       "source": [
-        "### Install PageIndex SDK"
+        "### Install PageIndex SDK\n",
+        "\n",
+        "> **Important:** This notebook uses the **PageIndex Cloud SDK** from PyPI (`pip install pageindex`), which includes cloud methods like `submit_document` and `chat_completions`.\n",
+        ">\n",
+        "> That SDK is **not** the same as the local open-source `PageIndexClient` in this GitHub repo (which only supports local `index` / retrieval helpers). If you cloned this repository, importing `pageindex` from the repo can shadow the PyPI package and make `chat_completions` appear missing.\n",
+        ">\n",
+        "> - Cloud Chat API docs: https://docs.pageindex.ai/sdk\n",
+        "> - Self-hosted agentic RAG (no Chat API): [`examples/agentic_vectorless_rag_demo.py`](../examples/agentic_vectorless_rag_demo.py)"
       ]
     },
     {
@@ -98,7 +105,17 @@
         "\n",
         "# Get your PageIndex API key from https://dash.pageindex.ai/api-keys\n",
         "PAGEINDEX_API_KEY = \"Your API KEY\"\n",
-        "pi_client = PageIndexClient(api_key=PAGEINDEX_API_KEY)"
+        "pi_client = PageIndexClient(api_key=PAGEINDEX_API_KEY)\n",
+        "\n",
+        "# Guard against accidentally importing the local open-source client from this repo\n",
+        "if not hasattr(pi_client, \"chat_completions\"):\n",
+        "    raise ImportError(\n",
+        "        \"This notebook requires the PageIndex Cloud SDK from PyPI \"\n",
+        "        \"(`pip install --upgrade pageindex`), which provides chat_completions. \"\n",
+        "        \"The local open-source PageIndexClient in this repository does not include \"\n",
+        "        \"the Chat API. See https://docs.pageindex.ai/sdk — or use \"\n",
+        "        \"examples/agentic_vectorless_rag_demo.py for self-hosted agentic RAG.\"\n",
+        "    )"
       ]
     },
     {

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -27,10 +27,14 @@ def _normalize_retrieve_model(model: str) -> str:
 
 class PageIndexClient:
     """
-    A client for indexing and retrieving document content.
+    Local open-source client for indexing and retrieving document content.
     Flow: index() -> get_document() / get_document_structure() / get_page_content()
 
-    For agent-based QA, see examples/agentic_vectorless_rag_demo.py.
+    This client does not implement the cloud Chat API (`chat_completions`,
+    `submit_document`, etc.). Those methods belong to the PageIndex Cloud SDK
+    on PyPI (`pip install pageindex`); see https://docs.pageindex.ai/sdk.
+
+    For self-hosted agent-based QA, see examples/agentic_vectorless_rag_demo.py.
     """
     def __init__(self, api_key: str = None, model: str = None, retrieve_model: str = None, workspace: str = None):
         if api_key:


### PR DESCRIPTION
## Summary
- Clarify that `chat_completions` / `submit_document` come from the PageIndex Cloud SDK on PyPI, not this repo's local `PageIndexClient`
- Fail fast in cookbooks if the local package shadows the SDK
- Point to cloud docs and the self-hosted agentic demo

Closes #345

## Test plan
- [ ] Open both cookbooks and confirm the install note is visible
- [ ] Importing the local client without cloud SDK raises the new ImportError
- [ ] With `pip install pageindex` cloud SDK, setup cell passes the `hasattr` check