### PR TITLE
Add PageIndex Flash section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ python3 run_pageindex.py --md_path /path/to/your/document.md
 > Note: in this mode, we use "#" to determine node headings and their levels. For example, "##" is level 2, "###" is level 3, etc. Make sure your markdown file is formatted correctly. If your Markdown file was converted from a PDF or HTML, we don't recommend using this mode, since most existing conversion tools cannot preserve the original hierarchy. Instead, use our [PageIndex OCR](https://pageindex.ai/blog/ocr), which is designed to preserve it, to convert the PDF to a markdown file and then use this mode.
 </details>
 
+## ⚡ PageIndex Flash *(preview)*
+
+For ultra fast, **LLM-free** PageIndex tree structure generation from PDFs, see [`pageindex/flash`](https://github.com/VectifyAI/PageIndex/tree/feat/pageindex-flash/pageindex/flash).
+
 ## 🚀 Agentic Vectorless RAG: An Example
 
 For a simple, end-to-end **agentic vectorless RAG** example using **self-hosted PageIndex** (with OpenAI Agents SDK), see [`examples/agentic_vectorless_rag_demo.py`](examples/agentic_vectorless_rag_demo.py).


### PR DESCRIPTION
Adds a minimal section linking to `pageindex/flash` on the `feat/pageindex-flash` branch, placed before the Agentic Vectorless RAG example.

README-only change.