### PR TITLE
Add page-level thinning to PDF pipeline

### DIFF
--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -1246,8 +1246,9 @@ def page_index_main(doc, opt=None):
 
     async def page_index_builder():
         structure = await tree_parser(page_list, opt, doc=doc, logger=logger)
+        page_level_thinning(structure)
         if opt.if_add_node_id == 'yes':
-            write_node_id(structure)    
+            write_node_id(structure)
         if opt.if_add_node_text == 'yes':
             add_node_text(structure, page_list)
         if opt.if_add_node_summary == 'yes':

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -658,6 +658,39 @@ def format_structure(structure, order=None):
     return structure
 
 
+def page_level_thinning(structure, thinning_threshold_node_num=20, min_pages_for_large_tree=3):
+    def count_nodes(nodes):
+        total = 0
+        for node in nodes:
+            total += 1
+            if node.get('nodes'):
+                total += count_nodes(node['nodes'])
+        return total
+
+    def get_subtree_end(node):
+        while node.get('nodes'):
+            node = node['nodes'][-1]
+        return node.get('end_index', 0)
+
+    def thin(nodes, total_nodes):
+        for node in nodes:
+            children = node.get('nodes')
+            if not children:
+                continue
+            end_index = get_subtree_end(node)
+            page_count = end_index - node.get('start_index', 0) + 1
+            if page_count == 1 or (total_nodes > thinning_threshold_node_num and page_count < min_pages_for_large_tree):
+                node['end_index'] = end_index
+                node.pop('nodes', None)
+            else:
+                thin(children, total_nodes)
+
+    nodes = structure if isinstance(structure, list) else [structure]
+    total = count_nodes(nodes)
+    thin(nodes, total)
+    return structure
+
+
 class ConfigLoader:
     def __init__(self, default_path: str = None):
         if default_path is None:


### PR DESCRIPTION
## Summary
- Add `page_level_thinning` to the PDF pipeline, aligning with pageindex-compute's production behavior
- Sections spanning only 1 page have children removed; in large trees (>20 nodes), sections spanning <3 pages also have children removed
- Thinning runs after `tree_parser` and before `write_node_id` so node IDs are assigned to the thinned tree

## Test plan
- [ ] Verified function logic matches compute's `page_level_thinning`
- [ ] Edge cases tested: empty structure, single leaf, 1-page sections, deeply nested, large trees, end_index propagation
- [ ] No regression on existing structures (small docs like earthmover unchanged)