### PR TITLE
Add summary_model config

### DIFF
--- a/pageindex/config.yaml
+++ b/pageindex/config.yaml
@@ -1,5 +1,6 @@
 model: "gpt-4o-2024-11-20"
 # model: "anthropic/claude-sonnet-4-6"
+summary_model: "gpt-4.1-nano"
 retrieve_model: "gpt-5.4"  # defaults to `model` if not set
 toc_check_page_num: 20
 max_page_num_each_node: 10

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -1260,7 +1260,7 @@ def page_index_main(doc, opt=None):
             if opt.if_add_doc_description == 'yes':
                 # Create a clean structure without unnecessary fields for description generation
                 clean_structure = create_clean_structure_for_description(structure)
-                doc_description = generate_doc_description(clean_structure, model=opt.model)
+                doc_description = generate_doc_description(clean_structure, model=getattr(opt, 'summary_model', None) or opt.model)
                 structure = format_structure(structure, order=['title', 'node_id', 'start_index', 'end_index', 'summary', 'text', 'nodes'])
                 return {
                     'doc_name': get_pdf_name(doc),
@@ -1276,7 +1276,7 @@ def page_index_main(doc, opt=None):
     return asyncio.run(page_index_builder())
 
 
-def page_index(doc, model=None, toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
+def page_index(doc, model=None, summary_model=None, toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
                if_add_node_id=None, if_add_node_summary=None, if_add_doc_description=None, if_add_node_text=None):
     
     user_opt = {

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -1276,7 +1276,7 @@ def page_index_main(doc, opt=None):
     return asyncio.run(page_index_builder())
 
 
-def page_index(doc, model=None, summary_model=None, toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
+def page_index(doc, model=None, toc_check_page_num=None, max_page_num_each_node=None, max_token_num_each_node=None,
                if_add_node_id=None, if_add_node_summary=None, if_add_doc_description=None, if_add_node_text=None):
     
     user_opt = {

--- a/pageindex/page_index.py
+++ b/pageindex/page_index.py
@@ -1254,7 +1254,7 @@ def page_index_main(doc, opt=None):
         if opt.if_add_node_summary == 'yes':
             if opt.if_add_node_text == 'no':
                 add_node_text(structure, page_list)
-            await generate_summaries_for_structure(structure, model=opt.model)
+            await generate_summaries_for_structure(structure, model=getattr(opt, 'summary_model', None) or opt.model)
             if opt.if_add_node_text == 'no':
                 remove_structure_text(structure)
             if opt.if_add_doc_description == 'yes':


### PR DESCRIPTION
## Summary
- Add `summary_model` config parameter (default: `gpt-4.1-nano`) for node summary generation
- LLM pipeline uses `summary_model` instead of `model` for summaries, with fallback to `model` if not set

## Test plan
- [ ] Verify summary generation uses the configured model
- [ ] Verify fallback works when `summary_model` is not in config