### PR TITLE
Fail fast on rejected keys and unknown models

### DIFF
--- a/pageindex/tree_optimize.py
+++ b/pageindex/tree_optimize.py
@@ -61,8 +61,8 @@ import re
 import sys
 from types import SimpleNamespace
 
-from .utils import (ConfigLoader, _is_openai_model, llm_acompletion,
-                    strip_internal_keys)
+from .utils import (ConfigLoader, _is_openai_model, _is_unrecoverable,
+                    llm_acompletion, strip_internal_keys)
 
 TRIGGER_PAGES = 5        # only look ahead on nodes larger than this
 ROUTING_COST = 1         # R(v), in pages
@@ -679,6 +679,8 @@ async def expand(structure, pages, lines, args, log, frozen):
             try:
                 proposed = await propose_children(node, pages, args)
             except Exception as exc:
+                if _is_unrecoverable(exc):
+                    raise  # every remaining node would fail identically
                 log.append({"op": "expand", "node_id": node.get("node_id"),
                             "decision": "error", "attempt": attempts,
                             "detail": f"{type(exc).__name__}: {exc}"})

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -43,6 +43,17 @@ _openai_sync_client = None
 _openai_async_client = None
 
 
+# Misconfiguration: no retry can fix a rejected key or a model that does not
+# exist, and every later call fails the same way. Deliberately not 400, which
+# also carries context_length_exceeded, a per-prompt failure the caller absorbs
+# today. An unknown status is a transport failure and stays retryable.
+_UNRECOVERABLE_STATUS = frozenset({401, 403, 404})
+
+
+def _is_unrecoverable(exc: Exception) -> bool:
+    return getattr(exc, "status_code", None) in _UNRECOVERABLE_STATUS
+
+
 def llm_completion(model, prompt, chat_history=None, return_finish_reason=False):
     use_openai_sdk = _is_openai_model(model)
     if model:
@@ -76,6 +87,8 @@ def llm_completion(model, prompt, chat_history=None, return_finish_reason=False)
                 return content, finish_reason
             return content
         except Exception as e:
+            if _is_unrecoverable(e):
+                raise
             print('************* Retrying *************')
             logging.error(f"Error: {e}")
             if i < max_retries - 1:
@@ -116,6 +129,8 @@ async def llm_acompletion(model, prompt):
                 )
             return response.choices[0].message.content
         except Exception as e:
+            if _is_unrecoverable(e):
+                raise
             print('************* Retrying *************')
             logging.error(f"Error: {e}")
             if i < max_retries - 1:


### PR DESCRIPTION
`llm_completion` and `llm_acompletion` caught every exception the same way:
retry ten times a second apart, then return `""`. A rejected key or a model
name that does not exist fails identically on all ten, so a run with a bad key
took half a minute to produce a document of empty summaries and exit 0.

They now re-raise on 401, 403 and 404. Those are misconfiguration: every later
call fails the same way, and no caller can do anything useful with the empty
string. Everything else keeps the existing retry, including an unknown status,
which is a transport failure.

400 is deliberately not in the set. It also carries `context_length_exceeded`,
which is a per-prompt failure on one oversized node rather than a broken setup,
and callers absorb that today. Promoting it would turn one empty summary into a
failed run.

`tree_optimize.expand` caught the new exception and logged it per node, so the
same misconfiguration went quiet on the `--optimize` path. It re-raises too.

Measured with an invalid key: a default run now stops in 7s and `--optimize` in
2.4s, both naming the 401, where before both finished with empty summaries.