### PR TITLE
Add a Flash summary flag

### DIFF
--- a/pageindex/flash/README.md
+++ b/pageindex/flash/README.md
@@ -12,6 +12,8 @@ an LLM.
 from pageindex.flash import page_index_flash
 
 tree = page_index_flash("paper.pdf")
+tree = page_index_flash("paper.pdf", summary=False)   # tree structure only, no LLM
+tree = page_index_flash("paper.pdf", optimize=True)   # refined tree for retrieval
 ```
 
 Takes a file path or an `io.BytesIO` stream and returns the tree as a dict.
@@ -21,7 +23,8 @@ Summaries are on by default and need an LLM API key.
 
 ```bash
 python3 run_pageindex.py --pdf_path document.pdf --flash
-python3 run_pageindex.py --pdf_path document.pdf --flash --optimize  # refined tree for retrieval
+python3 run_pageindex.py --pdf_path document.pdf --flash --no-summary  # tree structure only, no LLM
+python3 run_pageindex.py --pdf_path document.pdf --flash --optimize    # refined tree for retrieval
 ```
 
 Writes the tree to `results/<name>_structure_flash.json`.

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -13,6 +13,8 @@ if __name__ == "__main__":
     parser.add_argument('--flash', action='store_true', help='Use PageIndex Flash (with --pdf_path)')
     parser.add_argument('--embedded-toc', action=argparse.BooleanOptionalAction, default=None,
                       help='Use the PDF\'s embedded bookmarks when trustworthy (default: on with --flash)')
+    parser.add_argument('--summary', action=argparse.BooleanOptionalAction, default=None,
+                      help='Generate node summaries with an LLM (default: on with --flash)')
     parser.add_argument('--optimize', nargs='?', const='full', choices=['full', 'merge'],
                       default=None,
                       help='Refine the tree for search cost: a deterministic merge, then an '
@@ -56,6 +58,8 @@ if __name__ == "__main__":
         raise ValueError("--optimize requires --flash with --pdf_path")
     if args.embedded_toc is not None and not (args.pdf_path and args.flash):
         raise ValueError("--embedded-toc requires --flash with --pdf_path")
+    if args.summary is not None and not (args.pdf_path and args.flash):
+        raise ValueError("--summary requires --flash with --pdf_path")
 
     if args.pdf_path:
         # Validate PDF file
@@ -79,6 +83,7 @@ if __name__ == "__main__":
                 optimize_model=args.model,
                 summary_model=args.summary_model or args.model,
                 use_embedded_toc=args.embedded_toc if args.embedded_toc is not None else True,
+                summary=args.summary if args.summary is not None else True,
             )
             if 'optimize' in toc_with_page_number:
                 o = toc_with_page_number['optimize']


### PR DESCRIPTION
Adds `--summary/--no-summary` to the Flash CLI path (default on), matching the `page_index_flash(summary=...)` parameter, and restores the usage examples in the Flash README.