### PR TITLE
fix: keep page text for bookmarked Flash summaries

### DIFF
--- a/pageindex/flash/main.py
+++ b/pageindex/flash/main.py
@@ -166,11 +166,16 @@ def extract_toc(
             doc_name = Path(str(doc_handle)).name
         else:
             doc_name = "document.pdf"
+        page_texts = [
+            "\n".join(block_text(block) for block in (page.secondary_slot or []))
+            for page in pages
+        ]
         result = {
             "doc_name": doc_name,
             "doc_title": None,
             "structure": [],
             "has_abstract_or_references_section": False,
+            "page_texts": page_texts,
         }
         # Bookmarks need no extracted text, so they can still structure a
         # document this gate wrote off as unreadable.
@@ -178,9 +183,7 @@ def extract_toc(
             from .embedded_toc import apply_embedded_toc
             result["structure"], result["toc_source"] = apply_embedded_toc(
                 [], doc_handle, len(pages),
-                page_texts=["\n".join(block_text(block)
-                                      for block in (page.secondary_slot or []))
-                            for page in pages],
+                page_texts=page_texts,
             )
         return result
 

--- a/tests/test_flash_api.py
+++ b/tests/test_flash_api.py
@@ -1,0 +1,33 @@
+from io import BytesIO
+
+import pymupdf
+
+from pageindex.flash import page_index_flash
+
+
+def _sparse_bookmarked_pdf():
+    doc = pymupdf.open()
+    for marker in ("x", "y", "z"):
+        page = doc.new_page()
+        page.insert_text((72, 72), marker)
+    doc.set_toc([
+        [1, "Introduction", 1],
+        [1, "Methods", 2],
+        [1, "Results", 3],
+    ])
+    data = doc.tobytes()
+    doc.close()
+    return BytesIO(data)
+
+
+def test_sparse_bookmarked_pdf_can_use_default_summaries():
+    result = page_index_flash(_sparse_bookmarked_pdf(), summary=True)
+
+    assert result["toc_source"] == "hybrid"
+    assert [node["title"] for node in result["structure"]] == [
+        "Introduction",
+        "Methods",
+        "Results",
+    ]
+    assert all(node.get("summary") for node in result["structure"])
+    assert "page_texts" not in result


### PR DESCRIPTION
## Summary

- Fixes: PageIndex Flash raises IndexError when a sparse PDF reaches the early outline gate, embedded bookmarks supply a non-empty tree, and summaries are enabled.
- Root cause: The early-return path passed extracted page text to bookmark merging but omitted it from the result, so the public API gave summarize_tree an empty page list for the bookmark-derived nodes.

## Regression evidence

- Before: `PYTHONPATH=. uv run --with-requirements requirements.txt --with pytest pytest -q -p no:cacheprovider tests/test_flash_api.py` exited `1`

- After: `PYTHONPATH=. uv run --with-requirements requirements.txt --with pytest pytest -q -p no:cacheprovider tests/test_flash_api.py` exited `0`

## Verification

- `PYTHONPATH=. uv run --with-requirements requirements.txt --with pytest pytest -q -p no:cacheprovider`
- `PYTHONPATH=. uv run --with-requirements requirements.txt python -m compileall pageindex tests`

## Scope

- 2 files changed, +39 / -3 lines

## Authorship

This fix was developed with AI assistance and was validated with the regression and project checks listed above.
