### PR TITLE
ci: run tests on every push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,41 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+        # "without" proves the package works with no agent framework
+        # installed; "with" covers the framework integration paths.
+        agent-frameworks: [without, with]
+    name: py${{ matrix.python-version }} (${{ matrix.agent-frameworks }} frameworks)
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      # requirements.txt works on every branch; the packaging metadata
+      # (pyproject) does not exist on all of them.
+      - run: pip install -r requirements.txt pytest
+      - if: matrix.agent-frameworks == 'with'
+        run: pip install openai-agents claude-agent-sdk
+      # python -m pytest puts the repo root on sys.path, so the in-repo
+      # `pageindex` package is imported without an install step.
+      - run: python -m pytest -q

--- a/tests/test_issue_163.py
+++ b/tests/test_issue_163.py
@@ -1,9 +1,15 @@
 import pytest
 import sys
 import os
+from importlib import import_module
 from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Patch attributes on the module object: the package exports a *function*
+# named page_index that shadows the submodule, and Python 3.10's mock
+# resolves the string "pageindex.page_index" to that function.
+page_index_module = import_module("pageindex.page_index")
 
 from pageindex.page_index import (
     check_if_toc_extraction_is_complete,
@@ -16,50 +22,50 @@ from pageindex.page_index import (
 
 
 class TestRobustKeyAccess:
-    @patch("pageindex.page_index.llm_completion", return_value="")
+    @patch.object(page_index_module, "llm_completion", return_value="")
     def test_toc_detector_empty_response(self, mock_llm):
         result = toc_detector_single_page("some content", model="test")
         assert result == "no"
 
-    @patch("pageindex.page_index.llm_completion", return_value='{"toc_detected": "yes"}')
+    @patch.object(page_index_module, "llm_completion", return_value='{"toc_detected": "yes"}')
     def test_toc_detector_valid_response(self, mock_llm):
         result = toc_detector_single_page("some content", model="test")
         assert result == "yes"
 
-    @patch("pageindex.page_index.llm_completion", return_value="not json at all")
+    @patch.object(page_index_module, "llm_completion", return_value="not json at all")
     def test_toc_detector_malformed_response(self, mock_llm):
         result = toc_detector_single_page("some content", model="test")
         assert result == "no"
 
-    @patch("pageindex.page_index.llm_completion", return_value="")
+    @patch.object(page_index_module, "llm_completion", return_value="")
     def test_extraction_complete_empty_response(self, mock_llm):
         result = check_if_toc_extraction_is_complete("doc", "toc", model="test")
         assert result == "no"
 
-    @patch("pageindex.page_index.llm_completion", return_value='{"completed": "yes"}')
+    @patch.object(page_index_module, "llm_completion", return_value='{"completed": "yes"}')
     def test_extraction_complete_valid_response(self, mock_llm):
         result = check_if_toc_extraction_is_complete("doc", "toc", model="test")
         assert result == "yes"
 
-    @patch("pageindex.page_index.llm_completion", return_value="")
+    @patch.object(page_index_module, "llm_completion", return_value="")
     def test_transformation_complete_empty_response(self, mock_llm):
         result = check_if_toc_transformation_is_complete("raw", "cleaned", model="test")
         assert result == "no"
 
-    @patch("pageindex.page_index.llm_completion", return_value='{"thinking": "looks fine", "completed": "yes"}')
+    @patch.object(page_index_module, "llm_completion", return_value='{"thinking": "looks fine", "completed": "yes"}')
     def test_transformation_complete_valid_response(self, mock_llm):
         result = check_if_toc_transformation_is_complete("raw", "cleaned", model="test")
         assert result == "yes"
 
-    @patch("pageindex.page_index.llm_completion", return_value="")
+    @patch.object(page_index_module, "llm_completion", return_value="")
     def test_detect_page_index_empty_response(self, mock_llm):
         result = detect_page_index("toc text", model="test")
         assert result == "no"
 
 
 class TestExtractTocContentRetryLoop:
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_completes_on_first_try(self, mock_llm, mock_check):
         mock_llm.return_value = ("full toc content", "finished")
         mock_check.return_value = "yes"
@@ -67,8 +73,8 @@ class TestExtractTocContentRetryLoop:
         assert result == "full toc content"
         assert mock_llm.call_count == 1
 
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_continues_on_incomplete(self, mock_llm, mock_check):
         mock_llm.side_effect = [
             ("partial toc", "max_output_reached"),
@@ -79,8 +85,8 @@ class TestExtractTocContentRetryLoop:
         assert result == "partial toc continued toc"
         assert mock_llm.call_count == 2
 
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_max_retries_raises_exception(self, mock_llm, mock_check):
         mock_llm.return_value = ("chunk", "max_output_reached")
         mock_check.return_value = "no"
@@ -88,8 +94,8 @@ class TestExtractTocContentRetryLoop:
             extract_toc_content("raw content", model="test")
         assert mock_llm.call_count == 6
 
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_chat_history_grows_incrementally(self, mock_llm, mock_check):
         call_count = [0]
 
@@ -114,8 +120,8 @@ class TestExtractTocContentRetryLoop:
 
 
 class TestTocTransformerRetryLoop:
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_completes_on_first_try(self, mock_llm, mock_check):
         mock_llm.return_value = (
             '{"table_of_contents": [{"structure": "1", "title": "Intro", "page": 1}]}',
@@ -126,8 +132,8 @@ class TestTocTransformerRetryLoop:
         assert len(result) == 1
         assert result[0]["title"] == "Intro"
 
-    @patch("pageindex.page_index.check_if_toc_transformation_is_complete")
-    @patch("pageindex.page_index.llm_completion")
+    @patch.object(page_index_module, "check_if_toc_transformation_is_complete")
+    @patch.object(page_index_module, "llm_completion")
     def test_handles_missing_table_of_contents_key(self, mock_llm, mock_check):
         mock_llm.return_value = ('{"other_key": "value"}', "finished")
         mock_check.return_value = "yes"

--- a/tests/test_page_index.py
+++ b/tests/test_page_index.py
@@ -1,5 +1,11 @@
 import unittest
+from importlib import import_module
 from unittest.mock import Mock, patch
+
+# Patch attributes on the module object: the package exports a *function*
+# named page_index that shadows the submodule, and Python 3.10's mock
+# resolves the string "pageindex.page_index" to that function.
+page_index_module = import_module("pageindex.page_index")
 
 from pageindex.page_index import (
     _secure_doc_text,
@@ -19,10 +25,10 @@ class ProcessTocNoPageNumbersTest(unittest.TestCase):
             {"structure": "1", "title": "First", "physical_index": "<physical_index_1>"},
         ]
 
-        with patch("pageindex.page_index.toc_transformer", return_value=toc), \
-             patch("pageindex.page_index.count_tokens", return_value=1), \
-             patch("pageindex.page_index.page_list_to_group_text", return_value=["<physical_index_1> <physical_index_2>"]), \
-             patch("pageindex.page_index.add_page_number_to_toc", return_value=reordered):
+        with patch.object(page_index_module, "toc_transformer", return_value=toc), \
+             patch.object(page_index_module, "count_tokens", return_value=1), \
+             patch.object(page_index_module, "page_list_to_group_text", return_value=["<physical_index_1> <physical_index_2>"]), \
+             patch.object(page_index_module, "add_page_number_to_toc", return_value=reordered):
             with self.assertRaises(ValueError):
                 process_toc_no_page_numbers(
                     "toc",
@@ -32,17 +38,17 @@ class ProcessTocNoPageNumbersTest(unittest.TestCase):
                 )
 
     def test_process_no_toc_validates_continuation_chunks(self):
-        with patch("pageindex.page_index.count_tokens", return_value=1), \
-             patch(
-                 "pageindex.page_index.page_list_to_group_text",
+        with patch.object(page_index_module, "count_tokens", return_value=1), \
+             patch.object(
+                 page_index_module, "page_list_to_group_text",
                  return_value=["<physical_index_1>", "<physical_index_2>"],
              ), \
-             patch(
-                 "pageindex.page_index.generate_toc_init",
+             patch.object(
+                 page_index_module, "generate_toc_init",
                  return_value=[{"title": "First", "physical_index": "<physical_index_1>"}],
              ), \
-             patch(
-                 "pageindex.page_index.generate_toc_continue",
+             patch.object(
+                 page_index_module, "generate_toc_continue",
                  return_value=[{"title": "Second", "physical_index": "<physical_index_99>"}],
              ):
             result = process_no_toc(


### PR DESCRIPTION
The repo currently has no CI that runs tests: `publish.yml` ships to PyPI on tag without a test step, and PRs get no checks.

This adds one workflow — **pytest on push (main), every PR, and manual dispatch** — over a 2×2 matrix:

| | without frameworks | with frameworks |
|---|---|---|
| **Python 3.10** (floor) | ✅ | ✅ |
| **Python 3.13** | ✅ | ✅ |

The *without frameworks* legs enforce the lazy-import contract (`import pageindex` and every feature must work with neither `openai-agents` nor `claude-agent-sdk` installed); the *with* legs cover the integration paths. Installs via `requirements.txt` and runs `python -m pytest`, so the workflow works on every branch — including branches that predate the packaging metadata. No secrets needed (the live-parity test skips itself without `PAGEINDEX_API_KEY`).

**Running this on real CI immediately caught a latent bug the matrix exists to catch**: the test suite did not pass on Python 3.10, the supported floor. `mock.patch("pageindex.page_index.…")` resolves through `getattr`, and the package's `from .page_index import *` makes the *function* `page_index` shadow the submodule — 3.11+ mock resolves via `pkgutil.resolve_name` (module wins), 3.10 gets the function and fails with `AttributeError`. Fixed by patching the module object (`patch.object(page_index_module, …)`) in `test_issue_163.py` and `test_page_index.py` — version-independent and immune to the shadowing. Neither open PR touches these files, so rebase-merges keep the fix.

All 4 matrix legs are green on this PR. Optional follow-up (not included): make `publish.yml` require this workflow before shipping.