### PR TITLE
feat: chat() front door and Claude cache marking on LiteLLM routes

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -405,7 +405,8 @@ class PageIndexClient:
         backend, so any OpenAI-compatible server works; a ``/`` in the
         model name means LiteLLM provider routing, so prefix ``openai/``
         when the backend itself serves slashed ids, e.g.
-        ``openai/Qwen/...`` on vLLM). The non-stream
+        ``openai/Qwen/...`` on vLLM; Anthropic-routed models get the
+        managed prompt prefix cache-marked automatically). The non-stream
         response carries the final answer only; streaming yields the
         agent's visible text as it is produced, including narration before
         tool calls. ``finish_reason`` reports loop completion ("stop") —

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import time
 import warnings
-from typing import Any, Callable, Iterator, Optional, Union
+from typing import Any, Callable, Iterator, Optional, Union, cast
 
 from .errors import PageIndexAPIError
 
@@ -345,7 +345,44 @@ class PageIndexClient:
             "favor of chat completions; use chat_completions instead."
         ).get_retrieval(retrieval_id=retrieval_id)
 
-    # ---------- CHAT COMPLETIONS ----------
+    # ---------- CHAT ----------
+
+    def chat(
+        self,
+        messages: Union[str, list[dict[str, str]]],
+        doc_id: Optional[Union[str, list[str]]] = None,
+        stream: bool = False,
+        model: Optional[str] = None,
+    ) -> Union[str, Iterator[str]]:
+        """
+        Ask a question about your documents, get the answer.
+
+        Thin sugar over ``chat_completions()`` in both modes — same
+        engine, same wire, minus the envelope. Multi-turn: keep your own
+        role/content list of the visible conversation (append each answer
+        as an assistant message) and pass it back. For usage accounting,
+        streaming metadata, or the tool-use process, use the protocol
+        surfaces: ``chat_completions()``, ``responses()``, ``messages()``.
+
+        Args:
+            messages: A question string, or role/content conversation
+                history.
+            doc_id: Document ID or list of IDs to scope the conversation.
+                Keep it identical across a conversation's calls.
+            stream: Yield the answer as text chunks as it is produced.
+            model: Local only — backend model name (defaults to
+                ``retrieve_model``).
+
+        Returns:
+            - stream=False: the answer string
+            - stream=True: iterator of text chunks
+        """
+        result = self.chat_completions(messages, stream=stream,
+                                       doc_id=doc_id, model=model)
+        if stream:
+            return cast(Iterator[str], result)
+        envelope = cast(dict[str, Any], result)
+        return envelope["choices"][0]["message"]["content"] or ""
 
     def chat_completions(
         self,

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -405,8 +405,9 @@ class PageIndexClient:
         backend, so any OpenAI-compatible server works; a ``/`` in the
         model name means LiteLLM provider routing, so prefix ``openai/``
         when the backend itself serves slashed ids, e.g.
-        ``openai/Qwen/...`` on vLLM; Anthropic-routed models get the
-        managed prompt prefix cache-marked automatically). The non-stream
+        ``openai/Qwen/...`` on vLLM; LiteLLM-routed Claude models —
+        Anthropic direct, Bedrock, Vertex — get the managed prompt
+        prefix cache-marked automatically). The non-stream
         response carries the final answer only; streaming yields the
         agent's visible text as it is produced, including narration before
         tool calls. ``finish_reason`` reports loop completion ("stop") —

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -419,7 +419,10 @@ class PageIndexClient:
             messages: Conversation messages with 'role' and 'content' keys,
                 or a bare query string (it becomes a single user message).
                 Local also accepts system/developer messages — their content
-                is appended to the managed system prompt.
+                is appended to the managed system prompt. Local takes text
+                history only: tool-role turns are rejected (the cloud
+                endpoint forwards them verbatim), and message fields beyond
+                role/content are dropped.
             stream: Enable streaming responses.
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls — the

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -206,7 +206,8 @@ def _require_openai_agents(method: str) -> None:
     except ImportError as exc:
         raise PageIndexAPIError(
             f"{method} in local mode requires the OpenAI Agents SDK — "
-            "pip install openai-agents (or pip install 'pageindex[openai]')."
+            "pip install openai-agents (or pip install 'pageindex[openai]'). "
+            "messages() runs on the anthropic extra instead."
         ) from exc
 
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -275,10 +275,18 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
     """Anthropic's prompt caching is opt-in per request: on
     anthropic-routed LiteLLM models, mark the managed system prefix via
     LiteLLM's injection param so the loop's later turns and a
-    conversation's next calls read it instead of repaying full price."""
-    wire = model_name.removeprefix("litellm/")
-    if ("/" in model_name and not model_name.startswith("openai/")
-            and wire.split("/", 1)[0] == "anthropic"):
+    conversation's next calls read it instead of repaying full price.
+    Provider resolution is LiteLLM's own, so this predicate can never
+    disagree with where the request actually routes."""
+    if "/" not in model_name or model_name.startswith("openai/"):
+        return None
+    try:
+        from litellm import get_llm_provider
+        _, provider, _, _ = get_llm_provider(
+            model=model_name.removeprefix("litellm/"))
+    except Exception:
+        return None
+    if provider == "anthropic":
         return {"cache_control_injection_points": [
             {"location": "message", "role": "system"}]}
     return None

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -759,7 +759,9 @@ _CLAUDE_4096_MODELS = ("claude-3-opus", "claude-3-sonnet", "claude-3-haiku",
 
 def _default_max_tokens(model: str) -> int:
     """The wire-required per-turn budget when the caller sets none: 8192,
-    except the claude-3 generation whose output ceiling is 4096."""
+    except the claude-3 generation whose output ceiling is 4096 — a
+    closed historical set (every later model supports >=8192), so the
+    table needs no new entries and no live capability source."""
     return 4096 if model.startswith(_CLAUDE_4096_MODELS) else 8192
 
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -272,21 +272,23 @@ def _reported_model(model_name: str) -> str:
 
 
 def _cache_extra_args(model_name: str) -> Optional[dict]:
-    """Anthropic's prompt caching is opt-in per request: on
-    anthropic-routed LiteLLM models, mark the managed system prefix via
-    LiteLLM's injection param so the loop's later turns and a
-    conversation's next calls read it instead of repaying full price.
-    Provider resolution is LiteLLM's own, so this predicate can never
-    disagree with where the request actually routes."""
+    """Claude's prompt caching is opt-in per request: on Claude models
+    routed through LiteLLM (Anthropic direct, Bedrock, Vertex — each
+    channel live-verified), mark the managed system prefix via LiteLLM's
+    injection param so the loop's later turns and a conversation's next
+    calls read it instead of repaying full price. Provider resolution is
+    LiteLLM's own, so this predicate can never disagree with where the
+    request actually routes."""
     if "/" not in model_name or model_name.startswith("openai/"):
         return None
     try:
         from litellm import get_llm_provider
-        _, provider, _, _ = get_llm_provider(
+        model, provider, _, _ = get_llm_provider(
             model=model_name.removeprefix("litellm/"))
     except Exception:
         return None
-    if provider == "anthropic":
+    if provider == "anthropic" or (provider in ("bedrock", "vertex_ai")
+                                   and "claude" in model.lower()):
         return {"cache_control_injection_points": [
             {"location": "message", "role": "system"}]}
     return None

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -271,6 +271,19 @@ def _reported_model(model_name: str) -> str:
     return model_name.removeprefix("litellm/").removeprefix("openai/")
 
 
+def _cache_extra_args(model_name: str) -> Optional[dict]:
+    """Anthropic's prompt caching is opt-in per request: on
+    anthropic-routed LiteLLM models, mark the managed system prefix via
+    LiteLLM's injection param so the loop's later turns and a
+    conversation's next calls read it instead of repaying full price."""
+    wire = model_name.removeprefix("litellm/")
+    if ("/" in model_name and not model_name.startswith("openai/")
+            and wire.split("/", 1)[0] == "anthropic"):
+        return {"cache_control_injection_points": [
+            {"location": "message", "role": "system"}]}
+    return None
+
+
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
                   temperature, top_p, doc_ids=None):
     from agents import Agent, ModelSettings
@@ -280,7 +293,8 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
         instructions=instructions,
         tools=build_openai_tools(client, doc_ids=doc_ids),
         model=_openai_model(protocol, model_name),
-        model_settings=ModelSettings(temperature=temperature, top_p=top_p),
+        model_settings=ModelSettings(temperature=temperature, top_p=top_p,
+                                     extra_args=_cache_extra_args(model_name)),
     )
 
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -759,9 +759,7 @@ _CLAUDE_4096_MODELS = ("claude-3-opus", "claude-3-sonnet", "claude-3-haiku",
 
 def _default_max_tokens(model: str) -> int:
     """The wire-required per-turn budget when the caller sets none: 8192,
-    except the claude-3 generation whose output ceiling is 4096 — a
-    closed historical set (every later model supports >=8192), so the
-    table needs no new entries and no live capability source."""
+    except the claude-3 generation whose output ceiling is 4096."""
     return 4096 if model.startswith(_CLAUDE_4096_MODELS) else 8192
 
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -299,6 +299,64 @@ def test_anthropic_routed_models_mark_managed_prefix_for_cache(
         assert agent.model_settings.extra_args is None
 
 
+@needs_agents
+def test_status_recorder_attaches_to_the_real_responses_model(monkeypatch):
+    # Guards the private-attribute chain the recorder rides
+    # (agent.model._client.responses.create): a vendor rename turns the
+    # recorder into a silent no-op and truncation reports as completion.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    import openai
+    from agents.models.openai_responses import OpenAIResponsesModel
+    backend = openai.AsyncOpenAI()
+    model = OpenAIResponsesModel("gpt-test", openai_client=backend)
+    original = backend.responses.create
+    local_chat._record_response_status(types.SimpleNamespace(model=model), {})
+    assert backend.responses.create is not original
+    asyncio.run(backend.close())
+
+
+@needs_agents
+def test_cache_marker_reaches_the_anthropic_wire(client, store_path,
+                                                 monkeypatch):
+    # End-to-end guard for the injection flag: through the real
+    # LitellmModel and litellm's request build, the marker must appear in
+    # the HTTP body — a regression in either vendor hop silently reverts
+    # anthropic-routed calls to full price.
+    pytest.importorskip("litellm")
+    from litellm.llms.custom_httpx.http_handler import (AsyncHTTPHandler,
+                                                        HTTPHandler)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    captured = {}
+    reply = {"id": "msg_01", "type": "message", "role": "assistant",
+             "model": "claude-3-5-sonnet-20240620",
+             "content": [{"type": "text", "text": "ok"}],
+             "stop_reason": "end_turn", "stop_sequence": None,
+             "usage": {"input_tokens": 10, "output_tokens": 2}}
+
+    def _capture(url, kwargs):
+        body = kwargs.get("json")
+        if body is None and kwargs.get("data") is not None:
+            body = json.loads(kwargs["data"])
+        captured["url"] = str(url)
+        captured["body"] = body
+        return httpx.Response(200, json=reply,
+                              request=httpx.Request("POST", str(url)))
+
+    async def fake_apost(self, url=None, *args, **kwargs):
+        return _capture(url, kwargs)
+
+    def fake_post(self, url=None, *args, **kwargs):
+        return _capture(url, kwargs)
+
+    monkeypatch.setattr(AsyncHTTPHandler, "post", fake_apost)
+    monkeypatch.setattr(HTTPHandler, "post", fake_post)
+    result = client.chat_completions(
+        "hi", model="anthropic/claude-3-5-sonnet-20240620")
+    assert "/v1/messages" in captured["url"]
+    assert '"cache_control"' in json.dumps(captured["body"])
+    assert result["choices"][0]["message"]["content"] == "ok"
+
+
 # ── chat (front door) ──
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -290,7 +290,9 @@ def test_anthropic_routed_models_mark_managed_prefix_for_cache(
     for name in ("anthropic/claude-x", "litellm/anthropic/claude-x"):
         agent = _openai_agent(client, "chat", name, "sys", None, None)
         assert agent.model_settings.extra_args == marked
-    for name in ("gpt-5", "openai/Qwen/x", "litellm/groq/x"):
+    # bedrock/vertex Claude stay unmarked until verified live
+    for name in ("gpt-5", "openai/Qwen/x", "litellm/groq/x",
+                 "bedrock/anthropic.claude-v1", "vertex_ai/claude-x"):
         agent = _openai_agent(client, "chat", name, "sys", None, None)
         assert agent.model_settings.extra_args is None
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -280,6 +280,21 @@ def test_cloud_guards():
                        max_tokens=10)
 
 
+@needs_agents
+def test_anthropic_routed_models_mark_managed_prefix_for_cache(
+        client, store_path, fake_model):
+    fake_model([[_msg_item("ok")]])
+    from pageindex.local_chat import _openai_agent
+    marked = {"cache_control_injection_points": [
+        {"location": "message", "role": "system"}]}
+    for name in ("anthropic/claude-x", "litellm/anthropic/claude-x"):
+        agent = _openai_agent(client, "chat", name, "sys", None, None)
+        assert agent.model_settings.extra_args == marked
+    for name in ("gpt-5", "openai/Qwen/x", "litellm/groq/x"):
+        agent = _openai_agent(client, "chat", name, "sys", None, None)
+        assert agent.model_settings.extra_args is None
+
+
 # ── chat (front door) ──
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -280,6 +280,50 @@ def test_cloud_guards():
                        max_tokens=10)
 
 
+# ── chat (front door) ──
+
+@needs_agents
+def test_chat_returns_answer_string(client, store_path, fake_model):
+    doc_id = seed_doc(store_path, "pi-a", "report.pdf")
+    fake = fake_model([
+        [_call_item("get_document", {"doc_name": "report.pdf"})],
+        [_msg_item("The answer")],
+    ])
+    assert client.chat("What status?", doc_id=doc_id) == "The answer"
+    first_item = fake.inputs[0][0]
+    assert "The user has specified document: report.pdf" in first_item["content"]
+
+
+@needs_agents
+def test_chat_stream_yields_text_chunks(client, store_path, fake_model):
+    fake_model([[_msg_item("The answer")]])
+    assert list(client.chat("q", stream=True)) == ["The ", "answer"]
+
+
+@needs_agents
+def test_chat_multi_turn_history(client, store_path, fake_model):
+    fake = fake_model([[_msg_item("Chapter 4 covers pears")]])
+    history = [
+        {"role": "user", "content": "What about chapter 3?"},
+        {"role": "assistant", "content": "Chapter 3 covers apples"},
+        {"role": "user", "content": "And chapter 4?"},
+    ]
+    assert client.chat(history) == "Chapter 4 covers pears"
+    assert fake.inputs[0][-3:] == history
+
+
+def test_chat_cloud_unwraps_envelope(monkeypatch):
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+
+    def fake_cc(**kwargs):
+        assert kwargs["messages"] == [{"role": "user", "content": "q"}]
+        return {"choices": [{"message": {"role": "assistant",
+                                        "content": "cloud answer"}}]}
+
+    monkeypatch.setattr(cloud._api, "chat_completions", fake_cc)
+    assert cloud.chat("q") == "cloud answer"
+
+
 # ── responses ──
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -287,12 +287,14 @@ def test_anthropic_routed_models_mark_managed_prefix_for_cache(
     from pageindex.local_chat import _openai_agent
     marked = {"cache_control_injection_points": [
         {"location": "message", "role": "system"}]}
-    for name in ("anthropic/claude-x", "litellm/anthropic/claude-x"):
+    for name in ("anthropic/claude-x", "litellm/anthropic/claude-x",
+                 "bedrock/us.anthropic.claude-sonnet-5",
+                 "vertex_ai/claude-sonnet-4-5"):
         agent = _openai_agent(client, "chat", name, "sys", None, None)
         assert agent.model_settings.extra_args == marked
-    # bedrock/vertex Claude stay unmarked until verified live
     for name in ("gpt-5", "openai/Qwen/x", "litellm/groq/x",
-                 "bedrock/anthropic.claude-v1", "vertex_ai/claude-x"):
+                 "bedrock/meta.llama3-70b-instruct-v1:0",
+                 "vertex_ai/gemini-2.5-pro"):
         agent = _openai_agent(client, "chat", name, "sys", None, None)
         assert agent.model_settings.extra_args is None
 


### PR DESCRIPTION
Ports the eight pending commits from `feat/local-chat` (the v0.2.10 line) to `main`, following the #402/#404 pattern. After this merge, `git diff main feat/local-chat` is empty — main and the 0.2.10 branch are content-identical again (verified on the branch before opening this PR).

## `client.chat()` — the answer-out front door

`chat(messages, doc_id=None, stream=False, model=None)` returns the answer string (a text-chunk iterator when streaming). It is thin sugar over `chat_completions()` in both modes — same wire, envelope unwrapped, nothing rewritten. Multi-turn is the caller-maintained `role`/`content` list; a bare query string works as the minimal call. This is the only format-unpinned contract: `chat_completions()` / `responses()` / `messages()` stay the protocol doors for callers who need the envelope or the process.

## Managed-prefix cache marking on LiteLLM-routed Claude models

Claude prompt caching is opt-in per request (unlike OpenAI's automatic caching), so without a marker every managed turn re-pays full input price. `chat_completions()` now cache-marks the managed prompt prefix automatically on Claude models routed through LiteLLM — Anthropic direct, Bedrock Claude, Vertex Claude — via two documented parameter surfaces end to end: `ModelSettings.extra_args` → LiteLLM's `cache_control_injection_points`. No subclassing, no hooks, no content rewriting; user messages and the response envelope are untouched. Provider resolution asks LiteLLM's own `get_llm_provider` instead of hand-parsed prefixes.

Enablement doctrine: a wrong marker costs users a silent 1.25× cache-write premium, so each channel was live-verified write→read before being opened — Anthropic full-stack per-turn reads, Bedrock `us.anthropic.claude-sonnet-5` (w7264→r7264), Vertex `claude-sonnet-4-5` (w4842→r4842) — and non-Claude routes are pinned off by negative tests.

## Also in the port

Review remediation and docs: the missing-openai-agents error now points anthropic-extra users at `messages()`; two silent vendor chains gained guards (recorder attachment asserted against the real `OpenAIResponsesModel`, and a wire-level test asserting `cache_control` reaches the Anthropic HTTP body through `LitellmModel`); the local text-only history contract is stated on `chat_completions()` (cloud forwards tool turns, local rejects; extra message fields drop); the max-tokens docstring trimmed to the contract.

## Verification

276 tests green (3 skipped without the claude extra) on the ported branch. Cache marking was live-verified on all three Claude channels before landing on `feat/local-chat`, where #400 carries the full line for review.
