### PR TITLE
feat: openai-agents becomes a base dependency

### DIFF
--- a/examples/agentic_vectorless_rag_demo.py
+++ b/examples/agentic_vectorless_rag_demo.py
@@ -18,7 +18,7 @@ Steps:
   2 — View document metadata
   3 — Ask a question (agent reasons over the index and auto-calls tools)
 
-Requirements: pip install "pageindex[openai]"; OPENAI_API_KEY in the environment.
+Requirements: pip install pageindex; OPENAI_API_KEY in the environment.
 """
 import sys
 import asyncio

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -400,7 +400,7 @@ class PageIndexClient:
 
         Cloud: the hosted chat endpoint. Local: a managed document-QA agent
         run over the local tools against your own LLM backend's
-        /chat/completions (requires ``pageindex[openai]``; the OpenAI SDK's
+        /chat/completions (the OpenAI SDK's
         usual env config — OPENAI_API_KEY, OPENAI_BASE_URL — selects the
         backend, so any OpenAI-compatible server works; a ``/`` in the
         model name means LiteLLM provider routing, so prefix ``openai/``
@@ -492,7 +492,7 @@ class PageIndexClient:
         to keep provider prompt-cache prefix continuity and the agent's
         memory of what it already read.
 
-        Requires ``pageindex[openai]`` and a backend that supports the
+        Requires a backend that supports the
         Responses API; backends that only speak chat.completions should use
         ``chat_completions()``. Provider-prefixed models (``anthropic/…``)
         route through LiteLLM's chat.completions adapter and are therefore
@@ -694,8 +694,7 @@ class PageIndexClient:
         Local: the in-process tools, any model backend; ``hosted`` does
         not apply.
 
-        Requires ``openai-agents`` (``pip install 'pageindex[openai]'``),
-        imported only when this method is called.
+        ``openai-agents`` is imported only when this method is called.
 
         Args:
             include_management (bool): Also expose tools that modify the

--- a/pageindex/integrations/openai_agents.py
+++ b/pageindex/integrations/openai_agents.py
@@ -25,7 +25,7 @@ def build_openai_tools(client, include_management: bool = False,
     except ImportError as exc:
         raise PageIndexAPIError(
             "as_openai_tools requires the OpenAI Agents SDK — "
-            "pip install openai-agents (or pip install 'pageindex[openai]')."
+            "pip install openai-agents."
         ) from exc
     from ..agent_tools import (_dumps, _failure, _require_local_scope,
                                _tool_specs)

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -206,7 +206,7 @@ def _require_openai_agents(method: str) -> None:
     except ImportError as exc:
         raise PageIndexAPIError(
             f"{method} in local mode requires the OpenAI Agents SDK — "
-            "pip install openai-agents (or pip install 'pageindex[openai]'). "
+            "pip install openai-agents. "
             "messages() runs on the anthropic extra instead."
         ) from exc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ exclude = ["pageindex/flash/assets"]
 python = ">=3.10"
 requests = ">=2.28.0"
 openai = ">=1.70.0"
+# Older releases crash on current openai before the request is sent.
+openai-agents = ">=0.18.1"
 litellm = ">=1.84.0"
 PyPDF2 = ">=3.0.0"
 pypdfium2 = ">=4.30.0"
@@ -37,14 +39,13 @@ python-dotenv = ">=1.0.0"
 pyyaml = ">=6.0"
 # Older releases break string prompts with SDK MCP servers (#597, #780).
 claude-agent-sdk = { version = ">=0.1.53", optional = true }
-# Older releases crash on current openai before the request is sent.
-openai-agents = { version = ">=0.18.1", optional = true }
 # Older releases execute a refusal turn's tool_use blocks.
 anthropic = { version = ">=0.108.0", optional = true }
 
 [tool.poetry.extras]
 claude = ["claude-agent-sdk"]
-openai = ["openai-agents"]
+# Empty on purpose: keeps pip install "pageindex[openai]" valid.
+openai = []
 anthropic = ["anthropic"]
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 litellm==1.84.0
 openai>=1.70.0
 requests>=2.28.0
-# openai-agents  # optional
+openai-agents>=0.18.1
 # pymupdf  # optional
 PyPDF2==3.0.1
 pypdfium2==4.30.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -676,12 +676,12 @@ def test_retrieval_endpoints_cloud_only(local_client):
         local_client.get_retrieval("any")
 
 
-def test_chat_completions_local_needs_agents_extra(local_client, monkeypatch):
-    """Local chat is implemented (see test_local_chat.py); without the
-    openai-agents extra it raises the actionable install error."""
+def test_chat_completions_local_needs_openai_agents(local_client, monkeypatch):
+    """Local chat is implemented (see test_local_chat.py); without
+    openai-agents installed it raises the actionable install error."""
     import sys
     monkeypatch.setitem(sys.modules, "agents", None)
-    with pytest.raises(PageIndexAPIError, match="pageindex\\[openai\\]"):
+    with pytest.raises(PageIndexAPIError, match="pip install openai-agents"):
         local_client.chat_completions(
             messages=[{"role": "user", "content": "q"}])
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -263,7 +263,7 @@ def test_chat_completions_stream_modes(client, store_path, fake_model):
 
 def test_chat_completions_missing_framework(client, monkeypatch):
     monkeypatch.setitem(sys.modules, "agents", None)
-    with pytest.raises(PageIndexAPIError, match="pageindex\\[openai\\]"):
+    with pytest.raises(PageIndexAPIError, match="pip install openai-agents"):
         client.chat_completions([{"role": "user", "content": "x"}])
 
 


### PR DESCRIPTION
Ports the pending commit from `feat/local-chat` (the v0.2.10 line) to `main`, following the #402/#404/#405 pattern. After this merge, `git diff main feat/local-chat` is empty (verified on the branch before opening this PR).

## openai-agents becomes a base dependency

`chat()` is the SDK's front door, but its engine lived behind a vendor-named extra: `pip install pageindex` could index a document yet failed on the first chat call, and chatting with Claude required installing `[openai]`. The engine now ships with the SDK — `pip install pageindex` runs everything local (indexing, `chat()`, `chat_completions()`, `responses()`).

Measured before moving: the base tree already carries litellm (75 MB) + openai (13 MB); openai-agents adds ~15 MB (agents 8.1 + mcp 1.7 + griffe 1.4 + small pure-python deps). Current litellm's openai range (`>=2.20,<3`) intersects cleanly with openai-agents' (`>=2.45,<3`). The `>=0.18.1` floor is the live-probed minimum that works with current openai (f58cca1).

Extras now mean exactly one thing — a vendor's own SDK surface: `[anthropic]` for `messages()` / the tool runner, `[claude]` for the Claude Agent SDK. The `[openai]` extra stays declared but empty, so existing `pip install "pageindex[openai]"` commands keep resolving; error messages and docstrings drop the extra reference.

## Verification

276 tests green (3 skipped without the claude extra) on the ported branch; wheel metadata inspected — `Requires-Dist: openai-agents (>=0.18.1)` unconditional, `Provides-Extra: openai` retained. requirements.txt gains the dependency, so CI now runs the openai-agents test lane instead of skipping it. #400 carries the commit for review on `feat/local-chat`.
