### PR TITLE
docs: drop the demo's install step — openai-agents ships with the SDK now

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,6 @@ python3 run_pageindex.py --md_path /path/to/your/document.md
 For a simple, end-to-end **agentic vectorless RAG** example using **self-hosted PageIndex** (with OpenAI Agents SDK), see [`examples/agentic_vectorless_rag_demo.py`](examples/agentic_vectorless_rag_demo.py).
 
 ```bash
-# Install optional dependency
-pip3 install openai-agents
-
-# Run the demo
 python3 examples/agentic_vectorless_rag_demo.py
 ```
 


### PR DESCRIPTION
Ports the pending commit from `feat/local-chat` to `main` (the #402…#406 pattern; parity verified before opening). Completeness follow-up to #406: the README demo section still called openai-agents an optional dependency with a manual install step — it is a base dependency now, so the step is gone. After this merge, `git diff main feat/local-chat` is empty.