### PR TITLE
docs: clarify Markdown summary threshold

### DIFF
--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     parser.add_argument('--thinning-threshold', type=int, default=5000,
                       help='Minimum token threshold for thinning (markdown only)')
     parser.add_argument('--summary-token-threshold', type=int, default=200,
-                      help='Token threshold for generating summaries (markdown only)')
+                      help='Markdown only: nodes below this token count copy text as their summary; other nodes call the LLM (default: 200)')
     args = parser.parse_args()
     if args.flash:
         args.mode = 'flash'

--- a/tests/test_page_index_md.py
+++ b/tests/test_page_index_md.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest.mock import AsyncMock, patch
 
-from pageindex.page_index_md import extract_nodes_from_markdown
+from pageindex.page_index_md import extract_nodes_from_markdown, get_node_summary
 
 
 class ExtractNodesFromMarkdownTest(unittest.TestCase):
@@ -99,6 +100,32 @@ class MarkdownCliTest(unittest.TestCase):
                         if l.startswith("MODELS_SEEN="))
             self.assertEqual(json.loads(line[len("MODELS_SEEN="):]),
                              ["SUMMARY-SENTINEL"], res.stdout.decode())
+
+
+class GetNodeSummaryTest(unittest.IsolatedAsyncioTestCase):
+    async def test_below_threshold_uses_node_text_without_calling_llm(self):
+        node = {"text": "short section"}
+
+        with patch("pageindex.page_index_md.count_tokens", return_value=199), patch(
+            "pageindex.page_index_md.generate_node_summary", new_callable=AsyncMock
+        ) as generate_summary:
+            summary = await get_node_summary(node, summary_token_threshold=200)
+
+        self.assertEqual(summary, node["text"])
+        generate_summary.assert_not_awaited()
+
+    async def test_threshold_boundary_generates_a_summary(self):
+        node = {"text": "boundary section"}
+
+        with patch("pageindex.page_index_md.count_tokens", return_value=200), patch(
+            "pageindex.page_index_md.generate_node_summary",
+            new_callable=AsyncMock,
+            return_value="generated summary",
+        ) as generate_summary:
+            summary = await get_node_summary(node, summary_token_threshold=200)
+
+        self.assertEqual(summary, "generated summary")
+        generate_summary.assert_awaited_once_with(node, model=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- document the Markdown-only `--summary-token-threshold` behavior in the README
- clarify in `--help` that nodes below the threshold reuse their text without an LLM call
- add regression coverage for both the below-threshold path and the equality boundary

The change preserves the existing runtime behavior. Setting the threshold to `0` continues to make every node use LLM summary generation.

Fixes #355

## Validation

- `.venv/bin/python -m unittest discover -s tests -p 'test_page_index_md.py' -v`
- `.venv/bin/python run_pageindex.py --help`
