### PR TITLE
feat: model knobs, LiteLLM-verbatim chat lane, per-door passthrough params

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ You can customize the processing with additional optional arguments (the structu
 
 ```
 --mode                  Processing mode: flash (default) or standard
---model                 LLM model to use (default: gpt-4o-2024-11-20)
+--index-model           LLM model used to index the document (default: gpt-5.6-luna)
 --toc-check-pages       Pages to check for table of contents (default: 20)
 --max-pages-per-node    Max pages per node (default: 10)
 --max-tokens-per-node   Max tokens per node (default: 20000)

--- a/README.md
+++ b/README.md
@@ -213,10 +213,6 @@ python3 run_pageindex.py --md_path /path/to/your/document.md
 For a simple, end-to-end **agentic vectorless RAG** example using **self-hosted PageIndex** (with OpenAI Agents SDK), see [`examples/agentic_vectorless_rag_demo.py`](examples/agentic_vectorless_rag_demo.py).
 
 ```bash
-# Install optional dependency
-pip3 install openai-agents
-
-# Run the demo
 python3 examples/agentic_vectorless_rag_demo.py
 ```
 

--- a/pageindex/__init__.py
+++ b/pageindex/__init__.py
@@ -1,5 +1,10 @@
 """PageIndex SDK."""
+import os as _os
 from typing import TYPE_CHECKING as _TYPE_CHECKING
+
+# LiteLLM's import otherwise fetches its model map over the network — seconds
+# of blocking (or a hang offline). setdefault, so an explicit user choice wins.
+_os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 
 from .client import PageIndexClient, PageIndexCloudClient, PageIndexLocalClient
 from .errors import PageIndexAPIError

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -423,6 +423,8 @@ class PageIndexClient:
         enable_citations: bool = False,
         model: Optional[str] = None,
         max_turns: Optional[int] = None,
+        top_p: Optional[float] = None,
+        max_tokens: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
         extra_body: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[str], Iterator[dict[str, Any]]]:
@@ -467,6 +469,11 @@ class PageIndexClient:
             model: Local only — backend model name (defaults to
                 ``chat_model``). The cloud endpoint selects its own.
             max_turns: Local only — cap on agent turns per call.
+            top_p: Local only — nucleus sampling, passed through to the
+                model.
+            max_tokens: Local only — per-call output cap, passed through;
+                it bounds each backend call in the agent loop (the way
+                max_turns bounds the loop), not the whole run.
             reasoning_effort: Local only — passed through verbatim as
                 LiteLLM's ``reasoning_effort``; each provider maps it to
                 its own thinking control, and the values mean what the
@@ -497,15 +504,16 @@ class PageIndexClient:
                 self, messages, stream=stream, doc_id=doc_id,
                 temperature=temperature, stream_metadata=stream_metadata,
                 enable_citations=enable_citations, model=model,
-                max_turns=max_turns, reasoning_effort=reasoning_effort,
-                extra_body=extra_body,
+                max_turns=max_turns, top_p=top_p, max_tokens=max_tokens,
+                reasoning_effort=reasoning_effort, extra_body=extra_body,
             )
-        if (model is not None or max_turns is not None
-                or reasoning_effort is not None or extra_body is not None):
+        if (model is not None or max_turns is not None or top_p is not None
+                or max_tokens is not None or reasoning_effort is not None
+                or extra_body is not None):
             raise PageIndexAPIError(
-                "model, max_turns, reasoning_effort and extra_body are "
-                "local-mode parameters — the cloud chat endpoint selects "
-                "its own model."
+                "model, max_turns, top_p, max_tokens, reasoning_effort and "
+                "extra_body are local-mode parameters — the cloud chat "
+                "endpoint selects its own model."
             )
         return self._api.chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
@@ -523,6 +531,7 @@ class PageIndexClient:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         max_turns: Optional[int] = None,
+        max_output_tokens: Optional[int] = None,
         reasoning: Optional[dict[str, Any]] = None,
         extra_body: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
@@ -563,6 +572,10 @@ class PageIndexClient:
             instructions: Appended to the managed system prompt.
             temperature / top_p: Passed through to the model.
             max_turns: Cap on agent turns per call.
+            max_output_tokens: Per-call output cap, passed through; it
+                bounds each backend call in the agent loop (the way
+                max_turns bounds the loop), not the whole run. Echoed in
+                the envelope.
             reasoning: Responses reasoning options, forwarded verbatim
                 (e.g. ``{"effort": "low", "summary": "auto"}``) — the
                 values mean what the backend says they mean. Unset sends
@@ -581,7 +594,8 @@ class PageIndexClient:
         return run_responses(
             self, input, model=model, stream=stream, doc_id=doc_id,
             instructions=instructions, temperature=temperature, top_p=top_p,
-            max_turns=max_turns, reasoning=reasoning, extra_body=extra_body,
+            max_turns=max_turns, max_output_tokens=max_output_tokens,
+            reasoning=reasoning, extra_body=extra_body,
         )
 
     def messages(

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -64,17 +64,27 @@ class PageIndexClient:
     Args:
         api_key (str, optional): PageIndex cloud API key
             (https://dash.pageindex.ai/api-keys). Omit for local mode.
-        model (str, optional): Local mode only — LLM used to build document
-            trees. Defaults to the packaged config (see pageindex/config.yaml).
-        summary_model (str, optional): Local mode only — LLM used for node
-            summaries and document descriptions.
-        retrieve_model (str, optional): Local mode only — the model the
-            local chat surfaces (``chat_completions``, ``responses``)
-            default to, exposed as ``client.retrieve_model``. Chat names
+        index_model (str, optional): Local mode only — LLM used to index
+            documents (structure and summaries). Defaults to the SDK
+            default (fast and cheap).
+        chat_model (str, optional): Local mode only — the model the chat
+            surfaces (``chat``, ``chat_completions``, ``responses``)
+            default to, exposed as ``client.chat_model``. Chat names
             route through LiteLLM and mean what LiteLLM says they mean;
             bare names are OpenAI-compatible shorthand, and
             ``openai/Qwen/...`` is the form for an OpenAI-compatible
             server that itself serves slashed model ids (vLLM, TGI).
+            Defaults to the SDK default (strong).
+        model (str, optional): Local mode only — one model for both roles:
+            sets the default for ``index_model`` and ``chat_model`` at
+            once. The role-specific arguments win over it. (Also the
+            0.2.8-era name for the indexing model — old configs keep
+            working unchanged.)
+        summary_model (str, optional): Local mode only — legacy: overrides
+            the model used for node summaries and document descriptions;
+            ``index_model`` covers this.
+        retrieve_model (str, optional): Local mode only — legacy name for
+            ``chat_model``.
         storage_path (str, optional): Local mode only — directory where
             indexed documents are stored. Defaults to ``./.pageindex``.
 
@@ -97,6 +107,8 @@ class PageIndexClient:
         self,
         api_key: Optional[str] = None,
         *,
+        index_model: Optional[str] = None,
+        chat_model: Optional[str] = None,
         model: Optional[str] = None,
         summary_model: Optional[str] = None,
         retrieve_model: Optional[str] = None,
@@ -107,9 +119,11 @@ class PageIndexClient:
                 "api_key is an empty string. Pass a real PageIndex API key for "
                 "cloud mode, or omit api_key entirely for local mode."
             )
+        model_args = {"index_model": index_model, "chat_model": chat_model,
+                      "model": model, "summary_model": summary_model,
+                      "retrieve_model": retrieve_model}
         if api_key is not None:
-            local_only = {"model": model, "summary_model": summary_model,
-                          "retrieve_model": retrieve_model, "storage_path": storage_path}
+            local_only = dict(model_args, storage_path=storage_path)
             passed = [name for name, value in local_only.items() if value is not None]
             if passed:
                 raise PageIndexAPIError(
@@ -122,26 +136,29 @@ class PageIndexClient:
             self._api = CloudAPI(self)
         else:
             from .utils import ConfigLoader
-            overrides = {key: value for key, value in
-                         {"model": model, "summary_model": summary_model,
-                          "retrieve_model": retrieve_model}.items()
+            overrides = {key: value for key, value in model_args.items()
                          if value}
             opt = ConfigLoader().load(overrides or None)
             self.model = opt.model
-            self.summary_model = getattr(opt, "summary_model", None) or opt.model
-            self.retrieve_model = _agents_sdk_model_name(
-                getattr(opt, "retrieve_model", None) or opt.model)
+            self.index_model = opt.index_model
+            self.summary_model = opt.summary_model
+            self.chat_model = _agents_sdk_model_name(opt.chat_model)
             self.storage_path = storage_path or ".pageindex"
             from .local_api import LocalAPI
             self._api = LocalAPI(
                 storage_path=self.storage_path,
                 model=self.model,
                 summary_model=self.summary_model,
-                retrieve_model=self.retrieve_model,
+                retrieve_model=self.chat_model,
             )
             # LiteLLM's multi-second import would otherwise land on the
             # first chat call; failures resurface there with real context.
             threading.Thread(target=_preload_litellm, daemon=True).start()
+
+    @property
+    def retrieve_model(self):
+        """Legacy name for ``chat_model``."""
+        return self.chat_model
 
     # ---------- DOCUMENT SUBMISSION ----------
 
@@ -383,7 +400,7 @@ class PageIndexClient:
                 Keep it identical across a conversation's calls.
             stream: Yield the answer as text chunks as it is produced.
             model: Local only — backend model name (defaults to
-                ``retrieve_model``).
+                ``chat_model``).
 
         Returns:
             - stream=False: the answer string
@@ -446,7 +463,7 @@ class PageIndexClient:
             enable_citations: Cloud-only — local mode raises (citations need
                 block-level OCR data local mode does not store).
             model: Local only — backend model name (defaults to
-                ``retrieve_model``). The cloud endpoint selects its own.
+                ``chat_model``). The cloud endpoint selects its own.
             max_turns: Local only — cap on agent turns per call.
 
         Returns:
@@ -514,7 +531,7 @@ class PageIndexClient:
         Args:
             input: A user message string, or a list of Responses input items
                 (round-trip prior ``items`` here).
-            model: Backend model name (defaults to ``retrieve_model``).
+            model: Backend model name (defaults to ``chat_model``).
             stream: Yield Responses stream events as dicts — one logical
                 response per call: per-turn backend lifecycle events are
                 collapsed, sequence numbers are reassigned monotonically,
@@ -754,7 +771,7 @@ class PageIndexClient:
         Sugar over the explicit form — ``agent_instructions`` (with
         ``doc_id`` targeting) as the instructions and
         ``as_openai_tools`` as the tools; local clients also carry their
-        configured ``retrieve_model`` (cloud omits ``model`` so the
+        configured ``chat_model`` (cloud omits ``model`` so the
         framework default applies). To customize further, switch to
         those methods directly.
 
@@ -775,7 +792,7 @@ class PageIndexClient:
                                                      scoped=scope is not None),
             "tools": self.as_openai_tools(include_management, doc_id=scope),
         }
-        model = model or getattr(self, "retrieve_model", None)
+        model = model or getattr(self, "chat_model", None)
         if model:
             config["model"] = model
         return config
@@ -1032,10 +1049,13 @@ class PageIndexLocalClient(PageIndexClient):
     def __init__(
         self,
         *,
+        index_model: Optional[str] = None,
+        chat_model: Optional[str] = None,
         model: Optional[str] = None,
         summary_model: Optional[str] = None,
         retrieve_model: Optional[str] = None,
         storage_path: Optional[str] = None,
     ):
-        super().__init__(None, model=model, summary_model=summary_model,
+        super().__init__(None, index_model=index_model, chat_model=chat_model,
+                         model=model, summary_model=summary_model,
                          retrieve_model=retrieve_model, storage_path=storage_path)

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -424,6 +424,7 @@ class PageIndexClient:
         model: Optional[str] = None,
         max_turns: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[str], Iterator[dict[str, Any]]]:
         """
         PageIndex Chat Completions: document QA in one call.
@@ -471,6 +472,11 @@ class PageIndexClient:
                 its own thinking control, and the values mean what the
                 backend says they mean. Unset sends nothing (the
                 backend's default applies).
+            extra_body: Local only — extra request fields beyond this
+                method's parameters, merged last so they win.
+                OpenAI-compatible backends take them verbatim in the
+                request body; LiteLLM-routed providers take them as
+                LiteLLM's own params (mapped or refused per provider).
 
         Returns:
             - stream=False: complete response dict ({'id', 'object', 'created',
@@ -492,12 +498,14 @@ class PageIndexClient:
                 temperature=temperature, stream_metadata=stream_metadata,
                 enable_citations=enable_citations, model=model,
                 max_turns=max_turns, reasoning_effort=reasoning_effort,
+                extra_body=extra_body,
             )
         if (model is not None or max_turns is not None
-                or reasoning_effort is not None):
+                or reasoning_effort is not None or extra_body is not None):
             raise PageIndexAPIError(
-                "model, max_turns and reasoning_effort are local-mode "
-                "parameters — the cloud chat endpoint selects its own model."
+                "model, max_turns, reasoning_effort and extra_body are "
+                "local-mode parameters — the cloud chat endpoint selects "
+                "its own model."
             )
         return self._api.chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
@@ -516,6 +524,7 @@ class PageIndexClient:
         top_p: Optional[float] = None,
         max_turns: Optional[int] = None,
         reasoning: Optional[dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
         """
         Document QA over the OpenAI Responses protocol — the agentic surface.
@@ -558,6 +567,9 @@ class PageIndexClient:
                 (e.g. ``{"effort": "low", "summary": "auto"}``) — the
                 values mean what the backend says they mean. Unset sends
                 nothing (the backend's default applies).
+            extra_body: Extra request fields beyond this method's
+                parameters, merged verbatim into the request body (last,
+                so they win).
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -569,7 +581,7 @@ class PageIndexClient:
         return run_responses(
             self, input, model=model, stream=stream, doc_id=doc_id,
             instructions=instructions, temperature=temperature, top_p=top_p,
-            max_turns=max_turns, reasoning=reasoning,
+            max_turns=max_turns, reasoning=reasoning, extra_body=extra_body,
         )
 
     def messages(
@@ -586,6 +598,7 @@ class PageIndexClient:
         stop_sequences: Optional[list[str]] = None,
         max_turns: Optional[int] = None,
         thinking: Optional[dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[Any]]:
         """
         Document QA over the Anthropic Messages protocol — Claude-native.
@@ -623,6 +636,8 @@ class PageIndexClient:
             thinking: Anthropic thinking configuration, forwarded verbatim
                 (e.g. ``{"type": "adaptive"}``) — the values and their
                 constraints are the backend's. Unset sends nothing.
+            extra_body: Extra request fields beyond this method's
+                parameters, merged verbatim into each request body.
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -636,7 +651,7 @@ class PageIndexClient:
             stream=stream, doc_id=doc_id, system=system,
             temperature=temperature, top_p=top_p, top_k=top_k,
             stop_sequences=stop_sequences, max_turns=max_turns,
-            thinking=thinking,
+            thinking=thinking, extra_body=extra_body,
         )
 
     # ---------- DOCUMENT MANAGEMENT ----------

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -423,6 +423,7 @@ class PageIndexClient:
         enable_citations: bool = False,
         model: Optional[str] = None,
         max_turns: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> Union[dict[str, Any], Iterator[str], Iterator[dict[str, Any]]]:
         """
         PageIndex Chat Completions: document QA in one call.
@@ -465,6 +466,11 @@ class PageIndexClient:
             model: Local only — backend model name (defaults to
                 ``chat_model``). The cloud endpoint selects its own.
             max_turns: Local only — cap on agent turns per call.
+            reasoning_effort: Local only — passed through verbatim as
+                LiteLLM's ``reasoning_effort``; each provider maps it to
+                its own thinking control, and the values mean what the
+                backend says they mean. Unset sends nothing (the
+                backend's default applies).
 
         Returns:
             - stream=False: complete response dict ({'id', 'object', 'created',
@@ -485,12 +491,13 @@ class PageIndexClient:
                 self, messages, stream=stream, doc_id=doc_id,
                 temperature=temperature, stream_metadata=stream_metadata,
                 enable_citations=enable_citations, model=model,
-                max_turns=max_turns,
+                max_turns=max_turns, reasoning_effort=reasoning_effort,
             )
-        if model is not None or max_turns is not None:
+        if (model is not None or max_turns is not None
+                or reasoning_effort is not None):
             raise PageIndexAPIError(
-                "model and max_turns are local-mode parameters — the cloud "
-                "chat endpoint selects its own model."
+                "model, max_turns and reasoning_effort are local-mode "
+                "parameters — the cloud chat endpoint selects its own model."
             )
         return self._api.chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
@@ -508,6 +515,7 @@ class PageIndexClient:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         max_turns: Optional[int] = None,
+        reasoning: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
         """
         Document QA over the OpenAI Responses protocol — the agentic surface.
@@ -546,6 +554,10 @@ class PageIndexClient:
             instructions: Appended to the managed system prompt.
             temperature / top_p: Passed through to the model.
             max_turns: Cap on agent turns per call.
+            reasoning: Responses reasoning options, forwarded verbatim
+                (e.g. ``{"effort": "low", "summary": "auto"}``) — the
+                values mean what the backend says they mean. Unset sends
+                nothing (the backend's default applies).
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -557,7 +569,7 @@ class PageIndexClient:
         return run_responses(
             self, input, model=model, stream=stream, doc_id=doc_id,
             instructions=instructions, temperature=temperature, top_p=top_p,
-            max_turns=max_turns,
+            max_turns=max_turns, reasoning=reasoning,
         )
 
     def messages(
@@ -573,6 +585,7 @@ class PageIndexClient:
         top_k: Optional[int] = None,
         stop_sequences: Optional[list[str]] = None,
         max_turns: Optional[int] = None,
+        thinking: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[Any]]:
         """
         Document QA over the Anthropic Messages protocol — Claude-native.
@@ -607,6 +620,9 @@ class PageIndexClient:
                 OpenAI surfaces). A truncated run reports
                 ``stop_reason: "tool_use"`` and its ``messages`` remain
                 valid for continuation.
+            thinking: Anthropic thinking configuration, forwarded verbatim
+                (e.g. ``{"type": "adaptive"}``) — the values and their
+                constraints are the backend's. Unset sends nothing.
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -620,6 +636,7 @@ class PageIndexClient:
             stream=stream, doc_id=doc_id, system=system,
             temperature=temperature, top_p=top_p, top_k=top_k,
             stop_sequences=stop_sequences, max_turns=max_turns,
+            thinking=thinking,
         )
 
     # ---------- DOCUMENT MANAGEMENT ----------

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -70,12 +70,11 @@ class PageIndexClient:
             summaries and document descriptions.
         retrieve_model (str, optional): Local mode only — the model the
             local chat surfaces (``chat_completions``, ``responses``)
-            default to, exposed as ``client.retrieve_model``. On the chat
-            lane every name routes through LiteLLM (bare names are
-            OpenAI-compatible shorthand); prefix ``openai/`` to drive the
-            OpenAI SDK directly — also the form for an OpenAI-compatible
-            server that itself serves slashed model ids (vLLM, TGI,
-            e.g. ``openai/Qwen/...``).
+            default to, exposed as ``client.retrieve_model``. Chat names
+            route through LiteLLM and mean what LiteLLM says they mean;
+            bare names are OpenAI-compatible shorthand, and
+            ``openai/Qwen/...`` is the form for an OpenAI-compatible
+            server that itself serves slashed model ids (vLLM, TGI).
         storage_path (str, optional): Local mode only — directory where
             indexed documents are stored. Defaults to ``./.pageindex``.
 
@@ -413,14 +412,14 @@ class PageIndexClient:
 
         Cloud: the hosted chat endpoint. Local: a managed document-QA agent
         run over the local tools against your own LLM backend, routed
-        through LiteLLM (bare names are OpenAI-compatible shorthand: the
-        OpenAI SDK's usual env config — OPENAI_API_KEY, OPENAI_BASE_URL —
-        still selects the backend, so any OpenAI-compatible server works,
-        and prefixing ``openai/`` opts out of LiteLLM to the OpenAI SDK
-        directly, e.g. ``openai/Qwen/...`` on vLLM; provider-prefixed
-        names — ``anthropic/…``, ``bedrock/…`` — reach that provider, and
-        LiteLLM-routed Claude models get the managed prompt prefix
-        cache-marked automatically). The non-stream
+        through LiteLLM — model names mean what LiteLLM says they mean.
+        Bare names are OpenAI-compatible shorthand (the OpenAI SDK's usual
+        env config — OPENAI_API_KEY, OPENAI_BASE_URL — selects the
+        backend, so any OpenAI-compatible server works; write
+        ``openai/Qwen/...`` when the server itself serves slashed ids),
+        provider-prefixed names — ``anthropic/…``, ``bedrock/…`` — reach
+        that provider, and LiteLLM-routed Claude models get the managed
+        prompt prefix cache-marked automatically. The non-stream
         response carries the final answer only; streaming yields the
         agent's visible text as it is produced, including narration before
         tool calls. ``finish_reason`` reports loop completion ("stop") —

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -2,11 +2,19 @@
 from __future__ import annotations
 
 import os
+import threading
 import time
 import warnings
 from typing import Any, Callable, Iterator, Optional, Union, cast
 
 from .errors import PageIndexAPIError
+
+
+def _preload_litellm() -> None:
+    try:
+        import litellm  # noqa: F401
+    except Exception:
+        pass
 
 
 def _parse_pages(pages: str) -> list[int]:
@@ -62,10 +70,12 @@ class PageIndexClient:
             summaries and document descriptions.
         retrieve_model (str, optional): Local mode only — the model the
             local chat surfaces (``chat_completions``, ``responses``)
-            default to, exposed as ``client.retrieve_model``.
-            ``provider/model`` names route through LiteLLM; for an
-            OpenAI-compatible server that itself serves slashed model ids
-            (vLLM, TGI), prefix ``openai/`` (e.g. ``openai/Qwen/...``).
+            default to, exposed as ``client.retrieve_model``. On the chat
+            lane every name routes through LiteLLM (bare names are
+            OpenAI-compatible shorthand); prefix ``openai/`` to drive the
+            OpenAI SDK directly — also the form for an OpenAI-compatible
+            server that itself serves slashed model ids (vLLM, TGI,
+            e.g. ``openai/Qwen/...``).
         storage_path (str, optional): Local mode only — directory where
             indexed documents are stored. Defaults to ``./.pageindex``.
 
@@ -130,6 +140,9 @@ class PageIndexClient:
                 summary_model=self.summary_model,
                 retrieve_model=self.retrieve_model,
             )
+            # LiteLLM's multi-second import would otherwise land on the
+            # first chat call; failures resurface there with real context.
+            threading.Thread(target=_preload_litellm, daemon=True).start()
 
     # ---------- DOCUMENT SUBMISSION ----------
 
@@ -399,15 +412,15 @@ class PageIndexClient:
         PageIndex Chat Completions: document QA in one call.
 
         Cloud: the hosted chat endpoint. Local: a managed document-QA agent
-        run over the local tools against your own LLM backend's
-        /chat/completions (the OpenAI SDK's
-        usual env config — OPENAI_API_KEY, OPENAI_BASE_URL — selects the
-        backend, so any OpenAI-compatible server works; a ``/`` in the
-        model name means LiteLLM provider routing, so prefix ``openai/``
-        when the backend itself serves slashed ids, e.g.
-        ``openai/Qwen/...`` on vLLM; LiteLLM-routed Claude models —
-        Anthropic direct, Bedrock, Vertex — get the managed prompt
-        prefix cache-marked automatically). The non-stream
+        run over the local tools against your own LLM backend, routed
+        through LiteLLM (bare names are OpenAI-compatible shorthand: the
+        OpenAI SDK's usual env config — OPENAI_API_KEY, OPENAI_BASE_URL —
+        still selects the backend, so any OpenAI-compatible server works,
+        and prefixing ``openai/`` opts out of LiteLLM to the OpenAI SDK
+        directly, e.g. ``openai/Qwen/...`` on vLLM; provider-prefixed
+        names — ``anthropic/…``, ``bedrock/…`` — reach that provider, and
+        LiteLLM-routed Claude models get the managed prompt prefix
+        cache-marked automatically). The non-stream
         response carries the final answer only; streaming yields the
         agent's visible text as it is produced, including narration before
         tool calls. ``finish_reason`` reports loop completion ("stop") —

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -41,7 +41,7 @@ def _parse_pages(pages: str) -> list[int]:
     return sorted(result)
 
 
-def _normalize_retrieve_model(model: str) -> str:
+def _agents_sdk_model_name(model: str) -> str:
     """Preserve supported Agents SDK prefixes and route other provider paths via LiteLLM."""
     passthrough_prefixes = ("litellm/", "openai/")
     if not model or "/" not in model:
@@ -129,7 +129,7 @@ class PageIndexClient:
             opt = ConfigLoader().load(overrides or None)
             self.model = opt.model
             self.summary_model = getattr(opt, "summary_model", None) or opt.model
-            self.retrieve_model = _normalize_retrieve_model(
+            self.retrieve_model = _agents_sdk_model_name(
                 getattr(opt, "retrieve_model", None) or opt.model)
             self.storage_path = storage_path or ".pageindex"
             from .local_api import LocalAPI

--- a/pageindex/config.yaml
+++ b/pageindex/config.yaml
@@ -1,9 +1,11 @@
-# Models without a provider prefix use the OpenAI SDK directly.
-# For other providers, use "provider/model" format (e.g. "anthropic/claude-sonnet-4-6").
-model: "gpt-4o-2024-11-20"
-# model: "anthropic/claude-sonnet-4-6"
-summary_model: "gpt-5.6-luna"
-retrieve_model: "gpt-5.4"  # defaults to `model` if not set
+# Models — index_model indexes documents (structure and summaries),
+# chat_model answers questions on the chat surfaces; set model to use one
+# for both. Unset keys use the SDK defaults shown below. Legacy keys
+# (model, summary_model, retrieve_model) keep working.
+# Indexing names without a provider prefix use the OpenAI SDK directly;
+# for other providers, use "provider/model" (e.g. "anthropic/claude-sonnet-4-6").
+# index_model: "gpt-5.6-luna"
+# chat_model: "gpt-5.4"
 toc_check_page_num: 20
 max_page_num_each_node: 10
 max_token_num_each_node: 20000

--- a/pageindex/config.yaml
+++ b/pageindex/config.yaml
@@ -5,7 +5,7 @@
 # Indexing names without a provider prefix use the OpenAI SDK directly;
 # for other providers, use "provider/model" (e.g. "anthropic/claude-sonnet-4-6").
 # index_model: "gpt-5.6-luna"
-# chat_model: "gpt-5.4"
+# chat_model: "gpt-5.6-sol"
 toc_check_page_num: 20
 max_page_num_each_node: 10
 max_token_num_each_node: 20000

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -306,7 +306,8 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
 
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
                   temperature, top_p, doc_ids=None, cache_key=None,
-                  reasoning=None, reasoning_effort=None, extra_body=None):
+                  reasoning=None, reasoning_effort=None, extra_body=None,
+                  max_tokens=None):
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
     # ModelSettings.extra_body is the one channel all three engines put on
@@ -338,7 +339,7 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
         tools=build_openai_tools(client, doc_ids=doc_ids),
         model=_openai_model(protocol, model_name),
         model_settings=ModelSettings(
-            temperature=temperature, top_p=top_p,
+            temperature=temperature, top_p=top_p, max_tokens=max_tokens,
             reasoning=reasoning,
             extra_body=body,
             extra_args=extra_args),
@@ -484,6 +485,8 @@ def run_chat_completions(client, messages, stream: bool = False,
                          enable_citations: bool = False,
                          model: Optional[str] = None,
                          max_turns: Optional[int] = None,
+                         top_p: Optional[float] = None,
+                         max_tokens: Optional[int] = None,
                          reasoning_effort: Optional[str] = None,
                          extra_body: Optional[dict] = None,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
@@ -501,11 +504,11 @@ def run_chat_completions(client, messages, stream: bool = False,
     reported_model = _reported_model(model_name)
     managed = _managed_instructions(system_texts)
     agent = _openai_agent(client, "chat", model_name, managed,
-                          temperature, None, doc_ids=doc_id,
+                          temperature, top_p, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name,
                                                             managed, history),
                           reasoning_effort=reasoning_effort,
-                          extra_body=extra_body)
+                          extra_body=extra_body, max_tokens=max_tokens)
     run_kwargs = _run_kwargs(max_turns)
     import openai
     from agents import Runner
@@ -592,6 +595,7 @@ def run_responses(client, input, model: Optional[str] = None,
                   temperature: Optional[float] = None,
                   top_p: Optional[float] = None,
                   max_turns: Optional[int] = None,
+                  max_output_tokens: Optional[int] = None,
                   reasoning: Optional[dict] = None,
                   extra_body: Optional[dict] = None,
                   ) -> Union[dict, Iterator[dict]]:
@@ -616,7 +620,8 @@ def run_responses(client, input, model: Optional[str] = None,
                           temperature, top_p, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name, managed,
                                                             conversation),
-                          reasoning=reasoning, extra_body=extra_body)
+                          reasoning=reasoning, extra_body=extra_body,
+                          max_tokens=max_output_tokens)
     run_kwargs = _run_kwargs(max_turns)
     recorded: dict = {}
     import openai
@@ -645,7 +650,7 @@ def run_responses(client, input, model: Optional[str] = None,
             "temperature": temperature,
             "top_p": top_p,
             "reasoning": reasoning,
-            "max_output_tokens": None,
+            "max_output_tokens": max_output_tokens,
             "error": recorded.get("error"),
             "incomplete_details": recorded.get("incomplete_details"),
             "metadata": None,

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -215,20 +215,19 @@ def _require_openai_agents(method: str) -> None:
 def _openai_model(protocol: str, model_name: str):
     """The backend protocol driver — the seam tests replace with a fake.
 
-    chat protocol: every model routes through LiteLLM. Bare names are
-    OpenAI-compatible shorthand (wire form ``openai/<name>``, so
-    OPENAI_API_KEY / OPENAI_BASE_URL keep selecting the backend), a
-    ``litellm/`` prefix strips, a first segment LiteLLM does not know (a
-    HuggingFace repo id like ``Qwen/...``) is refused with the ``openai/``
-    escape instead of failing inside LiteLLM at request time, and an
-    ``openai/`` prefix opts out to the OpenAI SDK directly.
+    chat protocol: LiteLLM, full stop — model names mean what LiteLLM says
+    they mean. Bare names are OpenAI-compatible shorthand (wire form
+    ``openai/<name>``, so OPENAI_API_KEY / OPENAI_BASE_URL keep selecting
+    the backend), a ``litellm/`` prefix strips, and a first segment LiteLLM
+    does not know (a HuggingFace repo id like ``Qwen/...``) is refused with
+    the ``openai/`` form instead of failing inside LiteLLM at request time.
 
     responses protocol: the Responses API is OpenAI-SDK native — LiteLLM's
     completion surface speaks the chat.completions format, so
     provider-prefixed models are refused instead of silently downgrading;
     bare and ``openai/`` names drive the OpenAI SDK."""
-    if "/" in model_name and not model_name.startswith("openai/"):
-        if protocol == "responses":
+    if protocol == "responses":
+        if "/" in model_name and not model_name.startswith("openai/"):
             raise PageIndexAPIError(
                 f"responses() cannot drive "
                 f"'{model_name.removeprefix('litellm/')}': provider-prefixed "
@@ -238,47 +237,43 @@ def _openai_model(protocol: str, model_name: str):
                 "Responses-capable backend and use a bare or "
                 "'openai/'-prefixed model name."
             )
-    if protocol == "chat" and not model_name.startswith("openai/"):
+        import openai
+        model_name = model_name.removeprefix("openai/")
         try:
-            from agents.extensions.models.litellm_model import LitellmModel
-            import litellm
-        except ImportError:
+            backend = openai.AsyncOpenAI()
+        except openai.OpenAIError as exc:
             raise PageIndexAPIError(
-                f"'{model_name}' routes through LiteLLM, but litellm is not "
-                "installed. Run:  pip install 'litellm>=1.30'"
-            )
-        wire = model_name.removeprefix("litellm/")
-        if "/" not in wire:
-            if not os.environ.get("OPENAI_API_KEY"):
-                raise PageIndexAPIError(
-                    "The OpenAI backend is not configured: set the "
-                    "OPENAI_API_KEY environment variable (any value works "
-                    "for keyless OPENAI_BASE_URL servers)."
-                )
-            wire = f"openai/{wire}"
-        providers = getattr(litellm, "provider_list", None)
-        if providers and wire.split("/", 1)[0] not in providers:
-            raise PageIndexAPIError(
-                f"'{wire}' routes through LiteLLM, but "
-                f"'{wire.split('/', 1)[0]}' is not a LiteLLM provider. For an "
-                "OpenAI-compatible server (vLLM, TGI, Ollama) serving this "
-                f"model id, use 'openai/{wire}' and point OPENAI_BASE_URL "
-                "at the server."
-            )
-        return LitellmModel(wire)
-    import openai
-    model_name = model_name.removeprefix("openai/")
+                f"The OpenAI backend is not configured: {exc}") from exc
+        from agents.models.openai_responses import OpenAIResponsesModel
+        return OpenAIResponsesModel(model_name, openai_client=backend)
     try:
-        backend = openai.AsyncOpenAI()
-    except openai.OpenAIError as exc:
+        from agents.extensions.models.litellm_model import LitellmModel
+        import litellm
+    except ImportError:
         raise PageIndexAPIError(
-            f"The OpenAI backend is not configured: {exc}") from exc
-    if protocol == "chat":
-        from agents.models.openai_chatcompletions import (
-            OpenAIChatCompletionsModel)
-        return OpenAIChatCompletionsModel(model_name, backend)
-    from agents.models.openai_responses import OpenAIResponsesModel
-    return OpenAIResponsesModel(model_name, openai_client=backend)
+            f"'{model_name}' routes through LiteLLM, but litellm is not "
+            "installed. Run:  pip install 'litellm>=1.30'"
+        )
+    wire = model_name.removeprefix("litellm/")
+    if "/" not in wire or wire.startswith("openai/"):
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise PageIndexAPIError(
+                "The OpenAI backend is not configured: set the "
+                "OPENAI_API_KEY environment variable (any value works "
+                "for keyless OPENAI_BASE_URL servers)."
+            )
+    if "/" not in wire:
+        wire = f"openai/{wire}"
+    providers = getattr(litellm, "provider_list", None)
+    if providers and wire.split("/", 1)[0] not in providers:
+        raise PageIndexAPIError(
+            f"'{wire}' routes through LiteLLM, but "
+            f"'{wire.split('/', 1)[0]}' is not a LiteLLM provider. For an "
+            "OpenAI-compatible server (vLLM, TGI, Ollama) serving this "
+            f"model id, use 'openai/{wire}' and point OPENAI_BASE_URL "
+            "at the server."
+        )
+    return LitellmModel(wire)
 
 
 def _reported_model(model_name: str) -> str:

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -477,7 +477,7 @@ def run_chat_completions(client, messages, stream: bool = False,
     system_texts, history = _split_chat_messages(messages)
     block = _doc_block(client, doc_id)
     items = ([{"role": "user", "content": block}] if block else []) + history
-    model_name = model or client.retrieve_model
+    model_name = model or client.chat_model
     reported_model = _reported_model(model_name)
     managed = _managed_instructions(system_texts)
     agent = _openai_agent(client, "chat", model_name, managed,
@@ -586,7 +586,7 @@ def run_responses(client, input, model: Optional[str] = None,
     if block:
         items = [{"role": "user", "content": block}] + items
     extra = [instructions] if instructions else []
-    model_name = model or client.retrieve_model
+    model_name = model or client.chat_model
     managed = _managed_instructions(extra)
     agent = _openai_agent(client, "responses", model_name, managed,
                           temperature, top_p, doc_ids=doc_id,

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -252,7 +252,7 @@ def _openai_model(protocol: str, model_name: str):
     except ImportError:
         raise PageIndexAPIError(
             f"'{model_name}' routes through LiteLLM, but litellm is not "
-            "installed. Run:  pip install 'litellm>=1.84'"
+            "installed. Run:  pip install 'litellm>=1.97'"
         )
     wire = model_name.removeprefix("litellm/")
     if "/" not in wire or wire.startswith("openai/"):

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -260,7 +260,8 @@ def _openai_model(protocol: str, model_name: str):
             raise PageIndexAPIError(
                 "The OpenAI backend is not configured: set the "
                 "OPENAI_API_KEY environment variable (any value works "
-                "for keyless OPENAI_BASE_URL servers)."
+                "for keyless OPENAI_BASE_URL servers), or point "
+                "chat_model at another provider (e.g. 'anthropic/...')."
             )
     if "/" not in wire:
         wire = f"openai/{wire}"

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -24,6 +24,7 @@ import asyncio
 import concurrent.futures
 import hashlib
 import json
+import os
 import queue
 import threading
 import time
@@ -214,14 +215,18 @@ def _require_openai_agents(method: str) -> None:
 def _openai_model(protocol: str, model_name: str):
     """The backend protocol driver — the seam tests replace with a fake.
 
-    ``litellm/<provider>/<model>`` (the client's normalized retrieve_model
-    form) and bare ``<provider>/<model>`` paths drive the provider through
-    LiteLLM — chat.completions only, so the responses protocol refuses them
-    instead of silently downgrading; a first segment LiteLLM does not know
-    (a HuggingFace repo id like ``Qwen/...``) is refused with the
-    ``openai/`` escape instead of failing inside LiteLLM at request time;
-    an ``openai/`` prefix strips to the OpenAI SDK; bare names go to the
-    OpenAI SDK as-is."""
+    chat protocol: every model routes through LiteLLM. Bare names are
+    OpenAI-compatible shorthand (wire form ``openai/<name>``, so
+    OPENAI_API_KEY / OPENAI_BASE_URL keep selecting the backend), a
+    ``litellm/`` prefix strips, a first segment LiteLLM does not know (a
+    HuggingFace repo id like ``Qwen/...``) is refused with the ``openai/``
+    escape instead of failing inside LiteLLM at request time, and an
+    ``openai/`` prefix opts out to the OpenAI SDK directly.
+
+    responses protocol: the Responses API is OpenAI-SDK native — LiteLLM's
+    completion surface speaks the chat.completions format, so
+    provider-prefixed models are refused instead of silently downgrading;
+    bare and ``openai/`` names drive the OpenAI SDK."""
     if "/" in model_name and not model_name.startswith("openai/"):
         if protocol == "responses":
             raise PageIndexAPIError(
@@ -233,6 +238,7 @@ def _openai_model(protocol: str, model_name: str):
                 "Responses-capable backend and use a bare or "
                 "'openai/'-prefixed model name."
             )
+    if protocol == "chat" and not model_name.startswith("openai/"):
         try:
             from agents.extensions.models.litellm_model import LitellmModel
             import litellm
@@ -242,6 +248,14 @@ def _openai_model(protocol: str, model_name: str):
                 "installed. Run:  pip install 'litellm>=1.30'"
             )
         wire = model_name.removeprefix("litellm/")
+        if "/" not in wire:
+            if not os.environ.get("OPENAI_API_KEY"):
+                raise PageIndexAPIError(
+                    "The OpenAI backend is not configured: set the "
+                    "OPENAI_API_KEY environment variable (any value works "
+                    "for keyless OPENAI_BASE_URL servers)."
+                )
+            wire = f"openai/{wire}"
         providers = getattr(litellm, "provider_list", None)
         if providers and wire.split("/", 1)[0] not in providers:
             raise PageIndexAPIError(
@@ -296,16 +310,26 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
 
 
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
-                  temperature, top_p, doc_ids=None):
+                  temperature, top_p, doc_ids=None, cache_key=None):
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
+    # ModelSettings.extra_body is the one channel all three engines put on
+    # the wire: LiteLLM drops the bare prompt_cache_key kwarg (wire-verified),
+    # and both OpenAI model classes pass extra_body through verbatim. OpenAI
+    # destinations only — LiteLLM plants extra_body as a literal field in
+    # other providers' request bodies, which Anthropic rejects as unknown.
+    wire = model_name.removeprefix("litellm/")
+    openai_backend = "/" not in wire or wire.startswith("openai/")
     return Agent(
         name="PageIndex",
         instructions=instructions,
         tools=build_openai_tools(client, doc_ids=doc_ids),
         model=_openai_model(protocol, model_name),
-        model_settings=ModelSettings(temperature=temperature, top_p=top_p,
-                                     extra_args=_cache_extra_args(model_name)),
+        model_settings=ModelSettings(
+            temperature=temperature, top_p=top_p,
+            extra_body=({"prompt_cache_key": cache_key}
+                        if cache_key and openai_backend else None),
+            extra_args=_cache_extra_args(model_name)),
     )
 
 
@@ -315,27 +339,40 @@ def _validate_max_turns(max_turns) -> None:
         raise PageIndexAPIError("max_turns must be a positive integer.")
 
 
-def _conversation_group_id(model_name: str, instructions: str, items) -> str:
-    """Stable per-conversation cache-routing key: openai-agents hashes
-    RunConfig.group_id into the OpenAI prompt_cache_key, and without one it
-    stamps every run with a fresh key, tagging a round-tripped prefix as a
-    different cache group. Keyed on the prefix identity — model,
-    instructions, first conversation item — so a conversation's
-    continuations share one route without pooling unrelated conversations.
-    Callers pass the conversation's own items, never the SDK-prepended
-    doc-targeting block: that block is byte-identical for every
-    conversation about a document and would pool them all under one key."""
+def _conversation_cache_key(model_name: str, instructions: str, items) -> str:
+    """Stable per-conversation cache-routing key, sent as the OpenAI
+    ``prompt_cache_key`` through ModelSettings.extra_args (openai-agents
+    0.20 no longer derives it from RunConfig.group_id — verified against a
+    captured wire). Keyed on the prefix identity — model, instructions,
+    first conversation item — so a conversation's continuations share one
+    route without pooling unrelated conversations. Callers pass the
+    conversation's own items, never the SDK-prepended doc-targeting block:
+    that block is byte-identical for every conversation about a document
+    and would pool them all under one key."""
     seed = json.dumps([model_name, instructions,
                        items[0] if items else None],
                       sort_keys=True, default=str)
     return "pageindex-" + hashlib.sha256(seed.encode()).hexdigest()[:16]
 
 
-def _run_kwargs(max_turns, group_id: str) -> dict:
+def _model_backend_error(exc) -> PageIndexAPIError:
+    """Wrap a provider failure; the sol-class refusal (chatcmpl rejects
+    function tools while reasoning is on) gets its two documented exits
+    appended, since the fix is a different lane, not a retry."""
+    message = f"The model backend failed: {exc}"
+    if "Function tools with reasoning_effort" in str(exc):
+        message += (
+            " — this model runs tools on the Responses lane: upgrade "
+            "litellm (newer releases route it there automatically) or "
+            "call responses() instead."
+        )
+    return PageIndexAPIError(message)
+
+
+def _run_kwargs(max_turns) -> dict:
     # No traces — the caller opted into QA, not telemetry.
     from agents import RunConfig
-    kwargs: dict = {"run_config": RunConfig(tracing_disabled=True,
-                                            group_id=group_id)}
+    kwargs: dict = {"run_config": RunConfig(tracing_disabled=True)}
     if max_turns is not None:
         kwargs["max_turns"] = max_turns
     return kwargs
@@ -449,10 +486,10 @@ def run_chat_completions(client, messages, stream: bool = False,
     reported_model = _reported_model(model_name)
     managed = _managed_instructions(system_texts)
     agent = _openai_agent(client, "chat", model_name, managed,
-                          temperature, None, doc_ids=doc_id)
-    run_kwargs = _run_kwargs(max_turns,
-                             _conversation_group_id(model_name, managed,
-                                                    history))
+                          temperature, None, doc_ids=doc_id,
+                          cache_key=_conversation_cache_key(model_name,
+                                                            managed, history))
+    run_kwargs = _run_kwargs(max_turns)
     import openai
     from agents import Runner
     from agents.exceptions import AgentsException, MaxTurnsExceeded
@@ -466,8 +503,7 @@ def run_chat_completions(client, messages, stream: bool = False,
             raise PageIndexAPIError(
                 f"The agent backend failed: {exc}") from exc
         except openai.OpenAIError as exc:
-            raise PageIndexAPIError(
-                f"The model backend failed: {exc}") from exc
+            raise _model_backend_error(exc) from exc
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex}",
             "object": "chat.completion",
@@ -512,8 +548,7 @@ def run_chat_completions(client, messages, stream: bool = False,
             raise PageIndexAPIError(
                 f"The agent backend failed: {exc}") from exc
         except openai.OpenAIError as exc:
-            raise PageIndexAPIError(
-                f"The model backend failed: {exc}") from exc
+            raise _model_backend_error(exc) from exc
         finally:
             if not completed and hasattr(streamed, "cancel"):
                 streamed.cancel()  # abandoned/failed: stop the agent task
@@ -559,10 +594,10 @@ def run_responses(client, input, model: Optional[str] = None,
     model_name = model or client.retrieve_model
     managed = _managed_instructions(extra)
     agent = _openai_agent(client, "responses", model_name, managed,
-                          temperature, top_p, doc_ids=doc_id)
-    run_kwargs = _run_kwargs(max_turns,
-                             _conversation_group_id(model_name, managed,
-                                                    conversation))
+                          temperature, top_p, doc_ids=doc_id,
+                          cache_key=_conversation_cache_key(model_name, managed,
+                                                            conversation))
+    run_kwargs = _run_kwargs(max_turns)
     recorded: dict = {}
     import openai
     from agents import Runner

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -252,7 +252,7 @@ def _openai_model(protocol: str, model_name: str):
     except ImportError:
         raise PageIndexAPIError(
             f"'{model_name}' routes through LiteLLM, but litellm is not "
-            "installed. Run:  pip install 'litellm>=1.30'"
+            "installed. Run:  pip install 'litellm>=1.84'"
         )
     wire = model_name.removeprefix("litellm/")
     if "/" not in wire or wire.startswith("openai/"):
@@ -336,7 +336,7 @@ def _validate_max_turns(max_turns) -> None:
 
 def _conversation_cache_key(model_name: str, instructions: str, items) -> str:
     """Stable per-conversation cache-routing key, sent as the OpenAI
-    ``prompt_cache_key`` through ModelSettings.extra_args (openai-agents
+    ``prompt_cache_key`` through ModelSettings.extra_body (openai-agents
     0.20 no longer derives it from RunConfig.group_id — verified against a
     captured wire). Keyed on the prefix identity — model, instructions,
     first conversation item — so a conversation's continuations share one

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -305,7 +305,8 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
 
 
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
-                  temperature, top_p, doc_ids=None, cache_key=None):
+                  temperature, top_p, doc_ids=None, cache_key=None,
+                  reasoning=None, reasoning_effort=None):
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
     # ModelSettings.extra_body is the one channel all three engines put on
@@ -315,6 +316,13 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
     # other providers' request bodies, which Anthropic rejects as unknown.
     wire = model_name.removeprefix("litellm/")
     openai_backend = "/" not in wire or wire.startswith("openai/")
+    # Chat-lane effort rides extra_args: LiteLLM takes it as its own
+    # top-level kwarg on every supported openai-agents version, and the
+    # channel admits values outside the OpenAI enum ("none").
+    extra_args = _cache_extra_args(model_name)
+    if reasoning_effort is not None:
+        extra_args = {**(extra_args or {}),
+                      "reasoning_effort": reasoning_effort}
     return Agent(
         name="PageIndex",
         instructions=instructions,
@@ -322,9 +330,10 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
         model=_openai_model(protocol, model_name),
         model_settings=ModelSettings(
             temperature=temperature, top_p=top_p,
+            reasoning=reasoning,
             extra_body=({"prompt_cache_key": cache_key}
                         if cache_key and openai_backend else None),
-            extra_args=_cache_extra_args(model_name)),
+            extra_args=extra_args),
     )
 
 
@@ -358,7 +367,8 @@ def _model_backend_error(exc) -> PageIndexAPIError:
     if "Function tools with reasoning_effort" in str(exc):
         message += (
             " — this model runs tools on the Responses lane: upgrade "
-            "litellm (newer releases route it there automatically) or "
+            "litellm (newer releases route it there automatically), pass "
+            "reasoning_effort (older litellm routes explicit efforts), or "
             "call responses() instead."
         )
     return PageIndexAPIError(message)
@@ -466,6 +476,7 @@ def run_chat_completions(client, messages, stream: bool = False,
                          enable_citations: bool = False,
                          model: Optional[str] = None,
                          max_turns: Optional[int] = None,
+                         reasoning_effort: Optional[str] = None,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
@@ -483,7 +494,8 @@ def run_chat_completions(client, messages, stream: bool = False,
     agent = _openai_agent(client, "chat", model_name, managed,
                           temperature, None, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name,
-                                                            managed, history))
+                                                            managed, history),
+                          reasoning_effort=reasoning_effort)
     run_kwargs = _run_kwargs(max_turns)
     import openai
     from agents import Runner
@@ -570,6 +582,7 @@ def run_responses(client, input, model: Optional[str] = None,
                   temperature: Optional[float] = None,
                   top_p: Optional[float] = None,
                   max_turns: Optional[int] = None,
+                  reasoning: Optional[dict] = None,
                   ) -> Union[dict, Iterator[dict]]:
     _require_openai_agents("responses")
     _validate_max_turns(max_turns)
@@ -591,7 +604,8 @@ def run_responses(client, input, model: Optional[str] = None,
     agent = _openai_agent(client, "responses", model_name, managed,
                           temperature, top_p, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name, managed,
-                                                            conversation))
+                                                            conversation),
+                          reasoning=reasoning)
     run_kwargs = _run_kwargs(max_turns)
     recorded: dict = {}
     import openai
@@ -619,6 +633,7 @@ def run_responses(client, input, model: Optional[str] = None,
             "parallel_tool_calls": True,
             "temperature": temperature,
             "top_p": top_p,
+            "reasoning": reasoning,
             "max_output_tokens": None,
             "error": recorded.get("error"),
             "incomplete_details": recorded.get("incomplete_details"),
@@ -801,6 +816,7 @@ def run_messages(client, messages, model: str,
                  top_k: Optional[int] = None,
                  stop_sequences: Optional[list[str]] = None,
                  max_turns: Optional[int] = None,
+                 thinking: Optional[dict] = None,
                  ) -> Union[dict, Iterator[Any]]:
     from .integrations.anthropic_sdk import build_anthropic_tools
 
@@ -817,7 +833,7 @@ def run_messages(client, messages, model: str,
     prepared = [dict(message) for message in messages]
     passthrough = {key: value for key, value in {
         "temperature": temperature, "top_p": top_p, "top_k": top_k,
-        "stop_sequences": stop_sequences,
+        "stop_sequences": stop_sequences, "thinking": thinking,
     }.items() if value is not None}
     runner = _anthropic_client().beta.messages.tool_runner(
         max_tokens=(max_tokens if max_tokens is not None

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -306,7 +306,7 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
 
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
                   temperature, top_p, doc_ids=None, cache_key=None,
-                  reasoning=None, reasoning_effort=None):
+                  reasoning=None, reasoning_effort=None, extra_body=None):
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
     # ModelSettings.extra_body is the one channel all three engines put on
@@ -323,6 +323,15 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
     if reasoning_effort is not None:
         extra_args = {**(extra_args or {}),
                       "reasoning_effort": reasoning_effort}
+    body = ({"prompt_cache_key": cache_key}
+            if cache_key and openai_backend else None)
+    # Caller extras merge last, so they win over ours; non-OpenAI
+    # destinations take them as LiteLLM kwargs instead (see note above).
+    if extra_body:
+        if openai_backend:
+            body = {**(body or {}), **extra_body}
+        else:
+            extra_args = {**(extra_args or {}), **extra_body}
     return Agent(
         name="PageIndex",
         instructions=instructions,
@@ -331,8 +340,7 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
         model_settings=ModelSettings(
             temperature=temperature, top_p=top_p,
             reasoning=reasoning,
-            extra_body=({"prompt_cache_key": cache_key}
-                        if cache_key and openai_backend else None),
+            extra_body=body,
             extra_args=extra_args),
     )
 
@@ -477,6 +485,7 @@ def run_chat_completions(client, messages, stream: bool = False,
                          model: Optional[str] = None,
                          max_turns: Optional[int] = None,
                          reasoning_effort: Optional[str] = None,
+                         extra_body: Optional[dict] = None,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
@@ -495,7 +504,8 @@ def run_chat_completions(client, messages, stream: bool = False,
                           temperature, None, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name,
                                                             managed, history),
-                          reasoning_effort=reasoning_effort)
+                          reasoning_effort=reasoning_effort,
+                          extra_body=extra_body)
     run_kwargs = _run_kwargs(max_turns)
     import openai
     from agents import Runner
@@ -583,6 +593,7 @@ def run_responses(client, input, model: Optional[str] = None,
                   top_p: Optional[float] = None,
                   max_turns: Optional[int] = None,
                   reasoning: Optional[dict] = None,
+                  extra_body: Optional[dict] = None,
                   ) -> Union[dict, Iterator[dict]]:
     _require_openai_agents("responses")
     _validate_max_turns(max_turns)
@@ -605,7 +616,7 @@ def run_responses(client, input, model: Optional[str] = None,
                           temperature, top_p, doc_ids=doc_id,
                           cache_key=_conversation_cache_key(model_name, managed,
                                                             conversation),
-                          reasoning=reasoning)
+                          reasoning=reasoning, extra_body=extra_body)
     run_kwargs = _run_kwargs(max_turns)
     recorded: dict = {}
     import openai
@@ -817,6 +828,7 @@ def run_messages(client, messages, model: str,
                  stop_sequences: Optional[list[str]] = None,
                  max_turns: Optional[int] = None,
                  thinking: Optional[dict] = None,
+                 extra_body: Optional[dict] = None,
                  ) -> Union[dict, Iterator[Any]]:
     from .integrations.anthropic_sdk import build_anthropic_tools
 
@@ -834,6 +846,7 @@ def run_messages(client, messages, model: str,
     passthrough = {key: value for key, value in {
         "temperature": temperature, "top_p": top_p, "top_k": top_k,
         "stop_sequences": stop_sequences, "thinking": thinking,
+        "extra_body": extra_body,
     }.items() if value is not None}
     runner = _anthropic_client().beta.messages.tool_runner(
         max_tokens=(max_tokens if max_tokens is not None

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -955,7 +955,7 @@ def page_level_thinning(structure, thinning_threshold_node_num=20, min_pages_for
 
 
 DEFAULT_INDEX_MODEL = "gpt-5.6-luna"
-DEFAULT_CHAT_MODEL = "gpt-5.4"
+DEFAULT_CHAT_MODEL = "gpt-5.6-sol"
 
 # Every model name any released generation shipped: 0.2.8 (model),
 # 0.3.0.dev (model, retrieve_model), 0.2.10.dev (model, summary_model,

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -954,6 +954,31 @@ def page_level_thinning(structure, thinning_threshold_node_num=20, min_pages_for
     return structure
 
 
+DEFAULT_INDEX_MODEL = "gpt-5.6-luna"
+DEFAULT_CHAT_MODEL = "gpt-5.4"
+
+# Every model name any released generation shipped: 0.2.8 (model),
+# 0.3.0.dev (model, retrieve_model), 0.2.10.dev (model, summary_model,
+# retrieve_model), plus the current pair (index_model, chat_model).
+_MODEL_KEYS = ("model", "summary_model", "retrieve_model",
+               "index_model", "chat_model")
+
+
+def _resolve_models(merged: dict) -> None:
+    """Fill the model roles from whichever names were given: new names win
+    over old, specific over general, ``model`` sets every role, and the
+    built-in defaults close each chain. Idempotent, so already-resolved
+    config objects can round-trip through load()."""
+    given = {key: merged.get(key) for key in _MODEL_KEYS}
+    index = given["index_model"] or given["model"] or DEFAULT_INDEX_MODEL
+    summary = (given["summary_model"] or given["index_model"]
+               or given["model"] or DEFAULT_INDEX_MODEL)
+    chat = (given["chat_model"] or given["retrieve_model"]
+            or given["model"] or DEFAULT_CHAT_MODEL)
+    merged.update(model=index, index_model=index, summary_model=summary,
+                  chat_model=chat, retrieve_model=chat)
+
+
 class ConfigLoader:
     def __init__(self, default_path: str = None):
         if default_path is None:
@@ -966,7 +991,8 @@ class ConfigLoader:
             return yaml.safe_load(f) or {}
 
     def _validate_keys(self, user_dict):
-        unknown_keys = set(user_dict) - set(self._default_dict)
+        unknown_keys = (set(user_dict) - set(self._default_dict)
+                        - set(_MODEL_KEYS))
         if unknown_keys:
             raise ValueError(f"Unknown config keys: {unknown_keys}")
 
@@ -985,6 +1011,7 @@ class ConfigLoader:
 
         self._validate_keys(user_dict)
         merged = {**self._default_dict, **user_dict}
+        _resolve_models(merged)
         return config(**merged)
 
 def create_node_mapping(tree, include_page_ranges=False, max_page=None):

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -957,9 +957,7 @@ def page_level_thinning(structure, thinning_threshold_node_num=20, min_pages_for
 DEFAULT_INDEX_MODEL = "gpt-5.6-luna"
 DEFAULT_CHAT_MODEL = "gpt-5.6-sol"
 
-# Every model name any released generation shipped: 0.2.8 (model),
-# 0.3.0.dev (model, retrieve_model), 0.2.10.dev (model, summary_model,
-# retrieve_model), plus the current pair (index_model, chat_model).
+# Each of the five names has shipped in a release; all stay accepted.
 _MODEL_KEYS = ("model", "summary_model", "retrieve_model",
                "index_model", "chat_model")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requests = ">=2.28.0"
 openai = ">=1.70.0"
 # Older releases crash on current openai before the request is sent.
 openai-agents = ">=0.18.1"
-litellm = ">=1.84.0"
+litellm = ">=1.97.0"
 PyPDF2 = ">=3.0.0"
 pypdfium2 = ">=4.30.0"
 sortedcontainers = ">=2.4.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-litellm==1.84.0
+litellm==1.97.0
 openai>=1.70.0
 requests>=2.28.0
 openai-agents>=0.18.1

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -23,9 +23,12 @@ if __name__ == "__main__":
                       help='Refine the tree for search cost (default: full in flash mode). '
                            '`merge` for deterministic merge only; `off` to disable')
 
-    parser.add_argument('--model', type=str, default=None, help='Model to use (overrides config.yaml)')
+    parser.add_argument('--index-model', type=str, default=None,
+                      help='Model used to index the document (overrides config.yaml)')
+    parser.add_argument('--model', type=str, default=None,
+                      help='(legacy) Same as --index-model')
     parser.add_argument('--summary-model', type=str, default=None,
-                      help='Model for node summaries (defaults to --model, then config.yaml)')
+                      help='Model for node summaries (defaults to --index-model, then --model, then config.yaml)')
 
     parser.add_argument('--toc-check-pages', type=int, default=None,
                       help='Number of pages to check for table of contents (PDF only)')
@@ -87,7 +90,7 @@ if __name__ == "__main__":
             
         if args.mode == 'flash':
             from pageindex.flash import page_index_flash
-            summary_model = args.summary_model or args.model
+            summary_model = args.summary_model or args.index_model or args.model
             will_summarize = args.summary if args.summary is not None else True
             if summary_model and (will_summarize or args.optimize == 'full'):
                 import litellm
@@ -112,7 +115,9 @@ if __name__ == "__main__":
         else:
             # Process PDF file
             user_opt = {
+                'index_model': args.index_model,
                 'model': args.model,
+                'summary_model': args.summary_model,
                 'toc_check_page_num': args.toc_check_pages,
                 'max_page_num_each_node': args.max_pages_per_node,
                 'max_token_num_each_node': args.max_tokens_per_node,
@@ -157,6 +162,7 @@ if __name__ == "__main__":
         
         # Create options dict with user args
         user_opt = {
+            'index_model': args.index_model,
             'model': args.model,
             'if_add_node_summary': args.if_add_node_summary,
             'if_add_doc_description': args.if_add_doc_description,

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -754,6 +754,16 @@ def test_openai_agent_config_local(client, store_path):
     assert Agent(**client.openai_agent_config()).name == "PageIndex"
 
 
+def test_openai_agent_config_model_speaks_the_agents_sdk_grammar(tmp_path):
+    """The bundle's model string is resolved by the Agents SDK's own
+    prefix grammar, which refuses unknown prefixes — the constructor's
+    normalized litellm/ spelling is what must reach this door."""
+    client = PageIndexLocalClient(storage_path=str(tmp_path / "s"),
+                                  retrieve_model="anthropic/claude-x")
+    assert (client.openai_agent_config()["model"]
+            == "litellm/anthropic/claude-x")
+
+
 def test_openai_agent_config_cloud_omits_model(cloud_with_fake_bridge):
     pytest.importorskip("agents")
     cloud, _ = cloud_with_fake_bridge

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -758,6 +758,7 @@ def test_openai_agent_config_model_speaks_the_agents_sdk_grammar(tmp_path):
     """The bundle's model string is resolved by the Agents SDK's own
     prefix grammar, which refuses unknown prefixes — the constructor's
     normalized litellm/ spelling is what must reach this door."""
+    pytest.importorskip("agents")
     client = PageIndexLocalClient(storage_path=str(tmp_path / "s"),
                                   retrieve_model="anthropic/claude-x")
     assert (client.openai_agent_config()["model"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,6 +78,32 @@ def test_retrieve_model_carries_agents_sdk_prefix(tmp_path):
         assert resolved(already_routable) == already_routable
 
 
+def test_model_resolution_covers_every_generation(tmp_path):
+    """New names win over old, specific over general, ``model`` sets every
+    role, and the built-in defaults close each chain. One row per released
+    surface: 0.2.8 (model only), 0.3.0.dev (model + retrieve_model),
+    0.2.10.dev (all three legacy names), the current pair, plus the
+    umbrella and mixed forms."""
+    from pageindex.utils import DEFAULT_CHAT_MODEL, DEFAULT_INDEX_MODEL
+    cases = [
+        ({}, DEFAULT_INDEX_MODEL, DEFAULT_INDEX_MODEL, DEFAULT_CHAT_MODEL),
+        ({"model": "m"}, "m", "m", "m"),
+        ({"model": "m", "retrieve_model": "r"}, "m", "m", "r"),
+        ({"model": "m", "summary_model": "s", "retrieve_model": "r"},
+         "m", "s", "r"),
+        ({"index_model": "i", "chat_model": "c"}, "i", "i", "c"),
+        ({"model": "m", "index_model": "i"}, "i", "i", "m"),
+        ({"summary_model": "s"},
+         DEFAULT_INDEX_MODEL, "s", DEFAULT_CHAT_MODEL),
+    ]
+    for kwargs, index, summary, chat in cases:
+        client = PageIndexClient(storage_path=str(tmp_path / "s"), **kwargs)
+        assert (client.index_model, client.model) == (index, index), kwargs
+        assert client.summary_model == summary, kwargs
+        assert client.chat_model == chat, kwargs
+        assert client.retrieve_model == client.chat_model, kwargs
+
+
 def test_explicit_mode_clients(tmp_path):
     from pageindex import PageIndexCloudClient, PageIndexLocalClient
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -354,6 +354,9 @@ def test_cache_marker_reaches_the_anthropic_wire(client, store_path,
         "hi", model="anthropic/claude-3-5-sonnet-20240620")
     assert "/v1/messages" in captured["url"]
     assert '"cache_control"' in json.dumps(captured["body"])
+    # The OpenAI cache-routing hint must not leak here: LiteLLM plants
+    # extra_body as a literal field, and Anthropic rejects unknown fields.
+    assert "extra_body" not in json.dumps(captured["body"])
     assert result["choices"][0]["message"]["content"] == "ok"
 
 
@@ -478,13 +481,14 @@ def test_doc_id_conversations_get_distinct_cache_keys(client, store_path,
     under one prompt_cache_key."""
     seed_doc(store_path, "pi-a", "report.pdf")
     keys = []
-    real = local_chat._run_kwargs
+    real = local_chat._conversation_cache_key
 
-    def spy(max_turns, group_id):
-        keys.append(group_id)
-        return real(max_turns, group_id)
+    def spy(model_name, instructions, items):
+        key = real(model_name, instructions, items)
+        keys.append(key)
+        return key
 
-    monkeypatch.setattr(local_chat, "_run_kwargs", spy)
+    monkeypatch.setattr(local_chat, "_conversation_cache_key", spy)
 
     fake_model([[_msg_item("a")]])
     result = client.responses("What is the CAGR?", doc_id="pi-a")
@@ -831,26 +835,58 @@ def test_responses_envelope_fields_and_cache_group(client, store_path,
     assert result["tool_choice"] == "auto"
 
 
-def test_conversation_group_id_stable_per_conversation():
-    """Cache-routing key: openai-agents hashes group_id into the OpenAI
-    prompt_cache_key. A conversation's continuations must share one key
-    (same model/instructions/first item), and unrelated conversations must
-    not pool under it."""
+def test_sol_class_refusal_names_its_exits():
+    """The chatcmpl+tools-while-reasoning 400 is a lane problem, not a
+    retry problem — the wrapped error must name both exits."""
+    err = local_chat._model_backend_error(Exception(
+        "Error code: 400 - Function tools with reasoning_effort are not "
+        "supported for gpt-5.6-sol in /v1/chat/completions."))
+    assert "responses()" in str(err) and "litellm" in str(err)
+    plain = local_chat._model_backend_error(Exception("rate limited"))
+    assert "responses()" not in str(plain)
+
+
+def test_conversation_cache_key_stable_per_conversation():
+    """Cache-routing key, sent as the OpenAI prompt_cache_key. A
+    conversation's continuations must share one key (same model /
+    instructions / first item), and unrelated conversations must not pool
+    under it."""
     turn1 = [{"role": "user", "content": "q"}]
     continuation = turn1 + [{"role": "assistant", "content": "a"},
                             {"role": "user", "content": "and?"}]
-    key = local_chat._conversation_group_id("m", "sys", turn1)
-    assert key == local_chat._conversation_group_id("m", "sys", continuation)
-    assert key != local_chat._conversation_group_id(
+    key = local_chat._conversation_cache_key("m", "sys", turn1)
+    assert key == local_chat._conversation_cache_key("m", "sys", continuation)
+    assert key != local_chat._conversation_cache_key(
         "m", "sys", [{"role": "user", "content": "other"}])
-    assert key != local_chat._conversation_group_id("m2", "sys", turn1)
-    assert key != local_chat._conversation_group_id("m", "sys2", turn1)
+    assert key != local_chat._conversation_cache_key("m2", "sys", turn1)
+    assert key != local_chat._conversation_cache_key("m", "sys2", turn1)
 
 
 @needs_agents
-def test_run_kwargs_sets_conversation_group_id():
-    key = "pageindex-test"
-    assert (local_chat._run_kwargs(None, key)["run_config"].group_id == key)
+def test_agent_carries_prompt_cache_key_in_extra_args(monkeypatch):
+    """The key must reach the wire: openai-agents 0.20 dropped the
+    RunConfig.group_id -> prompt_cache_key derivation, so the agent's
+    ModelSettings.extra_body is the delivery channel. OpenAI destinations
+    only — prompt_cache_key is OpenAI's routing hint, and LiteLLM plants
+    extra_body as a literal field in other providers' bodies (Anthropic
+    rejects unknown fields); Claude routes keep their cache_control marker
+    in extra_args instead."""
+    monkeypatch.setattr(local_chat, "_openai_model", lambda *a: None)
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(
+        None, "chat", "anthropic/claude-x", "sys", None, None,
+        doc_ids=None, cache_key="pageindex-k1")
+    settings = agent.model_settings
+    assert settings.extra_body is None
+    assert "cache_control_injection_points" in settings.extra_args
+    for name in ("gpt-test", "openai/gpt-test", "litellm/openai/gpt-test"):
+        agent = local_chat._openai_agent(
+            None, "chat", name, "sys", None, None,
+            doc_ids=None, cache_key="pageindex-k2")
+        assert agent.model_settings.extra_body == {
+            "prompt_cache_key": "pageindex-k2"}, name
+        assert agent.model_settings.extra_args is None
 
 
 @needs_agents
@@ -902,8 +938,9 @@ def test_empty_doc_id_is_an_empty_allowlist(client, store_path, fake_model):
 
 @needs_agents
 def test_openai_model_resolves_provider_prefixes():
-    """retrieve_model arrives normalized (litellm/<provider>/<model>); the
-    OpenAI SDK must never see that prefix as a wire model name."""
+    """The chat lane routes everything through LiteLLM — bare names as the
+    openai/ shorthand, routing prefixes never leak as wire model names.
+    openai/ opts out to the OpenAI SDK; responses stays OpenAI-SDK native."""
     pytest.importorskip("litellm")
     from agents.extensions.models.litellm_model import LitellmModel
     from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
@@ -913,6 +950,8 @@ def test_openai_model_resolves_provider_prefixes():
     assert isinstance(model, LitellmModel) and model.model == "anthropic/claude-x"
     model = local_chat._openai_model("chat", "anthropic/claude-x")
     assert isinstance(model, LitellmModel) and model.model == "anthropic/claude-x"
+    model = local_chat._openai_model("chat", "gpt-5.2")
+    assert isinstance(model, LitellmModel) and model.model == "openai/gpt-5.2"
     model = local_chat._openai_model("chat", "openai/gpt-5.2")
     assert isinstance(model, OpenAIChatCompletionsModel)
     assert str(model.model) == "gpt-5.2"

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -863,7 +863,7 @@ def test_conversation_cache_key_stable_per_conversation():
 
 
 @needs_agents
-def test_agent_carries_prompt_cache_key_in_extra_args(monkeypatch):
+def test_agent_carries_prompt_cache_key_in_extra_body(monkeypatch):
     """The key must reach the wire: openai-agents 0.20 dropped the
     RunConfig.group_id -> prompt_cache_key derivation, so the agent's
     ModelSettings.extra_body is the delivery channel. OpenAI destinations

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -938,12 +938,12 @@ def test_empty_doc_id_is_an_empty_allowlist(client, store_path, fake_model):
 
 @needs_agents
 def test_openai_model_resolves_provider_prefixes():
-    """The chat lane routes everything through LiteLLM — bare names as the
-    openai/ shorthand, routing prefixes never leak as wire model names.
-    openai/ opts out to the OpenAI SDK; responses stays OpenAI-SDK native."""
+    """The chat lane is LiteLLM, full stop — model names mean what LiteLLM
+    says they mean, bare names are the openai/ shorthand, and routing
+    prefixes never leak as wire model names. responses stays OpenAI-SDK
+    native."""
     pytest.importorskip("litellm")
     from agents.extensions.models.litellm_model import LitellmModel
-    from agents.models.openai_chatcompletions import OpenAIChatCompletionsModel
     from agents.models.openai_responses import OpenAIResponsesModel
 
     model = local_chat._openai_model("chat", "litellm/anthropic/claude-x")
@@ -953,9 +953,11 @@ def test_openai_model_resolves_provider_prefixes():
     model = local_chat._openai_model("chat", "gpt-5.2")
     assert isinstance(model, LitellmModel) and model.model == "openai/gpt-5.2"
     model = local_chat._openai_model("chat", "openai/gpt-5.2")
-    assert isinstance(model, OpenAIChatCompletionsModel)
-    assert str(model.model) == "gpt-5.2"
+    assert isinstance(model, LitellmModel) and model.model == "openai/gpt-5.2"
     model = local_chat._openai_model("responses", "gpt-5.2")
+    assert isinstance(model, OpenAIResponsesModel)
+    assert str(model.model) == "gpt-5.2"
+    model = local_chat._openai_model("responses", "openai/gpt-5.2")
     assert isinstance(model, OpenAIResponsesModel)
     assert str(model.model) == "gpt-5.2"
 
@@ -1021,8 +1023,9 @@ def test_chat_missing_openai_key_fails_loud(monkeypatch):
     """A missing backend credential surfaces as the SDK's own error type,
     like every other precondition on the chat surfaces."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with pytest.raises(PageIndexAPIError, match="OPENAI_API_KEY"):
-        local_chat._openai_model("chat", "gpt-4o")
+    for name in ("gpt-4o", "openai/gpt-4o"):
+        with pytest.raises(PageIndexAPIError, match="OPENAI_API_KEY"):
+            local_chat._openai_model("chat", name)
 
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -274,6 +274,9 @@ def test_cloud_guards():
     with pytest.raises(PageIndexAPIError, match="local-mode"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                reasoning_effort="low")
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               extra_body={"service_tier": "auto"})
     with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
                                                 "cloud yet"):
         cloud.responses("x")
@@ -929,6 +932,36 @@ def test_reasoning_passthrough_reaches_each_engine(monkeypatch):
 
 
 @needs_agents
+def test_extra_body_passthrough_reaches_each_engine(monkeypatch):
+    """Caller extras merge last — over the cache key on OpenAI
+    destinations — and ride LiteLLM's own kwargs elsewhere, where
+    extra_body would plant literal fields providers reject."""
+    pytest.importorskip("litellm")
+    monkeypatch.setattr(local_chat, "_openai_model", lambda *a: None)
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None, cache_key="pageindex-k",
+                                     extra_body={"logit_bias": {"1": 5},
+                                                 "prompt_cache_key": "mine"})
+    assert agent.model_settings.extra_body == {
+        "prompt_cache_key": "mine", "logit_bias": {"1": 5}}
+    assert agent.model_settings.extra_args is None
+    agent = local_chat._openai_agent(None, "chat", "anthropic/claude-x",
+                                     "sys", None, None,
+                                     reasoning_effort="low",
+                                     extra_body={"top_k": 20})
+    assert agent.model_settings.extra_body is None
+    assert agent.model_settings.extra_args["top_k"] == 20
+    assert agent.model_settings.extra_args["reasoning_effort"] == "low"
+    assert "cache_control_injection_points" in agent.model_settings.extra_args
+    agent = local_chat._openai_agent(None, "responses", "gpt-test", "sys",
+                                     None, None,
+                                     extra_body={"service_tier": "flex"})
+    assert agent.model_settings.extra_body == {"service_tier": "flex"}
+
+
+@needs_agents
 def test_responses_envelope_echoes_reasoning(client, store_path, fake_model):
     seed_doc(store_path, "pi-a", "report.pdf")
     fake_model([[_msg_item("ok")]])
@@ -1366,6 +1399,21 @@ def test_messages_thinking_passes_through(client, fake_anthropic):
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
     client.messages("q", model="claude-sonnet-4-5")
     assert "thinking" not in calls[0]
+
+
+@needs_anthropic
+def test_messages_extra_body_merges_into_the_wire_body(client, fake_anthropic):
+    """The anthropic SDK merges extra_body keys into the request JSON —
+    asserted on the captured wire body, not the SDK call."""
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    client.messages("q", model="claude-sonnet-4-5",
+                    extra_body={"service_tier": "auto"})
+    assert calls[0]["service_tier"] == "auto"
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    client.messages("q", model="claude-sonnet-4-5")
+    assert "service_tier" not in calls[0]
 
 
 @needs_anthropic

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -271,6 +271,9 @@ def test_cloud_guards():
     cloud = PageIndexCloudClient(api_key="pi-test-key")
     with pytest.raises(PageIndexAPIError, match="local-mode parameters"):
         cloud.chat_completions([{"role": "user", "content": "x"}], model="m")
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               reasoning_effort="low")
     with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
                                                 "cloud yet"):
         cloud.responses("x")
@@ -837,11 +840,12 @@ def test_responses_envelope_fields_and_cache_group(client, store_path,
 
 def test_sol_class_refusal_names_its_exits():
     """The chatcmpl+tools-while-reasoning 400 is a lane problem, not a
-    retry problem — the wrapped error must name both exits."""
+    retry problem — the wrapped error must name every exit."""
     err = local_chat._model_backend_error(Exception(
         "Error code: 400 - Function tools with reasoning_effort are not "
         "supported for gpt-5.6-sol in /v1/chat/completions."))
     assert "responses()" in str(err) and "litellm" in str(err)
+    assert "pass reasoning_effort" in str(err)
     plain = local_chat._model_backend_error(Exception("rate limited"))
     assert "responses()" not in str(plain)
 
@@ -887,6 +891,51 @@ def test_agent_carries_prompt_cache_key_in_extra_body(monkeypatch):
         assert agent.model_settings.extra_body == {
             "prompt_cache_key": "pageindex-k2"}, name
         assert agent.model_settings.extra_args is None
+
+
+@needs_agents
+def test_reasoning_passthrough_reaches_each_engine(monkeypatch):
+    """Per-door native reasoning, forwarded verbatim. The chat door's
+    effort rides extra_args — LiteLLM's own top-level kwarg on every
+    supported openai-agents version, and the channel admits values outside
+    the OpenAI enum ("none") — coexisting with the Claude cache marker.
+    The responses door's object rides ModelSettings.reasoning, which the
+    Responses model forwards verbatim. Unset sends nothing."""
+    pytest.importorskip("litellm")
+    monkeypatch.setattr(local_chat, "_openai_model", lambda *a: None)
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None, reasoning_effort="low")
+    assert agent.model_settings.extra_args == {"reasoning_effort": "low"}
+    assert agent.model_settings.reasoning is None
+    agent = local_chat._openai_agent(None, "chat", "anthropic/claude-x",
+                                     "sys", None, None,
+                                     reasoning_effort="none")
+    assert agent.model_settings.extra_args["reasoning_effort"] == "none"
+    assert "cache_control_injection_points" in agent.model_settings.extra_args
+    agent = local_chat._openai_agent(None, "responses", "gpt-test", "sys",
+                                     None, None,
+                                     reasoning={"effort": "low",
+                                                "summary": "auto"})
+    # ModelSettings coerces the dict into the typed openai Reasoning object.
+    assert agent.model_settings.reasoning.effort == "low"
+    assert agent.model_settings.reasoning.summary == "auto"
+    assert agent.model_settings.extra_args is None
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None)
+    assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args is None
+
+
+@needs_agents
+def test_responses_envelope_echoes_reasoning(client, store_path, fake_model):
+    seed_doc(store_path, "pi-a", "report.pdf")
+    fake_model([[_msg_item("ok")]])
+    result = client.responses("q", reasoning={"effort": "low"})
+    assert result["reasoning"] == {"effort": "low"}
+    fake_model([[_msg_item("ok")]])
+    assert client.responses("q")["reasoning"] is None
 
 
 @needs_agents
@@ -1302,6 +1351,21 @@ def test_messages_max_tokens_default_resolves_per_model(client, fake_anthropic):
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
     client.messages("q", model="claude-3-opus-20240229", max_tokens=1234)
     assert calls[0]["max_tokens"] == 1234
+
+
+@needs_anthropic
+def test_messages_thinking_passes_through(client, fake_anthropic):
+    """Anthropic-native thinking config, forwarded verbatim; unset sends
+    nothing so the backend default applies."""
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    client.messages("q", model="claude-sonnet-4-5",
+                    thinking={"type": "adaptive"})
+    assert calls[0]["thinking"] == {"type": "adaptive"}
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    client.messages("q", model="claude-sonnet-4-5")
+    assert "thinking" not in calls[0]
 
 
 @needs_anthropic

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -277,6 +277,11 @@ def test_cloud_guards():
     with pytest.raises(PageIndexAPIError, match="local-mode"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                extra_body={"service_tier": "auto"})
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}], top_p=0.9)
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               max_tokens=256)
     with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
                                                 "cloud yet"):
         cloud.responses("x")
@@ -959,6 +964,35 @@ def test_extra_body_passthrough_reaches_each_engine(monkeypatch):
                                      None, None,
                                      extra_body={"service_tier": "flex"})
     assert agent.model_settings.extra_body == {"service_tier": "flex"}
+
+
+@needs_agents
+def test_sampling_knobs_ride_model_settings(client, store_path, fake_model,
+                                            monkeypatch):
+    """top_p/max_tokens ride ModelSettings fields — the one channel clean
+    on every lane (extra_body collides with LitellmModel's explicit
+    kwargs). responses' max_output_tokens is the same field's wire name,
+    echoed in the envelope."""
+    seed_doc(store_path, "pi-a", "report.pdf")
+    seen = {}
+    real = local_chat._openai_agent
+
+    def spy(*args, **kwargs):
+        agent = real(*args, **kwargs)
+        seen[args[1]] = agent.model_settings
+        return agent
+
+    monkeypatch.setattr(local_chat, "_openai_agent", spy)
+    fake_model([[_msg_item("ok")]])
+    client.chat_completions("q", top_p=0.9, max_tokens=256)
+    assert seen["chat"].top_p == 0.9
+    assert seen["chat"].max_tokens == 256
+    fake_model([[_msg_item("ok")]])
+    result = client.responses("q", max_output_tokens=321)
+    assert seen["responses"].max_tokens == 321
+    assert result["max_output_tokens"] == 321
+    fake_model([[_msg_item("ok")]])
+    assert client.responses("q")["max_output_tokens"] is None
 
 
 @needs_agents


### PR DESCRIPTION
Ports the pending feat/local-chat work to main (16 commits; per-commit history stays on feat/local-chat, review record in #400).

**Model knobs.** The documented surface becomes `index_model` (indexing: structure + summaries) + `chat_model` (all chat doors), resolved in one seam (`ConfigLoader.load()`), with every released name still accepted: `model` sets both roles, `summary_model`/`retrieve_model` keep their specific roles. New names win over old, specific over general, and the packaged config.yaml ships no model keys, so key presence distinguishes user choice from built-in defaults (`gpt-5.6-luna` / `gpt-5.6-sol`). CLI leads with `--index-model` (`--model` stays as legacy synonym); the standard branch's silently-ignored `--summary-model` now works.

**Chat lane routing.** Every chat-lane model routes through LiteLLM — bare names are OpenAI-compatible shorthand, and no prefix triggers a direct lane; the model-name grammar is LiteLLM's, verbatim. `responses()` stays native.

**Per-door passthrough.** Protocol-native reasoning params, forwarded verbatim with no default of ours: `chat_completions(reasoning_effort=)`, `responses(reasoning={})`, `messages(thinking={})`. Named `top_p`/`max_tokens` on the chat door and `max_output_tokens` on responses (ModelSettings fields — the one channel clean on every lane; both caps bound each backend call in the loop, like max_turns bounds the loop). An `extra_body` escape hatch on all three doors for fields the methods don't name, merged last so caller keys win. Cloud rejects the local-only knobs explicitly.

**litellm floor 1.84 → 1.97.0** — the release whose bridge routes sol-class chatcmpl+tools calls onto /v1/responses automatically (A/B-verified against 1.96.2), so the default chat model works out of the box.

285 tests green; wire-level probes verified max_tokens translation on both LiteLLM paths (chatcmpl `max_completion_tokens`, bridge `max_output_tokens`), extra_body delivery per lane, and the anthropic runner spreading extra_body into every turn's request.