### PR TITLE
feat: backend connection overrides; extra_headers on every local door

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -87,6 +87,15 @@ class PageIndexClient:
             ``chat_model``.
         storage_path (str, optional): Local mode only — directory where
             indexed documents are stored. Defaults to ``./.pageindex``.
+        index_backend (dict, optional): Local mode only — connection
+            overrides for the indexing lane's LLM calls. Keys are
+            LiteLLM's own connection params — ``api_key``, ``api_base``,
+            ``api_version``, ``aws_*``, … — passed through verbatim.
+        chat_backend (dict, optional): Local mode only — default
+            connection overrides for the chat surfaces; a call's own
+            ``backend`` keys win over it. The dict reaches whichever
+            door runs, in that door's vocabulary (see each method) —
+            ``api_key`` / ``base_url`` mean the same thing on all three.
 
     Usage:
         client = PageIndexClient(api_key="...")   # cloud

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -113,6 +113,8 @@ class PageIndexClient:
         summary_model: Optional[str] = None,
         retrieve_model: Optional[str] = None,
         storage_path: Optional[str] = None,
+        index_backend: Optional[dict[str, Any]] = None,
+        chat_backend: Optional[dict[str, Any]] = None,
     ):
         if api_key == "":
             raise PageIndexAPIError(
@@ -123,7 +125,9 @@ class PageIndexClient:
                       "model": model, "summary_model": summary_model,
                       "retrieve_model": retrieve_model}
         if api_key is not None:
-            local_only = dict(model_args, storage_path=storage_path)
+            local_only = dict(model_args, storage_path=storage_path,
+                              index_backend=index_backend,
+                              chat_backend=chat_backend)
             passed = [name for name, value in local_only.items() if value is not None]
             if passed:
                 raise PageIndexAPIError(
@@ -143,6 +147,7 @@ class PageIndexClient:
             self.index_model = opt.index_model
             self.summary_model = opt.summary_model
             self.chat_model = _agents_sdk_model_name(opt.chat_model)
+            self.chat_backend = chat_backend
             self.storage_path = storage_path or ".pageindex"
             from .local_api import LocalAPI
             self._api = LocalAPI(
@@ -150,6 +155,7 @@ class PageIndexClient:
                 model=self.model,
                 summary_model=self.summary_model,
                 retrieve_model=self.chat_model,
+                index_backend=index_backend,
             )
             # LiteLLM's multi-second import would otherwise land on the
             # first chat call; failures resurface there with real context.
@@ -433,6 +439,8 @@ class PageIndexClient:
         max_tokens: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
         extra_body: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        backend: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[str], Iterator[dict[str, Any]]]:
         """
         PageIndex Chat Completions: document QA in one call.
@@ -490,6 +498,17 @@ class PageIndexClient:
                 OpenAI-compatible backends take them verbatim in the
                 request body; LiteLLM-routed providers take them as
                 LiteLLM's own params (mapped or refused per provider).
+                Credentials belong in ``backend``, never here.
+            extra_headers: Local only — extra HTTP headers merged into
+                each backend request; caller headers win. One exception:
+                LiteLLM's anthropic adapter owns the ``anthropic-beta``
+                header (your value is dropped there) — use ``messages()``
+                for Anthropic beta flags.
+            backend: Local only — connection overrides for this call's
+                backend, merged over the client's ``chat_backend``
+                (per-call keys win). Keys are LiteLLM's own connection
+                params — ``api_key``, ``base_url``, ``api_version``,
+                ``aws_*``, … — passed through verbatim.
 
         Returns:
             - stream=False: complete response dict ({'id', 'object', 'created',
@@ -512,14 +531,16 @@ class PageIndexClient:
                 enable_citations=enable_citations, model=model,
                 max_turns=max_turns, top_p=top_p, max_tokens=max_tokens,
                 reasoning_effort=reasoning_effort, extra_body=extra_body,
+                extra_headers=extra_headers, backend=backend,
             )
         if (model is not None or max_turns is not None or top_p is not None
                 or max_tokens is not None or reasoning_effort is not None
-                or extra_body is not None):
+                or extra_body is not None or extra_headers is not None
+                or backend is not None):
             raise PageIndexAPIError(
-                "model, max_turns, top_p, max_tokens, reasoning_effort and "
-                "extra_body are local-mode parameters — the cloud chat "
-                "endpoint selects its own model."
+                "model, max_turns, top_p, max_tokens, reasoning_effort, "
+                "extra_body, extra_headers and backend are local-mode "
+                "parameters — the cloud chat endpoint selects its own model."
             )
         return self._api.chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
@@ -540,6 +561,8 @@ class PageIndexClient:
         max_output_tokens: Optional[int] = None,
         reasoning: Optional[dict[str, Any]] = None,
         extra_body: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        backend: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
         """
         Document QA over the OpenAI Responses protocol — the agentic surface.
@@ -588,7 +611,15 @@ class PageIndexClient:
                 nothing (the backend's default applies).
             extra_body: Extra request fields beyond this method's
                 parameters, merged verbatim into the request body (last,
-                so they win).
+                so they win). Credentials belong in ``backend``, never
+                here.
+            extra_headers: Extra HTTP headers merged into each request;
+                caller headers win over defaults.
+            backend: Connection overrides for this call's backend client,
+                merged over the client's ``chat_backend`` (per-call keys
+                win). Keys are the openai SDK's client params —
+                ``api_key``, ``base_url``, ``organization``, … — passed
+                verbatim; unknown keys raise.
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -602,6 +633,7 @@ class PageIndexClient:
             instructions=instructions, temperature=temperature, top_p=top_p,
             max_turns=max_turns, max_output_tokens=max_output_tokens,
             reasoning=reasoning, extra_body=extra_body,
+            extra_headers=extra_headers, backend=backend,
         )
 
     def messages(
@@ -619,6 +651,8 @@ class PageIndexClient:
         max_turns: Optional[int] = None,
         thinking: Optional[dict[str, Any]] = None,
         extra_body: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        backend: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[Any]]:
         """
         Document QA over the Anthropic Messages protocol — Claude-native.
@@ -658,6 +692,15 @@ class PageIndexClient:
                 constraints are the backend's. Unset sends nothing.
             extra_body: Extra request fields beyond this method's
                 parameters, merged verbatim into each request body.
+                Credentials belong in ``backend``, never here.
+            extra_headers: Extra HTTP headers merged into each request
+                (e.g. ``anthropic-beta`` feature flags); caller headers
+                win over defaults.
+            backend: Connection overrides for this call's backend client,
+                merged over the client's ``chat_backend`` (per-call keys
+                win). Keys are the anthropic SDK's client params —
+                ``api_key``, ``base_url``, ``auth_token``, … — passed
+                verbatim; unknown keys raise.
         """
         from .cloud_api import CloudAPI
         if isinstance(self._api, CloudAPI):
@@ -672,6 +715,7 @@ class PageIndexClient:
             temperature=temperature, top_p=top_p, top_k=top_k,
             stop_sequences=stop_sequences, max_turns=max_turns,
             thinking=thinking, extra_body=extra_body,
+            extra_headers=extra_headers, backend=backend,
         )
 
     # ---------- DOCUMENT MANAGEMENT ----------
@@ -825,7 +869,9 @@ class PageIndexClient:
         ``as_openai_tools`` as the tools; local clients also carry their
         configured ``chat_model`` (cloud omits ``model`` so the
         framework default applies). To customize further, switch to
-        those methods directly.
+        those methods directly. You run this config in your own
+        environment, so its model auth comes from there —
+        ``chat_backend`` does not travel with it.
 
         Args:
             doc_id: Document ID or list of IDs to target, as in
@@ -1107,7 +1153,10 @@ class PageIndexLocalClient(PageIndexClient):
         summary_model: Optional[str] = None,
         retrieve_model: Optional[str] = None,
         storage_path: Optional[str] = None,
+        index_backend: Optional[dict[str, Any]] = None,
+        chat_backend: Optional[dict[str, Any]] = None,
     ):
         super().__init__(None, index_model=index_model, chat_model=chat_model,
                          model=model, summary_model=summary_model,
-                         retrieve_model=retrieve_model, storage_path=storage_path)
+                         retrieve_model=retrieve_model, storage_path=storage_path,
+                         index_backend=index_backend, chat_backend=chat_backend)

--- a/pageindex/local_api.py
+++ b/pageindex/local_api.py
@@ -35,13 +35,24 @@ class LocalAPI:
     """Backs PageIndexClient's local mode. One instance per client."""
 
     def __init__(self, storage_path: str, model: str, summary_model: str,
-                 retrieve_model: str):
+                 retrieve_model: str, index_backend: dict | None = None):
         self._store = DocStore(storage_path)
         self._model = model
         self._summary_model = summary_model
         self._retrieve_model = retrieve_model
+        self._index_backend = index_backend
         from .utils import ConfigLoader
         self._config_loader = ConfigLoader()
+
+    def _with_backend(self, func, *args):
+        """Scope the indexing lane's connection overrides around one
+        operation — runs inside whatever thread _run_indexer picked."""
+        from .utils import _llm_backend
+        token = _llm_backend.set(self._index_backend)
+        try:
+            return func(*args)
+        finally:
+            _llm_backend.reset(token)
 
     # ── indexing ──
 
@@ -104,11 +115,12 @@ class LocalAPI:
         try:
             if mode == "flash":
                 structure, description = _run_indexer(
-                    self._index_flash, file_path, page_texts
+                    self._with_backend, self._index_flash, file_path, page_texts
                 )
             else:
                 structure, description = _run_indexer(
-                    self._index_standard, file_path, page_texts
+                    self._with_backend, self._index_standard, file_path,
+                    page_texts
                 )
         except PageIndexAPIError:
             raise
@@ -183,11 +195,12 @@ class LocalAPI:
         from .utils import (add_node_text, create_clean_structure_for_description,
                             generate_doc_description, write_node_id)
         import litellm
-        env = litellm.validate_environment(self._summary_model)
-        if not env["keys_in_environment"]:
-            raise PageIndexAPIError(
-                f"Failed to submit document: missing API key for "
-                f"{self._summary_model}: {', '.join(env['missing_keys'])}")
+        if not self._index_backend:
+            env = litellm.validate_environment(self._summary_model)
+            if not env["keys_in_environment"]:
+                raise PageIndexAPIError(
+                    f"Failed to submit document: missing API key for "
+                    f"{self._summary_model}: {', '.join(env['missing_keys'])}")
         result = page_index_flash(file_path, summary=True,
                                   summary_model=self._summary_model,
                                   optimize="full",

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -212,7 +212,7 @@ def _require_openai_agents(method: str) -> None:
         ) from exc
 
 
-def _openai_model(protocol: str, model_name: str):
+def _openai_model(protocol: str, model_name: str, backend=None):
     """The backend protocol driver — the seam tests replace with a fake.
 
     chat protocol: LiteLLM, full stop — model names mean what LiteLLM says
@@ -240,12 +240,12 @@ def _openai_model(protocol: str, model_name: str):
         import openai
         model_name = model_name.removeprefix("openai/")
         try:
-            backend = openai.AsyncOpenAI()
-        except openai.OpenAIError as exc:
+            sdk_client = openai.AsyncOpenAI(**(backend or {}))
+        except (openai.OpenAIError, TypeError) as exc:
             raise PageIndexAPIError(
                 f"The OpenAI backend is not configured: {exc}") from exc
         from agents.models.openai_responses import OpenAIResponsesModel
-        return OpenAIResponsesModel(model_name, openai_client=backend)
+        return OpenAIResponsesModel(model_name, openai_client=sdk_client)
     try:
         from agents.extensions.models.litellm_model import LitellmModel
         import litellm
@@ -258,7 +258,8 @@ def _openai_model(protocol: str, model_name: str):
     _repair_litellm_types()
     wire = model_name.removeprefix("litellm/")
     if "/" not in wire or wire.startswith("openai/"):
-        if not os.environ.get("OPENAI_API_KEY"):
+        if (not os.environ.get("OPENAI_API_KEY")
+                and not (backend or {}).get("api_key")):
             raise PageIndexAPIError(
                 "The OpenAI backend is not configured: set the "
                 "OPENAI_API_KEY environment variable (any value works "
@@ -276,7 +277,8 @@ def _openai_model(protocol: str, model_name: str):
             f"model id, use 'openai/{wire}' and point OPENAI_BASE_URL "
             "at the server."
         )
-    return LitellmModel(wire)
+    return LitellmModel(wire, api_key=(backend or {}).get("api_key"),
+                        base_url=(backend or {}).get("base_url"))
 
 
 def _reported_model(model_name: str) -> str:
@@ -307,10 +309,18 @@ def _cache_extra_args(model_name: str) -> Optional[dict]:
     return None
 
 
+def _merged_backend(client, backend):
+    """This call's connection overrides: the client's ``chat_backend``
+    under the per-call dict, per-call keys winning."""
+    merged = {**(getattr(client, "chat_backend", None) or {}),
+              **(backend or {})}
+    return merged or None
+
+
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
                   temperature, top_p, doc_ids=None, cache_key=None,
                   reasoning=None, reasoning_effort=None, extra_body=None,
-                  max_tokens=None):
+                  max_tokens=None, backend=None, extra_headers=None):
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
     # ModelSettings.extra_body is the one channel all three engines put on
@@ -327,6 +337,16 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
     if reasoning_effort is not None:
         extra_args = {**(extra_args or {}),
                       "reasoning_effort": reasoning_effort}
+    conn = dict(backend) if backend else {}
+    if conn and protocol == "chat":
+        # LiteLLM takes connection params per call, except the two names
+        # LitellmModel pins as its own keywords — those ride its constructor.
+        lifted = {"api_key": conn.pop("api_key", None),
+                  "base_url": conn.pop("base_url", conn.pop("api_base", None))}
+        if conn:
+            extra_args = {**(extra_args or {}), **conn}
+        conn = {key: value for key, value in lifted.items()
+                if value is not None}
     body = ({"prompt_cache_key": cache_key}
             if cache_key and openai_backend else None)
     # Caller extras merge last, so they win over ours; non-OpenAI
@@ -340,11 +360,12 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
         name="PageIndex",
         instructions=instructions,
         tools=build_openai_tools(client, doc_ids=doc_ids),
-        model=_openai_model(protocol, model_name),
+        model=_openai_model(protocol, model_name, conn or None),
         model_settings=ModelSettings(
             temperature=temperature, top_p=top_p, max_tokens=max_tokens,
             reasoning=reasoning,
             extra_body=body,
+            extra_headers=extra_headers,
             extra_args=extra_args),
     )
 
@@ -492,6 +513,8 @@ def run_chat_completions(client, messages, stream: bool = False,
                          max_tokens: Optional[int] = None,
                          reasoning_effort: Optional[str] = None,
                          extra_body: Optional[dict] = None,
+                         extra_headers: Optional[dict] = None,
+                         backend: Optional[dict] = None,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
@@ -511,7 +534,9 @@ def run_chat_completions(client, messages, stream: bool = False,
                           cache_key=_conversation_cache_key(model_name,
                                                             managed, history),
                           reasoning_effort=reasoning_effort,
-                          extra_body=extra_body, max_tokens=max_tokens)
+                          extra_body=extra_body, max_tokens=max_tokens,
+                          backend=_merged_backend(client, backend),
+                          extra_headers=extra_headers)
     run_kwargs = _run_kwargs(max_turns)
     import openai
     from agents import Runner
@@ -601,6 +626,8 @@ def run_responses(client, input, model: Optional[str] = None,
                   max_output_tokens: Optional[int] = None,
                   reasoning: Optional[dict] = None,
                   extra_body: Optional[dict] = None,
+                  extra_headers: Optional[dict] = None,
+                  backend: Optional[dict] = None,
                   ) -> Union[dict, Iterator[dict]]:
     _require_openai_agents("responses")
     _validate_max_turns(max_turns)
@@ -624,7 +651,9 @@ def run_responses(client, input, model: Optional[str] = None,
                           cache_key=_conversation_cache_key(model_name, managed,
                                                             conversation),
                           reasoning=reasoning, extra_body=extra_body,
-                          max_tokens=max_output_tokens)
+                          max_tokens=max_output_tokens,
+                          backend=_merged_backend(client, backend),
+                          extra_headers=extra_headers)
     run_kwargs = _run_kwargs(max_turns)
     recorded: dict = {}
     import openai
@@ -759,10 +788,10 @@ def _require_anthropic() -> None:
         ) from exc
 
 
-def _anthropic_client():
+def _anthropic_client(backend=None):
     """The backend client — the seam tests replace with a fake transport."""
     import anthropic
-    return anthropic.Anthropic()
+    return anthropic.Anthropic(**(backend or {}))
 
 
 def _anthropic_system(extra_system, block: Optional[str]) -> list[dict]:
@@ -837,6 +866,8 @@ def run_messages(client, messages, model: str,
                  max_turns: Optional[int] = None,
                  thinking: Optional[dict] = None,
                  extra_body: Optional[dict] = None,
+                 extra_headers: Optional[dict] = None,
+                 backend: Optional[dict] = None,
                  ) -> Union[dict, Iterator[Any]]:
     from .integrations.anthropic_sdk import build_anthropic_tools
 
@@ -854,9 +885,10 @@ def run_messages(client, messages, model: str,
     passthrough = {key: value for key, value in {
         "temperature": temperature, "top_p": top_p, "top_k": top_k,
         "stop_sequences": stop_sequences, "thinking": thinking,
-        "extra_body": extra_body,
+        "extra_body": extra_body, "extra_headers": extra_headers,
     }.items() if value is not None}
-    runner = _anthropic_client().beta.messages.tool_runner(
+    runner = _anthropic_client(_merged_backend(client, backend)) \
+        .beta.messages.tool_runner(
         max_tokens=(max_tokens if max_tokens is not None
                     else _default_max_tokens(model)),
         messages=prepared,

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -262,8 +262,8 @@ def _openai_model(protocol: str, model_name: str, backend=None):
                 and not (backend or {}).get("api_key")):
             raise PageIndexAPIError(
                 "The OpenAI backend is not configured: set the "
-                "OPENAI_API_KEY environment variable or pass "
-                "backend={'api_key': ...} (any value works for keyless "
+                "OPENAI_API_KEY environment variable, pass an api_key "
+                "in chat_backend / backend (any value works for keyless "
                 "OPENAI_BASE_URL servers), or point chat_model at "
                 "another provider (e.g. 'anthropic/...')."
             )
@@ -794,7 +794,7 @@ def _anthropic_client(backend=None):
     import anthropic
     try:
         return anthropic.Anthropic(**(backend or {}))
-    except (anthropic.AnthropicError, TypeError) as exc:
+    except TypeError as exc:
         raise PageIndexAPIError(
             f"The Anthropic backend is not configured: {exc}") from exc
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -262,9 +262,10 @@ def _openai_model(protocol: str, model_name: str, backend=None):
                 and not (backend or {}).get("api_key")):
             raise PageIndexAPIError(
                 "The OpenAI backend is not configured: set the "
-                "OPENAI_API_KEY environment variable (any value works "
-                "for keyless OPENAI_BASE_URL servers), or point "
-                "chat_model at another provider (e.g. 'anthropic/...')."
+                "OPENAI_API_KEY environment variable or pass "
+                "backend={'api_key': ...} (any value works for keyless "
+                "OPENAI_BASE_URL servers), or point chat_model at "
+                "another provider (e.g. 'anthropic/...')."
             )
     if "/" not in wire:
         wire = f"openai/{wire}"
@@ -791,7 +792,11 @@ def _require_anthropic() -> None:
 def _anthropic_client(backend=None):
     """The backend client — the seam tests replace with a fake transport."""
     import anthropic
-    return anthropic.Anthropic(**(backend or {}))
+    try:
+        return anthropic.Anthropic(**(backend or {}))
+    except (anthropic.AnthropicError, TypeError) as exc:
+        raise PageIndexAPIError(
+            f"The Anthropic backend is not configured: {exc}") from exc
 
 
 def _anthropic_system(extra_system, block: Optional[str]) -> list[dict]:

--- a/pageindex/page_index_classic.py
+++ b/pageindex/page_index_classic.py
@@ -7,7 +7,6 @@ import re
 from .utils import *
 from .tree_optimize import merge_tree
 import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
 
 ######################### Hardening for prompt injection patterns ####################################################
 _INJECTION_PATTERNS = re.compile(

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -1,3 +1,4 @@
+import contextvars
 import logging
 import os
 import sys
@@ -19,6 +20,20 @@ import re
 
 # litellm is imported inside the functions that use it; eager import is slow
 # and fetches a remote model-cost map.
+
+
+# The indexing lane's connection overrides, scoped by LocalAPI around each
+# indexing operation — a contextvar, so the value reaches this module's
+# helpers and their asyncio tasks without threading it through every call.
+_llm_backend: contextvars.ContextVar = contextvars.ContextVar(
+    "pageindex_llm_backend", default=None)
+
+
+def _openai_sdk_kwargs(backend: dict) -> dict:
+    """The same backend dict works on both gateway paths: LiteLLM accepts
+    either endpoint spelling, the openai SDK only ``base_url``."""
+    return {("base_url" if key == "api_base" else key): value
+            for key, value in backend.items()}
 
 
 def _repair_litellm_types() -> None:
@@ -85,15 +100,21 @@ def llm_completion(model, prompt, chat_history=None, return_finish_reason=False)
             model = _strip_prefix(model, "openai/")
     max_retries = 10
     messages = list(chat_history) + [{"role": "user", "content": prompt}] if chat_history else [{"role": "user", "content": prompt}]
+    backend = _llm_backend.get()
     if use_openai_sdk:
-        global _openai_sync_client
-        if _openai_sync_client is None:
-            import openai
-            _openai_sync_client = openai.OpenAI(max_retries=0)
+        import openai
+        if backend:
+            oai_client = openai.OpenAI(**{"max_retries": 0,
+                                          **_openai_sdk_kwargs(backend)})
+        else:
+            global _openai_sync_client
+            if _openai_sync_client is None:
+                _openai_sync_client = openai.OpenAI(max_retries=0)
+            oai_client = _openai_sync_client
     for i in range(max_retries):
         try:
             if use_openai_sdk:
-                response = _openai_sync_client.chat.completions.create(
+                response = oai_client.chat.completions.create(
                     model=model,
                     messages=messages,
                 )
@@ -105,6 +126,7 @@ def llm_completion(model, prompt, chat_history=None, return_finish_reason=False)
                     messages=messages,
                     temperature=0,
                     drop_params=True,
+                    **(backend or {}),
                 )
             content = response.choices[0].message.content
             if return_finish_reason:
@@ -132,15 +154,21 @@ async def llm_acompletion(model, prompt):
             model = _strip_prefix(model, "openai/")
     max_retries = 10
     messages = [{"role": "user", "content": prompt}]
+    backend = _llm_backend.get()
     if use_openai_sdk:
-        global _openai_async_client
-        if _openai_async_client is None:
-            import openai
-            _openai_async_client = openai.AsyncOpenAI(max_retries=0)
+        import openai
+        if backend:
+            oai_client = openai.AsyncOpenAI(**{"max_retries": 0,
+                                               **_openai_sdk_kwargs(backend)})
+        else:
+            global _openai_async_client
+            if _openai_async_client is None:
+                _openai_async_client = openai.AsyncOpenAI(max_retries=0)
+            oai_client = _openai_async_client
     for i in range(max_retries):
         try:
             if use_openai_sdk:
-                response = await _openai_async_client.chat.completions.create(
+                response = await oai_client.chat.completions.create(
                     model=model,
                     messages=messages,
                 )
@@ -152,6 +180,7 @@ async def llm_acompletion(model, prompt):
                     messages=messages,
                     temperature=0,
                     drop_params=True,
+                    **(backend or {}),
                 )
             return response.choices[0].message.content
         except Exception as e:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -835,3 +835,72 @@ def test_parse_pages_overlap_counts_union():
     assert len(pages) == 9000 and pages[0] == 1 and pages[-1] == 9000
     with pytest.raises(ValueError, match="spans more than"):
         _parse_pages("1-10001")
+
+
+# ── backend: the indexing lane ──
+
+def test_backend_scopes_the_index_lane(tmp_path, monkeypatch):
+    """index_backend reaches both gateway paths — LiteLLM's call kwargs
+    and a fresh openai-SDK client — scoped to the operation, with the
+    endpoint spelling normalized for the openai SDK."""
+    pytest.importorskip("litellm")
+    import litellm
+    import openai
+    from types import SimpleNamespace
+    from pageindex.local_api import LocalAPI
+    from pageindex.utils import _llm_backend, llm_completion
+
+    api = LocalAPI(storage_path=str(tmp_path / "s"), model="m",
+                   summary_model="s", retrieve_model="r",
+                   index_backend={"api_key": "ik", "api_base": "http://b"})
+    assert api._with_backend(_llm_backend.get) == {"api_key": "ik",
+                                                   "api_base": "http://b"}
+    assert _llm_backend.get() is None
+
+    reply = SimpleNamespace(choices=[SimpleNamespace(
+        message=SimpleNamespace(content="ok"), finish_reason="stop")])
+    captured = {}
+    monkeypatch.setattr(litellm, "completion",
+                        lambda **kw: (captured.update(kw), reply)[1])
+    api._with_backend(lambda: llm_completion("anthropic/claude-x", "p"))
+    assert captured["api_key"] == "ik"
+    assert captured["api_base"] == "http://b"
+
+    seen = {}
+
+    class _FakeOpenAI:
+        def __init__(self, **kw):
+            seen.update(kw)
+            self.chat = SimpleNamespace(completions=SimpleNamespace(
+                create=lambda **_: reply))
+
+    monkeypatch.setattr(openai, "OpenAI", _FakeOpenAI)
+    api._with_backend(lambda: llm_completion("gpt-4o", "p"))
+    assert seen["api_key"] == "ik"
+    assert seen["base_url"] == "http://b"
+
+
+def test_index_backend_skips_the_env_precheck(tmp_path, monkeypatch):
+    """The missing-key pre-check reads environment variables only, so a
+    backend-supplied key must bypass it instead of being refused."""
+    pytest.importorskip("litellm")
+    import litellm
+    from pageindex.local_api import LocalAPI
+
+    api = LocalAPI(storage_path=str(tmp_path / "s"), model="m",
+                   summary_model="s", retrieve_model="r",
+                   index_backend={"api_key": "ik"})
+    monkeypatch.setattr(litellm, "validate_environment",
+                        lambda *a, **k: pytest.fail("env pre-check ran"))
+    monkeypatch.setattr(pageindex.flash, "page_index_flash",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            RuntimeError("reached-flash")))
+    with pytest.raises(RuntimeError, match="reached-flash"):
+        api._index_flash("f.pdf", ["text"])
+
+
+def test_backend_args_are_local_only():
+    with pytest.raises(PageIndexAPIError, match="chat_backend"):
+        PageIndexClient(api_key="pi-k", chat_backend={"api_key": "x"})
+    with pytest.raises(PageIndexAPIError, match="index_backend"):
+        PageIndexClient(api_key="pi-k", index_backend={"api_key": "x"})

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -159,8 +159,9 @@ def fake_model(monkeypatch):
         fake = FakeModel(turns)
         state["protocols"] = []
 
-        def factory(protocol, model_name):
+        def factory(protocol, model_name, backend=None):
             state["protocols"].append((protocol, model_name))
+            state["backends"] = state.get("backends", []) + [backend]
             return fake
 
         monkeypatch.setattr(local_chat, "_openai_model", factory)
@@ -284,6 +285,12 @@ def test_cloud_guards():
                                max_tokens=256)
     with pytest.raises(PageIndexAPIError, match="local-mode"):
         cloud.chat("x", reasoning_effort="low")
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               backend={"api_key": "k"})
+    with pytest.raises(PageIndexAPIError, match="local-mode"):
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               extra_headers={"x-beta": "1"})
     with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
                                                 "cloud yet"):
         cloud.responses("x")
@@ -650,7 +657,8 @@ def fake_anthropic(monkeypatch):
         fake = anthropic.Anthropic(
             api_key="test",
             http_client=httpx.Client(transport=httpx.MockTransport(handler)))
-        monkeypatch.setattr(local_chat, "_anthropic_client", lambda: fake)
+        monkeypatch.setattr(local_chat, "_anthropic_client",
+                            lambda backend=None: fake)
         return state["calls"]
 
     return install
@@ -1295,7 +1303,7 @@ def test_responses_stream_backend_terminal_states_are_events(
     fake = _TerminalModel([[]])
     fake.terminal = terminal
     monkeypatch.setattr(local_chat, "_openai_model",
-                        lambda protocol, model_name: fake)
+                        lambda protocol, model_name, backend=None: fake)
     events = list(client.responses("q", stream=True))
     assert events[0]["type"] == "response.output_text.delta"
     last = events[-1]
@@ -1354,7 +1362,8 @@ def test_messages_provider_errors_wrap_as_sdk_errors(client, store_path,
     fake = anthropic.Anthropic(
         api_key="test", max_retries=0,
         http_client=httpx.Client(transport=httpx.MockTransport(handler)))
-    monkeypatch.setattr(local_chat, "_anthropic_client", lambda: fake)
+    monkeypatch.setattr(local_chat, "_anthropic_client",
+                        lambda backend=None: fake)
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
         client.messages("q", model="claude-test")
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
@@ -1604,3 +1613,97 @@ def test_messages_edge_validation(client, store_path, fake_anthropic):
     with pytest.raises(PageIndexAPIError, match="doc_id"):
         client.messages([{"role": "user", "content": "q"}],
                         model="claude-test", max_tokens=100, doc_id=123)
+
+
+# ── backend + extra_headers: the chat doors ──
+
+@needs_agents
+def test_backend_connection_reaches_each_engine(monkeypatch):
+    """api_key/base_url ride each engine's client construction; the
+    LiteLLM lane's remaining keys ride its call kwargs; a backend key
+    satisfies the responses lane's missing-key check."""
+    pytest.importorskip("litellm")
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(None, "chat", "anthropic/claude-x",
+                                     "sys", None, None,
+                                     backend={"api_key": "k1",
+                                              "api_base": "http://lb",
+                                              "api_version": "v9"})
+    assert agent.model.api_key == "k1"
+    assert agent.model.base_url == "http://lb"
+    assert agent.model_settings.extra_args["api_version"] == "v9"
+    assert "api_key" not in agent.model_settings.extra_args
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    agent = local_chat._openai_agent(None, "responses", "gpt-test", "sys",
+                                     None, None, backend={"api_key": "k2"})
+    assert agent.model._client.api_key == "k2"
+
+
+def test_merged_backend_precedence():
+    from types import SimpleNamespace
+    stub = SimpleNamespace(chat_backend={"api_key": "a", "api_version": "v1"})
+    assert local_chat._merged_backend(stub, {"api_key": "b"}) == {
+        "api_key": "b", "api_version": "v1"}
+    assert local_chat._merged_backend(SimpleNamespace(), None) is None
+
+
+@needs_anthropic
+def test_messages_backend_merges_and_reaches_the_client(client, fake_anthropic,
+                                                        monkeypatch):
+    real = local_chat._anthropic_client({"api_key": "kk",
+                                         "base_url": "http://x"})
+    assert real.api_key == "kk"
+    assert str(real.base_url).rstrip("/") == "http://x"
+
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    fixture_client = local_chat._anthropic_client
+    seen = {}
+    monkeypatch.setattr(
+        local_chat, "_anthropic_client",
+        lambda backend=None: (seen.setdefault("backend", backend),
+                              fixture_client())[1])
+    client.chat_backend = {"base_url": "http://cb"}
+    client.messages("q", model="claude-sonnet-4-5", backend={"api_key": "z"})
+    assert seen["backend"] == {"base_url": "http://cb", "api_key": "z"}
+
+
+@needs_agents
+def test_extra_headers_ride_model_settings(monkeypatch):
+    """Both openai-agents doors merge ModelSettings.extra_headers into
+    their requests (wire-probed: LiteLLM's chatcmpl adapters forward
+    custom headers; its anthropic adapter owns anthropic-beta only)."""
+    monkeypatch.setattr(local_chat, "_openai_model", lambda *a: None)
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None,
+                                     extra_headers={"x-beta": "1"})
+    assert agent.model_settings.extra_headers == {"x-beta": "1"}
+    agent = local_chat._openai_agent(None, "responses", "gpt-test", "sys",
+                                     None, None,
+                                     extra_headers={"x-beta": "2"})
+    assert agent.model_settings.extra_headers == {"x-beta": "2"}
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None)
+    assert agent.model_settings.extra_headers is None
+
+
+@needs_anthropic
+def test_messages_extra_headers_reach_the_wire(client, monkeypatch):
+    import anthropic
+    seen = {}
+
+    def handler(request):
+        seen["beta"] = request.headers.get("anthropic-beta")
+        return httpx.Response(200, json=_anthropic_message(
+            [{"type": "text", "text": "ok"}], "end_turn"))
+
+    fake = anthropic.Anthropic(api_key="t", http_client=httpx.Client(
+        transport=httpx.MockTransport(handler)))
+    monkeypatch.setattr(local_chat, "_anthropic_client",
+                        lambda backend=None: fake)
+    client.messages("q", model="claude-sonnet-4-5",
+                    extra_headers={"anthropic-beta": "context-1m-2025"})
+    assert seen["beta"] == "context-1m-2025"

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -1669,6 +1669,13 @@ def test_messages_backend_merges_and_reaches_the_client(client, fake_anthropic,
     assert seen["backend"] == {"base_url": "http://cb", "api_key": "z"}
 
 
+@needs_anthropic
+def test_messages_bad_backend_wraps_like_the_other_doors():
+    with pytest.raises(PageIndexAPIError,
+                       match="Anthropic backend is not configured"):
+        local_chat._anthropic_client({"no_such_param": 1})
+
+
 @needs_agents
 def test_extra_headers_ride_model_settings(monkeypatch):
     """Both openai-agents doors merge ModelSettings.extra_headers into


### PR DESCRIPTION
Two clients, two configs — the gap this closes.

**backend**: `index_backend` / `chat_backend` on the constructor, plus per-call `backend` on the three protocol doors (mirroring per-call `model`), carry connection params in each lane's own vocabulary, verbatim:

- the indexing gateways take the dict as LiteLLM call kwargs (a contextvar scopes it per operation; the env-var key pre-check yields to it; the openai-SDK fast path normalizes LiteLLM's `api_base` spelling),
- the chat lane lifts `api_key` / `base_url` into `LitellmModel`'s two pinned constructor slots and rides the rest as call kwargs,
- `responses()` / `messages()` hand the dict to their SDK client constructors (unknown keys raise, wrapped uniformly).

Per-call keys win over the client's. `chat()` deliberately takes no per-call backend; the client-level `chat_backend` still applies to it. Config bundles deliberately don't carry credentials — you run those in your own environment (docstring says so).

**extra_headers** lands on all three protocol doors, merged verbatim into each backend request (`anthropic-beta` wire-proven on `messages()`). Documented exception on the chat door: LiteLLM's anthropic adapter owns the `anthropic-beta` header and drops the caller's value — Anthropic beta flags belong on `messages()`.

Cloud rejects the new knobs like the other local-only params. Docstrings state credentials belong in `backend`, never `extra_body` (on the bare lane they would leak into the JSON body without touching auth — wire-probed).

Audit follow-ups included: constructor Args documents both backends; a dead import from the 0.2.9 merge is gone; the bare-model missing-key error names both key routes; a bad backend dict on `messages()` wraps as `PageIndexAPIError` like the responses door (constructor raises only `TypeError` in the supported anthropic range — a missing key defers to request time).

295 tests pass (+9 for the wave).