### PR TITLE
Fix process_large_node_recursively discarding real children on large …

### DIFF
--- a/pageindex/page_index_classic.py
+++ b/pageindex/page_index_classic.py
@@ -1165,6 +1165,13 @@ async def meta_processor(page_list, mode=None, toc_content=None, toc_page_list=N
         
  
 async def process_large_node_recursively(node, page_list, opt=None, logger=None):
+    if node.get('nodes'):
+        await asyncio.gather(*[
+            process_large_node_recursively(child_node, page_list, opt, logger=logger)
+            for child_node in node['nodes']
+        ])
+        return node
+
     node_page_list = page_list[node['start_index']-1:node['end_index']]
     token_num = sum([page[1] for page in node_page_list])
     
@@ -1184,13 +1191,6 @@ async def process_large_node_recursively(node, page_list, opt=None, logger=None)
             node['nodes'] = post_processing(valid_node_toc_items, node['end_index'])
             node['end_index'] = valid_node_toc_items[0]['start_index'] if valid_node_toc_items else node['end_index']
         
-    if 'nodes' in node and node['nodes']:
-        tasks = [
-            process_large_node_recursively(child_node, page_list, opt, logger=logger)
-            for child_node in node['nodes']
-        ]
-        await asyncio.gather(*tasks)
-    
     return node
 
 async def tree_parser(page_list, opt, doc=None, logger=None):


### PR DESCRIPTION
Fix process_large_node_recursively discarding real children on large parent nodes
post_processing/list_to_tree give a parent node an end_index that only reaches its first child's start_index, not the full subtree span. When that preamble alone exceeded max_page_num_each_node/max_token_num_each_node, process_large_node_recursively re-ran meta_processor over just that prefix and overwrote node['nodes'] with the result, silently discarding the node's already-discovered children and everything under them.

Skip the large-node split when the node already has children and recurse into the existing children instead. Adds a regression test asserting the original children survive and meta_processor is not called in that case.