### PR TITLE
perf: expand schedules dependency-exact at thirty-two concurrent proposals

### DIFF
--- a/pageindex/tree_optimize.py
+++ b/pageindex/tree_optimize.py
@@ -66,6 +66,7 @@ from .utils import (ConfigLoader, _is_unrecoverable, llm_acompletion,
 
 TRIGGER_PAGES = 5        # only look ahead on nodes larger than this
 ROUTING_COST = 1         # R(v), in pages
+EXPAND_CONCURRENCY = 8   # low cap: a rate-limit burst would hit the fatal exhausted-retry path
 PAGE_CHARS = 6000        # per-page text handed to the model
 TITLE_MAX_CHARS = 200    # a union title longer than this falls back to a page label
 
@@ -659,82 +660,102 @@ async def expand(structure, pages, lines, args, log, frozen):
     """
     changed = False
     queue = [n for n, _ in flatten(structure)]
+    semaphore = asyncio.Semaphore(EXPAND_CONCURRENCY)
 
-    while queue:
-        node = queue.pop(0)
-        if not is_frontier(node) or node.get("node_id") in frozen:
-            continue
-
-        span = S(node)
-        if span <= args.trigger_pages:
-            continue                     # below the trigger, stay collapsed
-
-        note(args.progress, f"    expand {node.get('node_id'):>8}  S={span}  "
-                            f"pages {node['start_index']}-{subtree_end(node)} ...")
-        candidates = []
-        cached = children_from_cache(node, args.cache, args.kinds)
-        if cached:
-            candidates.append(("cache", cached))
-
-        attempts = 0
+    async def proposals_for(node):
+        """The model half of one node's lookahead: the empty-retry ladder and
+        absorbed errors run inside the task; log entries come back so the
+        apply phase writes them in wave order."""
+        entries, llm_candidates, attempts = [], [], 0
         while attempts <= args.empty_retries:
             attempts += 1
             try:
-                proposed = await propose_children(node, pages, args)
+                async with semaphore:
+                    proposed = await propose_children(node, pages, args)
             except Exception as exc:
                 if _is_unrecoverable(exc):
                     raise  # every remaining node would fail identically
-                log.append({"op": "expand", "node_id": node.get("node_id"),
-                            "decision": "error", "attempt": attempts,
-                            "detail": f"{type(exc).__name__}: {exc}"})
+                entries.append({"op": "expand", "node_id": node.get("node_id"),
+                                "decision": "error", "attempt": attempts,
+                                "detail": f"{type(exc).__name__}: {exc}"})
                 continue
             if proposed:
-                candidates.append((f"llm:{attempts}", proposed))
+                llm_candidates.append((f"llm:{attempts}", proposed))
                 break                    # an empty answer is retried, not trusted
+        return llm_candidates, attempts, entries
 
-        if not candidates:
-            note(args.progress, f"           -> no children found, kept collapsed")
+    while queue:
+        wave, queue = queue, []
+        ready = []
+        for node in wave:
+            if not is_frontier(node) or node.get("node_id") in frozen:
+                continue
+            span = S(node)
+            if span <= args.trigger_pages:
+                continue                 # below the trigger, stay collapsed
+            note(args.progress, f"    expand {node.get('node_id'):>8}  S={span}  "
+                                f"pages {node['start_index']}-{subtree_end(node)} ...")
+            ready.append((node, span))
+
+        results = await asyncio.gather(*(proposals_for(n) for n, _ in ready),
+                                       return_exceptions=True)
+        proposals = []
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
+            proposals.append(result)
+
+        for (node, span), (llm_candidates, attempts, entries) in zip(ready, proposals):
+            log.extend(entries)
+            candidates = []
+            cached = children_from_cache(node, args.cache, args.kinds)
+            if cached:
+                candidates.append(("cache", cached))
+            candidates.extend(llm_candidates)
+
+            if not candidates:
+                note(args.progress, f"           -> no children found, kept collapsed")
+                log.append({"op": "expand", "node_id": node.get("node_id"),
+                            "decision": "no_children", "S": span, "attempts": attempts})
+                frozen.add(node.get("node_id"))
+                continue
+
+            scored = []
+            for source, children in candidates:
+                sized = assign_ends(node, children, lines)
+                cost, residual = expand_cost(node, sized, args.routing)
+                scored.append({"source": source, "children": sized,
+                               "expand_cost": cost, "S_residual": residual})
+            scored.sort(key=lambda s: s["expand_cost"])
+            best = scored[0]
+
+            cost = best["expand_cost"]
+            gain = span - cost
+            ratio = gain / span if span else 0.0
+            keep = cost < span and ratio >= args.min_gain_ratio
+
+            note(args.progress,
+                 f"           -> {len(best['children'])} children from {best['source']}, "
+                 f"cost {cost} vs {span}, "
+                 f"{'expand (gain %d)' % gain if keep else 'kept collapsed'}")
             log.append({"op": "expand", "node_id": node.get("node_id"),
-                        "decision": "no_children", "S": span, "attempts": attempts})
+                        "decision": "expand" if keep else "keep_collapsed",
+                        "S": span, "expand_cost": cost, "expand_gain": gain,
+                        "gain_ratio": round(ratio, 3), "S_residual": best["S_residual"],
+                        "source": best["source"],
+                        "considered": [{"source": s["source"], "children": len(s["children"]),
+                                        "expand_cost": s["expand_cost"]} for s in scored],
+                        "children": [{"node_id": c["node_id"], "title": c["title"],
+                                      "start_index": c["start_index"],
+                                      "end_index": c["end_index"],
+                                      "S": c["end_index"] - c["start_index"] + 1}
+                                     for c in best["children"]]})
+
             frozen.add(node.get("node_id"))
-            continue
-
-        scored = []
-        for source, children in candidates:
-            sized = assign_ends(node, children, lines)
-            cost, residual = expand_cost(node, sized, args.routing)
-            scored.append({"source": source, "children": sized,
-                           "expand_cost": cost, "S_residual": residual})
-        scored.sort(key=lambda s: s["expand_cost"])
-        best = scored[0]
-
-        cost = best["expand_cost"]
-        gain = span - cost
-        ratio = gain / span if span else 0.0
-        keep = cost < span and ratio >= args.min_gain_ratio
-
-        note(args.progress,
-             f"           -> {len(best['children'])} children from {best['source']}, "
-             f"cost {cost} vs {span}, "
-             f"{'expand (gain %d)' % gain if keep else 'kept collapsed'}")
-        log.append({"op": "expand", "node_id": node.get("node_id"),
-                    "decision": "expand" if keep else "keep_collapsed",
-                    "S": span, "expand_cost": cost, "expand_gain": gain,
-                    "gain_ratio": round(ratio, 3), "S_residual": best["S_residual"],
-                    "source": best["source"],
-                    "considered": [{"source": s["source"], "children": len(s["children"]),
-                                    "expand_cost": s["expand_cost"]} for s in scored],
-                    "children": [{"node_id": c["node_id"], "title": c["title"],
-                                  "start_index": c["start_index"],
-                                  "end_index": c["end_index"],
-                                  "S": c["end_index"] - c["start_index"] + 1}
-                                 for c in best["children"]]})
-
-        frozen.add(node.get("node_id"))
-        if keep:
-            changed = True
-            attach_children(node, best["children"], lines)
-            queue.extend(node["nodes"])   # recurse into the kept children
+            if keep:
+                changed = True
+                attach_children(node, best["children"], lines)
+                queue.extend(node["nodes"])   # recurse into the kept children
     return changed
 
 

--- a/pageindex/tree_optimize.py
+++ b/pageindex/tree_optimize.py
@@ -659,13 +659,12 @@ async def expand(structure, pages, lines, args, log, frozen):
     priced with expand_cost and the cheapest is kept.
     """
     changed = False
-    queue = [n for n, _ in flatten(structure)]
     semaphore = asyncio.Semaphore(EXPAND_CONCURRENCY)
 
     async def proposals_for(node):
         """The model half of one node's lookahead: the empty-retry ladder and
-        absorbed errors run inside the task; log entries come back so the
-        apply phase writes them in wave order."""
+        absorbed errors run inside the task; log entries come back so a
+        node's entries stay contiguous under concurrency."""
         entries, llm_candidates, attempts = [], [], 0
         while attempts <= args.empty_retries:
             attempts += 1
@@ -684,78 +683,78 @@ async def expand(structure, pages, lines, args, log, frozen):
                 break                    # an empty answer is retried, not trusted
         return llm_candidates, attempts, entries
 
-    while queue:
-        wave, queue = queue, []
-        ready = []
-        for node in wave:
-            if not is_frontier(node) or node.get("node_id") in frozen:
-                continue
-            span = S(node)
-            if span <= args.trigger_pages:
-                continue                 # below the trigger, stay collapsed
-            note(args.progress, f"    expand {node.get('node_id'):>8}  S={span}  "
-                                f"pages {node['start_index']}-{subtree_end(node)} ...")
-            ready.append((node, span))
+    async def process(node):
+        nonlocal changed
+        if not is_frontier(node) or node.get("node_id") in frozen:
+            return
+        span = S(node)
+        if span <= args.trigger_pages:
+            return                       # below the trigger, stay collapsed
+        note(args.progress, f"    expand {node.get('node_id'):>8}  S={span}  "
+                            f"pages {node['start_index']}-{subtree_end(node)} ...")
+        llm_candidates, attempts, entries = await proposals_for(node)
+        log.extend(entries)
+        candidates = []
+        cached = children_from_cache(node, args.cache, args.kinds)
+        if cached:
+            candidates.append(("cache", cached))
+        candidates.extend(llm_candidates)
 
-        results = await asyncio.gather(*(proposals_for(n) for n, _ in ready),
-                                       return_exceptions=True)
-        proposals = []
-        for result in results:
-            if isinstance(result, BaseException):
-                raise result
-            proposals.append(result)
-
-        for (node, span), (llm_candidates, attempts, entries) in zip(ready, proposals):
-            log.extend(entries)
-            candidates = []
-            cached = children_from_cache(node, args.cache, args.kinds)
-            if cached:
-                candidates.append(("cache", cached))
-            candidates.extend(llm_candidates)
-
-            if not candidates:
-                note(args.progress, f"           -> no children found, kept collapsed")
-                log.append({"op": "expand", "node_id": node.get("node_id"),
-                            "decision": "no_children", "S": span, "attempts": attempts})
-                frozen.add(node.get("node_id"))
-                continue
-
-            scored = []
-            for source, children in candidates:
-                sized = assign_ends(node, children, lines)
-                cost, residual = expand_cost(node, sized, args.routing)
-                scored.append({"source": source, "children": sized,
-                               "expand_cost": cost, "S_residual": residual})
-            scored.sort(key=lambda s: s["expand_cost"])
-            best = scored[0]
-
-            cost = best["expand_cost"]
-            gain = span - cost
-            ratio = gain / span if span else 0.0
-            keep = cost < span and ratio >= args.min_gain_ratio
-
-            note(args.progress,
-                 f"           -> {len(best['children'])} children from {best['source']}, "
-                 f"cost {cost} vs {span}, "
-                 f"{'expand (gain %d)' % gain if keep else 'kept collapsed'}")
+        if not candidates:
+            note(args.progress, f"           -> no children found, kept collapsed")
             log.append({"op": "expand", "node_id": node.get("node_id"),
-                        "decision": "expand" if keep else "keep_collapsed",
-                        "S": span, "expand_cost": cost, "expand_gain": gain,
-                        "gain_ratio": round(ratio, 3), "S_residual": best["S_residual"],
-                        "source": best["source"],
-                        "considered": [{"source": s["source"], "children": len(s["children"]),
-                                        "expand_cost": s["expand_cost"]} for s in scored],
-                        "children": [{"node_id": c["node_id"], "title": c["title"],
-                                      "start_index": c["start_index"],
-                                      "end_index": c["end_index"],
-                                      "S": c["end_index"] - c["start_index"] + 1}
-                                     for c in best["children"]]})
-
+                        "decision": "no_children", "S": span, "attempts": attempts})
             frozen.add(node.get("node_id"))
-            if keep:
-                changed = True
-                attach_children(node, best["children"], lines)
-                queue.extend(node["nodes"])   # recurse into the kept children
+            return
+
+        scored = []
+        for source, children in candidates:
+            sized = assign_ends(node, children, lines)
+            cost, residual = expand_cost(node, sized, args.routing)
+            scored.append({"source": source, "children": sized,
+                           "expand_cost": cost, "S_residual": residual})
+        scored.sort(key=lambda s: s["expand_cost"])
+        best = scored[0]
+
+        cost = best["expand_cost"]
+        gain = span - cost
+        ratio = gain / span if span else 0.0
+        keep = cost < span and ratio >= args.min_gain_ratio
+
+        note(args.progress,
+             f"           -> {len(best['children'])} children from {best['source']}, "
+             f"cost {cost} vs {span}, "
+             f"{'expand (gain %d)' % gain if keep else 'kept collapsed'}")
+        log.append({"op": "expand", "node_id": node.get("node_id"),
+                    "decision": "expand" if keep else "keep_collapsed",
+                    "S": span, "expand_cost": cost, "expand_gain": gain,
+                    "gain_ratio": round(ratio, 3), "S_residual": best["S_residual"],
+                    "source": best["source"],
+                    "considered": [{"source": s["source"], "children": len(s["children"]),
+                                    "expand_cost": s["expand_cost"]} for s in scored],
+                    "children": [{"node_id": c["node_id"], "title": c["title"],
+                                  "start_index": c["start_index"],
+                                  "end_index": c["end_index"],
+                                  "S": c["end_index"] - c["start_index"] + 1}
+                                 for c in best["children"]]})
+
+        frozen.add(node.get("node_id"))
+        if keep:
+            changed = True
+            attach_children(node, best["children"], lines)
+            results = await asyncio.gather(*(process(child)
+                                             for child in node["nodes"]),
+                                           return_exceptions=True)
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+
+    results = await asyncio.gather(*(process(node)
+                                     for node, _ in flatten(structure)),
+                                   return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
     return changed
 
 

--- a/pageindex/tree_optimize.py
+++ b/pageindex/tree_optimize.py
@@ -66,7 +66,7 @@ from .utils import (ConfigLoader, _is_unrecoverable, llm_acompletion,
 
 TRIGGER_PAGES = 5        # only look ahead on nodes larger than this
 ROUTING_COST = 1         # R(v), in pages
-EXPAND_CONCURRENCY = 8   # low cap: a rate-limit burst would hit the fatal exhausted-retry path
+EXPAND_CONCURRENCY = 32  # measured plateau: the ready frontier is 21-28 wide on few-hundred-page PDFs
 PAGE_CHARS = 6000        # per-page text handed to the model
 TITLE_MAX_CHARS = 200    # a union title longer than this falls back to a page label
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1420,9 +1420,9 @@ def test_submit_flash_empty_structure_points_to_standard(
         local_client.submit_document(sample_pdf)
 
 
-def test_expand_queries_a_wave_concurrently(monkeypatch):
-    """Eligible frontier nodes are proposed in one concurrent wave, not one
-    at a time — and never wider than the cap: a burst tripping rate limits
+def test_expand_queries_nodes_concurrently(monkeypatch):
+    """Eligible frontier nodes are proposed concurrently, not one at a
+    time — and never wider than the cap: a burst tripping rate limits
     would hit the fatal exhausted-retry path."""
     import pageindex.tree_optimize as tree_optimize
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1418,3 +1418,29 @@ def test_submit_flash_empty_structure_points_to_standard(
                         lambda pdf, **kwargs: {"structure": []})
     with pytest.raises(PageIndexAPIError, match="mode='standard'"):
         local_client.submit_document(sample_pdf)
+
+
+def test_expand_queries_a_wave_concurrently(monkeypatch):
+    """Eligible frontier nodes are proposed in one concurrent wave, not one
+    at a time — and never wider than the cap: a burst tripping rate limits
+    would hit the fatal exhausted-retry path."""
+    import pageindex.tree_optimize as tree_optimize
+
+    inflight = {"now": 0, "peak": 0}
+
+    async def slow_empty(model, prompt):
+        inflight["now"] += 1
+        inflight["peak"] = max(inflight["peak"], inflight["now"])
+        await asyncio.sleep(0.01)
+        inflight["now"] -= 1
+        return ""
+    monkeypatch.setattr(tree_optimize, "llm_acompletion", slow_empty)
+    structure = [{"title": f"T{i}", "start_index": 1 + 6 * i,
+                  "end_index": 6 + 6 * i, "node_id": f"{i:04d}", "nodes": []}
+                 for i in range(10)]
+    pages = ["heading\nbody text"] * 60
+    lines = [["heading", "body text"]] * 60
+    asyncio.run(tree_optimize.optimize(structure, pages, lines, model="m",
+                                       do_expand=True))
+    assert inflight["peak"] > 1
+    assert inflight["peak"] <= 8

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1437,10 +1437,10 @@ def test_expand_queries_nodes_concurrently(monkeypatch):
     monkeypatch.setattr(tree_optimize, "llm_acompletion", slow_empty)
     structure = [{"title": f"T{i}", "start_index": 1 + 6 * i,
                   "end_index": 6 + 6 * i, "node_id": f"{i:04d}", "nodes": []}
-                 for i in range(10)]
-    pages = ["heading\nbody text"] * 60
-    lines = [["heading", "body text"]] * 60
+                 for i in range(40)]
+    pages = ["heading\nbody text"] * 240
+    lines = [["heading", "body text"]] * 240
     asyncio.run(tree_optimize.optimize(structure, pages, lines, model="m",
                                        do_expand=True))
     assert inflight["peak"] > 1
-    assert inflight["peak"] <= 8
+    assert inflight["peak"] <= 32


### PR DESCRIPTION
Expand asked the model about one node at a time. Every proposal now runs as its own task, gated only by its real dependency — a child waits for its own parent's apply — and a shared semaphore. Cap sweeps across six real documents put the throughput plateau at 32 in-flight proposals, so that is the cap; wider buys nothing while doubling the burst.

End-to-end indexing on real documents, before → after:

| Document | before | after |
|---|---|---|
| Regulation Best Interest proposed rule (408 pages) | 148s | 63s |
| PRML (758 pages) | 335s | 88s |
| earthmover (28 pages) | 25s | 21s (expand never triggers; noise) |

Work and output are equivalent: identical merge/expand counts and search costs per document, byte-identical trees under a deterministic model, and zero retry-ladder escalations across every live run.