### PR TITLE
feat: the client grows two sides — documents and chat each pick their home

### DIFF
--- a/pageindex/__init__.py
+++ b/pageindex/__init__.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING as _TYPE_CHECKING
 
 from .client import PageIndexClient, PageIndexCloudClient, PageIndexLocalClient
 from .errors import PageIndexAPIError
+from .types import (ChatConfig, CloudIndexConfig, IndexConfig,
+                    LocalIndexConfig)
 
 if _TYPE_CHECKING:
     from .flash import page_index_flash
@@ -13,6 +15,7 @@ if _TYPE_CHECKING:
 __all__ = [
     "PageIndexClient", "PageIndexCloudClient", "PageIndexLocalClient",
     "PageIndexAPIError",
+    "IndexConfig", "CloudIndexConfig", "LocalIndexConfig", "ChatConfig",
     "page_index", "page_index_main", "page_index_flash",
     "optimize_tree", "md_to_tree",
 ]
@@ -25,7 +28,7 @@ _LAZY = {
 _SUBMODULES = {"agent_tools", "client", "cloud_api", "errors", "flash",
                "integrations", "local_api", "local_chat", "local_store",
                "mcp_bridge", "page_index_classic", "page_index_md",
-               "tree_optimize", "utils"}
+               "tree_optimize", "types", "utils"}
 
 
 def __getattr__(name):

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1508,6 +1508,12 @@ def _tool_specs(client, include_management: bool = False, doc_ids=None,
     if getattr(client, "api_key", None):
         bridge = _cloud_bridge(client, gated=not include_management)
         tools_meta = bridge.list_tools()
+        if not tools_meta:
+            raise PageIndexAPIError(
+                "The MCP server returned no tools — a zero-tool agent would "
+                "answer from the model's own knowledge, not the documents, "
+                "with nothing to signal it."
+            )
         return [(str(meta.get("name") or "tool"),
                  meta.get("description") or "",
                  copy.deepcopy(meta.get("inputSchema"))

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1491,8 +1491,10 @@ def _require_local_scope(client, doc_ids) -> None:
     _require_doc_selection(doc_ids)
     if doc_ids is not None and getattr(client, "api_key", None):
         raise PageIndexAPIError(
-            "doc_ids scoping applies to local tools only — cloud calls "
-            "are scoped server-side."
+            "doc_ids scoping applies to local tools only — the managed "
+            "cloud chat scopes doc_id server-side, and own-model chat "
+            "over cloud documents targets documents at the prompt level, "
+            "without a tool-layer allowlist."
         )
 
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -88,17 +88,17 @@ _ARG_TYPES: "dict[str, tuple[type, ...]]" = {
     "chat_backend": (dict,)}
 
 
-def _declared_type(value, side: str):
+def _declared_mode(value, side: str):
     if value not in (None, "cloud", "local"):
         raise PageIndexAPIError(
-            f'{side} "type" must be "cloud" or "local", not {value!r}.')
+            f'{side} "mode" must be "cloud" or "local", not {value!r}.')
     return value
 
 
 def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
     """The ``index=`` slot as (cloud api_key, local overrides). A dict
-    declares its side by its keys; an optional "type" states it and must
-    agree. Keyless cloud spellings ("pageindex-cloud", {"type": "cloud"})
+    declares its side by its keys; an optional "mode" states it and must
+    agree. Keyless cloud spellings ("pageindex-cloud", {"mode": "cloud"})
     read the key from the environment."""
     from .types import PAGEINDEX_CLOUD
     if isinstance(index, str):
@@ -111,7 +111,7 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
             raise PageIndexAPIError(
                 f'index="{index}" is not a mode word — a bare string here '
                 "is a local index model name. For cloud documents write "
-                '"pageindex-cloud", index={"type": "cloud"} (key from '
+                '"pageindex-cloud", index={"mode": "cloud"} (key from '
                 'PAGEINDEX_API_KEY) or {"api_key": ...}; local is the '
                 "default.")
         if index.strip():
@@ -123,10 +123,10 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
         # None-valued keys mean "absent", exactly like the flat arguments.
         conf = {name: value for name, value in index.items()
                 if value is not None}
-        declared = _declared_type(conf.pop("type", None), "index")
+        declared = _declared_mode(conf.pop("mode", None), "index")
         if not conf:
             if declared == "cloud":
-                return _env_cloud_key('index={"type": "cloud"}',
+                return _env_cloud_key('index={"mode": "cloud"}',
                                       'index={"api_key": ...}'), {}
             if declared == "local":
                 return None, {}
@@ -143,7 +143,7 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
         if "api_key" in conf:
             if declared == "local":
                 raise PageIndexAPIError(
-                    'index declares type "local" but carries api_key — '
+                    'index declares mode "local" but carries api_key — '
                     "an API key means cloud documents. Drop one of them.")
             if len(conf) > 1:
                 raise PageIndexAPIError(
@@ -157,7 +157,7 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
             return key, {}
         if declared == "cloud":
             raise PageIndexAPIError(
-                'index declares type "cloud" but carries local keys '
+                'index declares mode "cloud" but carries local keys '
                 f"({', '.join(sorted(conf))}) — the cloud pipeline does "
                 'its own indexing; cloud takes "api_key" only.')
         mapped = {"index_model": conf.get("model"),
@@ -181,7 +181,7 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
                 f'chat="{chat}" is not a mode word — a bare string here is '
                 "your own model name (e.g. \"openai/gpt-5.2\"). For the "
                 'managed chat write "pageindex-cloud" or '
-                '{"type": "cloud"}.')
+                '{"mode": "cloud"}.')
         if chat.strip():
             return "own", {"chat_model": chat.strip()}
         raise PageIndexAPIError(
@@ -191,21 +191,21 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
         # None-valued keys mean "absent", exactly like the flat arguments.
         conf = {name: value for name, value in chat.items()
                 if value is not None}
-        declared = _declared_type(conf.pop("type", None), "chat")
+        declared = _declared_mode(conf.pop("mode", None), "chat")
         unknown = set(conf) - {"model", "backend"}
         if (not conf and declared is None) or unknown:
             raise PageIndexAPIError(
                 ("chat is an empty dict" if not conf else
                  f"Unknown chat keys ({', '.join(sorted(unknown))})")
                 + ' — chat takes "model" and "backend" (your own model), '
-                'or {"type": "cloud"} / "pageindex-cloud" for the managed '
+                'or {"mode": "cloud"} / "pageindex-cloud" for the managed '
                 "chat.")
         if declared == "cloud":
             if conf:
                 raise PageIndexAPIError(
-                    'chat declares type "cloud" but carries '
+                    'chat declares mode "cloud" but carries '
                     f"({', '.join(sorted(conf))}) — the managed chat "
-                    "selects its own model. Drop the type, or the keys.")
+                    "selects its own model. Drop the mode, or the keys.")
             return "managed", {}
         mapped = {"chat_model": conf.get("model"),
                   "chat_backend": conf.get("backend")}
@@ -257,22 +257,22 @@ class PageIndexClient:
             ``"pageindex-cloud"`` (cloud, key from the environment), a
             local index model name, or a dict: ``{"api_key": ...}`` for
             cloud, ``{"model", "summary_model", "backend",
-            "storage_path"}`` for local. An optional ``"type"`` key
+            "storage_path"}`` for local. An optional ``"mode"`` key
             (``"cloud"`` / ``"local"``) states the side and must agree
-            with the other keys; ``{"type": "cloud"}`` alone reads the
+            with the other keys; ``{"mode": "cloud"}`` alone reads the
             key from the environment. Not combinable with this side's
             flat arguments.
         chat (str | dict, optional): The chat side, grouped — a model
             name (your own model), ``"pageindex-cloud"`` (managed chat,
             cloud clients only), or ``{"model", "backend"}``. An
-            optional ``"type"`` key states the side: ``{"type":
+            optional ``"mode"`` key states the side: ``{"mode":
             "cloud"}`` alone is the managed chat, ``"local"`` is your
             own model and must agree with the other keys. Not
             combinable with this side's flat arguments.
-        type (str, optional): Client-level declaration of where the
+        mode (str, optional): Client-level declaration of where the
             documents live — ``"cloud"`` or ``"local"`` — checked
-            against the other arguments (``type="local"`` with an
-            api_key errors). ``type="cloud"`` alone reads the key from
+            against the other arguments (``mode="local"`` with an
+            api_key errors). ``mode="cloud"`` alone reads the key from
             the ``PAGEINDEX_API_KEY`` environment variable. Always
             optional: the arguments themselves already carry the mode.
         index_model (str, optional): Local mode only — LLM used to index
@@ -330,7 +330,7 @@ class PageIndexClient:
         *,
         index: Optional[Union[dict[str, Any], str]] = None,
         chat: Optional[Union[dict[str, Any], str]] = None,
-        type: Optional[str] = None,
+        mode: Optional[str] = None,
         index_model: Optional[str] = None,
         chat_model: Optional[str] = None,
         model: Optional[str] = None,
@@ -376,27 +376,27 @@ class PageIndexClient:
                 "chat= and the flat chat-side arguments "
                 f"({', '.join(sorted(chat_flat))}) are two spellings of "
                 "the same thing — use one or the other.")
-        # ``type=`` is a cross-check, not a spelling: it combines with
+        # ``mode=`` is a cross-check, not a spelling: it combines with
         # either spelling of the index side and must agree with it.
-        declared = _declared_type(type, "client")
+        declared = _declared_mode(mode, "client")
         if index is not None:
             cloud_key, index_conf = _resolve_index_slot(index)
             if declared == "local" and cloud_key is not None:
                 raise PageIndexAPIError(
-                    'type="local" disagrees with index= — that index '
+                    'mode="local" disagrees with index= — that index '
                     "selects cloud documents. Drop one of them.")
             if declared == "cloud" and cloud_key is None:
                 raise PageIndexAPIError(
-                    'type="cloud" disagrees with index= — that index '
+                    'mode="cloud" disagrees with index= — that index '
                     "configures the local store. Drop one of them.")
         else:
             cloud_key = api_key
             if declared == "local" and api_key is not None:
                 raise PageIndexAPIError(
-                    'type="local" conflicts with api_key — an API key '
+                    'mode="local" conflicts with api_key — an API key '
                     "means cloud documents. Drop one of them.")
             if declared == "cloud" and cloud_key is None:
-                cloud_key = _env_cloud_key('type="cloud"')
+                cloud_key = _env_cloud_key('mode="cloud"')
             index_conf = {name: value for name, value in index_flat.items()
                           if name != "api_key"}
         if chat is not None:
@@ -410,11 +410,9 @@ class PageIndexClient:
         for conf in (index_conf, chat_conf):
             for name, value in conf.items():
                 if not isinstance(value, _ARG_TYPES[name]):
-                    # value.__class__: the ``type=`` parameter shadows the
-                    # builtin in this scope.
                     raise PageIndexAPIError(
                         f"{name} must be a {_ARG_TYPES[name][0].__name__}, "
-                        f"got {value.__class__.__name__}.")
+                        f"got {type(value).__name__}.")
                 if not value:
                     raise PageIndexAPIError(
                         f"{name} is empty — it configures nothing. Pass a "

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -413,7 +413,7 @@ class PageIndexClient:
                     raise PageIndexAPIError(
                         f"{name} must be a {_ARG_TYPES[name][0].__name__}, "
                         f"got {type(value).__name__}.")
-                if not value:
+                if not (value.strip() if isinstance(value, str) else value):
                     raise PageIndexAPIError(
                         f"{name} is empty — it configures nothing. Pass a "
                         "real value, or drop the argument.")
@@ -477,9 +477,7 @@ class PageIndexClient:
     @property
     def _local_chat(self) -> bool:
         # Derived, never stored: own-model chat is exactly "a chat model
-        # is configured" (None on a managed-chat client), so a
-        # post-construction ``client.chat_model = m`` switches the whole
-        # client, not half of it.
+        # is configured" (None on a managed-chat client).
         return getattr(self, "chat_model", None) is not None
 
     @property

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -348,7 +348,7 @@ class PageIndexClient:
         # ``model`` sets every role, so it claims both sides.
         index_flat: dict[str, Any] = {
             name: value for name, value in
-            (("api_key", api_key), ("type", type),
+            (("api_key", api_key),
              ("index_model", index_model),
              ("summary_model", summary_model),
              ("index_backend", index_backend),
@@ -375,10 +375,20 @@ class PageIndexClient:
                 "chat= and the flat chat-side arguments "
                 f"({', '.join(sorted(chat_flat))}) are two spellings of "
                 "the same thing — use one or the other.")
+        # ``type=`` is a cross-check, not a spelling: it combines with
+        # either spelling of the index side and must agree with it.
+        declared = _declared_type(type, "client")
         if index is not None:
             cloud_key, index_conf = _resolve_index_slot(index)
+            if declared == "local" and cloud_key is not None:
+                raise PageIndexAPIError(
+                    'type="local" disagrees with index= — that index '
+                    "selects cloud documents. Drop one of them.")
+            if declared == "cloud" and cloud_key is None:
+                raise PageIndexAPIError(
+                    'type="cloud" disagrees with index= — that index '
+                    "configures the local store. Drop one of them.")
         else:
-            declared = _declared_type(index_flat.pop("type", None), "client")
             cloud_key = api_key
             if declared == "local" and api_key is not None:
                 raise PageIndexAPIError(
@@ -718,7 +728,10 @@ class PageIndexClient:
             messages: A question string, or role/content conversation
                 history.
             doc_id: Document ID or list of IDs to scope the conversation.
-                Keep it identical across a conversation's calls.
+                Keep it identical across a conversation's calls. Local
+                documents: also enforced at the tool layer, not just
+                prompted. Cloud documents: the managed chat scopes
+                server-side; own-model chat targets at the prompt level.
             stream: Yield the answer as text chunks as it is produced.
             model: Own-model chat only — backend model name (defaults
                 to ``chat_model``).
@@ -799,7 +812,10 @@ class PageIndexClient:
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls — the
                 targeting block it adds is re-set each call and is part
-                of the cached prompt prefix.
+                of the cached prompt prefix. Local documents: also
+                enforced at the tool layer, not just prompted. Cloud
+                documents: the managed chat scopes server-side;
+                own-model chat targets at the prompt level.
             temperature: Sampling temperature, passed through to the model.
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
@@ -928,7 +944,9 @@ class PageIndexClient:
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls — the
                 targeting block it adds is re-set each call and is part
-                of the cached prompt prefix.
+                of the cached prompt prefix. Local documents: also
+                enforced at the tool layer; cloud documents:
+                prompt-level targeting only.
             instructions: Appended to the managed system prompt.
             temperature / top_p: Passed through to the model.
             max_turns: Cap on agent turns per call.
@@ -1018,7 +1036,9 @@ class PageIndexClient:
                 convenience events), one message sequence per turn.
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls — the
-                targeting block it adds is re-set each call.
+                targeting block it adds is re-set each call. Local
+                documents: also enforced at the tool layer; cloud
+                documents: prompt-level targeting only.
             system: Appended after the managed system blocks.
             temperature / top_p / top_k / stop_sequences: Passed through.
             max_turns: Cap on agent turns per call (default 10, like the
@@ -1544,7 +1564,15 @@ class PageIndexCloudClient(PageIndexClient):
     the environment: ``PageIndexCloudClient()`` reads PAGEINDEX_API_KEY.
     The shortest env-key cloud spelling."""
 
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        chat: Optional[Union[dict[str, Any], str]] = None,
+        chat_model: Optional[str] = None,
+        retrieve_model: Optional[str] = None,
+        chat_backend: Optional[dict[str, Any]] = None,
+    ):
         if api_key is None:
             # .env keys arrive via utils' import-time load_dotenv().
             from . import utils  # noqa: F401
@@ -1555,7 +1583,9 @@ class PageIndexCloudClient(PageIndexClient):
                 "api_key=..., or export PAGEINDEX_API_KEY. Get one at "
                 "https://dash.pageindex.ai/api-keys."
             )
-        super().__init__(api_key)
+        super().__init__(api_key, chat=chat, chat_model=chat_model,
+                         retrieve_model=retrieve_model,
+                         chat_backend=chat_backend)
 
 
 class PageIndexLocalClient(PageIndexClient):

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -288,7 +288,8 @@ class PageIndexClient:
             OpenAI-compatible shorthand, and ``openai/Qwen/...`` is the
             form for an OpenAI-compatible server that itself serves
             slashed model ids (vLLM, TGI). Defaults to the SDK default
-            (strong).
+            (strong); reads ``None`` on a cloud client where the managed
+            chat answers.
         model (str, optional): Local mode only — one model for both roles:
             sets the default for ``index_model`` and ``chat_model`` at
             once. The role-specific arguments win over it. (Also the
@@ -440,6 +441,10 @@ class PageIndexClient:
                 self.chat_model = opt.chat_model
                 self.chat_backend = chat_conf.get("chat_backend")
                 _preload_litellm()
+            else:
+                # Managed chat: the endpoint selects its own model.
+                self.chat_model = None
+                self.chat_backend = None
         else:
             if chat_mode == "managed":
                 raise PageIndexAPIError(
@@ -474,9 +479,10 @@ class PageIndexClient:
     @property
     def _local_chat(self) -> bool:
         # Derived, never stored: own-model chat is exactly "a chat model
-        # is configured", so a post-construction ``client.chat_model = m``
-        # switches the whole client, not half of it.
-        return hasattr(self, "chat_model")
+        # is configured" (None on a managed-chat client), so a
+        # post-construction ``client.chat_model = m`` switches the whole
+        # client, not half of it.
+        return getattr(self, "chat_model", None) is not None
 
     @property
     def retrieve_model(self):

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -283,12 +283,12 @@ class PageIndexClient:
             ``client.chat_model`` — on a cloud client, setting it runs
             the document-QA agent in your process over the cloud
             documents (page content then flows through your process to
-            your model provider). Chat names
-            route through LiteLLM and mean what LiteLLM says they mean;
-            bare names are OpenAI-compatible shorthand, and
-            ``openai/Qwen/...`` is the form for an OpenAI-compatible
-            server that itself serves slashed model ids (vLLM, TGI).
-            Defaults to the SDK default (strong).
+            your model provider). Chat names route through LiteLLM and
+            mean what LiteLLM says they mean; bare names are
+            OpenAI-compatible shorthand, and ``openai/Qwen/...`` is the
+            form for an OpenAI-compatible server that itself serves
+            slashed model ids (vLLM, TGI). Defaults to the SDK default
+            (strong).
         model (str, optional): Local mode only — one model for both roles:
             sets the default for ``index_model`` and ``chat_model`` at
             once. The role-specific arguments win over it. (Also the
@@ -736,10 +736,9 @@ class PageIndexClient:
             model: Own-model chat only — backend model name (defaults
                 to ``chat_model``).
             reasoning_effort: Own-model chat only — how hard the model
-                thinks
-                (``"low"`` / ``"medium"`` / ``"high"``; what a backend
-                accepts is its own). Unset sends nothing — the model's
-                default behavior applies.
+                thinks (``"low"`` / ``"medium"`` / ``"high"``; what a
+                backend accepts is its own). Unset sends nothing — the
+                model's default behavior applies.
 
         Returns:
             - stream=False: the answer string
@@ -824,11 +823,12 @@ class PageIndexClient:
             model: Own-model chat only — backend model name (defaults to
                 ``chat_model``). The managed endpoint selects its own.
             max_turns: Own-model chat only — cap on agent turns per call.
-            top_p: Own-model chat only — nucleus sampling, passed through to the
-                model.
-            max_tokens: Own-model chat only — per-call output cap, passed through;
-                it bounds each backend call in the agent loop (the way
-                max_turns bounds the loop), not the whole run.
+            top_p: Own-model chat only — nucleus sampling, passed
+                through to the model.
+            max_tokens: Own-model chat only — per-call output cap,
+                passed through; it bounds each backend call in the agent
+                loop (the way max_turns bounds the loop), not the whole
+                run.
             reasoning_effort: Own-model chat only — passed through verbatim as
                 LiteLLM's ``reasoning_effort``; each provider maps it to
                 its own thinking control, and the values mean what the
@@ -881,7 +881,7 @@ class PageIndexClient:
                 "model, max_turns, top_p, max_tokens, reasoning_effort, "
                 "extra_body, extra_headers and backend drive your own chat "
                 "model, which this client does not configure — construct "
-                "the client with chat_model=... (or chat=...) to run the "
+                "the client with chat_model=... (or a chat= model) to run the "
                 "agent in your process, or drop them to use the managed "
                 "chat endpoint, which selects its own model."
             )
@@ -913,11 +913,11 @@ class PageIndexClient:
 
         Own-model chat only — local mode, or a cloud client constructed
         with ``chat_model=``/``chat=``. Drives your backend's /responses
-        end to end (no
-        translation layer). The envelope is official Responses shape —
-        ``output`` carries the model-produced items and parses with the
-        openai SDK types — and the whole process transcript (including the
-        tool outputs the SDK executed) rides in the extra ``items`` field.
+        end to end (no translation layer). The envelope is official
+        Responses shape — ``output`` carries the model-produced items
+        and parses with the openai SDK types — and the whole process
+        transcript (including the tool outputs the SDK executed) rides
+        in the extra ``items`` field.
         Append the returned ``items`` to your next call's ``input`` verbatim
         to keep provider prompt-cache prefix continuity and the agent's
         memory of what it already read.
@@ -973,7 +973,7 @@ class PageIndexClient:
         if not self._local_chat:
             raise PageIndexAPIError(
                 "responses() drives your own chat model — construct the "
-                "client with chat_model=... (or chat=...); the managed "
+                "client with chat_model=... (or a chat= model); the managed "
                 "cloud chat serves chat_completions() only."
             )
         from .local_chat import run_responses
@@ -1008,10 +1008,10 @@ class PageIndexClient:
 
         Own-model chat only — local mode, or a cloud client constructed
         with ``chat_model=``/``chat=``. Drives Anthropic's /v1/messages
-        via the
-        Anthropic SDK's own tool runner (requires ``pageindex[anthropic]``;
-        ANTHROPIC_API_KEY selects the backend). ``tool_use``/``tool_result``
-        round-trip is the format's native behavior: the response is the
+        via the Anthropic SDK's own tool runner (requires
+        ``pageindex[anthropic]``; ANTHROPIC_API_KEY selects the
+        backend). ``tool_use``/``tool_result`` round-trip is the
+        format's native behavior: the response is the
         final message envelope with cross-turn aggregated ``usage`` plus a
         ``messages`` field — the full new turn sequence, valid for verbatim
         append to your history. The managed system prompt carries a
@@ -1063,7 +1063,7 @@ class PageIndexClient:
         if not self._local_chat:
             raise PageIndexAPIError(
                 "messages() drives your own chat model — construct the "
-                "client with chat_model=... (or chat=...); the managed "
+                "client with chat_model=... (or a chat= model); the managed "
                 "cloud chat serves chat_completions() only."
             )
         from .local_chat import run_messages

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -60,9 +60,9 @@ def _agents_sdk_model_name(model: str) -> str:
 
 _LOCAL_INDEX_KEYS = ("model", "summary_model", "backend", "storage_path")
 
-# Bare mode words would otherwise parse as model names — a silent wrong
-# mode. Reserved: they error with the real spellings instead.
-_RESERVED_MODE_WORDS = {"cloud", "local", "hosted", "managed"}
+# Near-synonyms of "cloud" that would otherwise parse as model names —
+# a silent wrong mode. They error, pointing at the real word.
+_RESERVED_MODE_WORDS = {"hosted", "managed"}
 
 
 def _env_cloud_key(spelling: str, inline: str = "api_key=...") -> str:
@@ -89,36 +89,43 @@ _ARG_TYPES: "dict[str, tuple[type, ...]]" = {
 
 
 def _declared_mode(value, side: str):
+    if isinstance(value, str):
+        value = value.strip().lower()
     if value not in (None, "cloud", "local"):
         raise PageIndexAPIError(
             f'{side} "mode" must be "cloud" or "local", not {value!r}.')
     return value
 
 
-def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
+_CloudKey = Union[str, Callable[[], str], None]
+
+
+def _resolve_index_slot(index) -> "tuple[_CloudKey, dict[str, Any]]":
     """The ``index=`` slot as (cloud api_key, local overrides). A dict
     declares its side by its keys; an optional "mode" states it and must
-    agree. Keyless cloud spellings ("pageindex-cloud", {"mode": "cloud"})
-    read the key from the environment."""
+    agree. Keyless cloud spellings ("cloud" / "pageindex-cloud",
+    {"mode": "cloud"}) return the environment read as a thunk, so the
+    caller's mode cross-check runs before the environment is touched."""
     from .types import PAGEINDEX_CLOUD
     if isinstance(index, str):
-        # Normalized compare: a case/whitespace variant of the label must
-        # never fall through and silently become a model name.
-        if index.strip().lower() == PAGEINDEX_CLOUD:
-            return _env_cloud_key('index="pageindex-cloud"',
-                                  'index={"api_key": ...}'), {}
-        if index.strip().lower() in _RESERVED_MODE_WORDS:
+        # Normalized compare: a case/whitespace variant of a mode word
+        # must never fall through and silently become a model name.
+        word = index.strip().lower()
+        if word in (PAGEINDEX_CLOUD, "cloud"):
+            return lambda: _env_cloud_key(f'index="{index.strip()}"',
+                                          'index={"api_key": ...}'), {}
+        if word == "local":
+            return None, {}
+        if word in _RESERVED_MODE_WORDS:
             raise PageIndexAPIError(
-                f'index="{index}" is a reserved word — a bare string here '
-                "is a local index model name. For cloud documents write "
-                '"pageindex-cloud", index={"mode": "cloud"} (key from '
-                'PAGEINDEX_API_KEY) or {"api_key": ...}; local is the '
-                "default.")
+                f'index="{index}" is not a mode word — the cloud spelling '
+                'is index="cloud" (key from PAGEINDEX_API_KEY) or '
+                'index={"api_key": ...}.')
         if index.strip():
-            return None, {"index_model": index.strip()}
+            return None, {"index_model": index}
         raise PageIndexAPIError(
             "index is an empty string — pass a local index model name, "
-            'or "pageindex-cloud".')
+            'or "cloud".')
     if isinstance(index, dict):
         # None-valued keys mean "absent", exactly like the flat arguments.
         conf = {name: value for name, value in index.items()
@@ -126,8 +133,8 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
         declared = _declared_mode(conf.pop("mode", None), "index")
         if not conf:
             if declared == "cloud":
-                return _env_cloud_key('index={"mode": "cloud"}',
-                                      'index={"api_key": ...}'), {}
+                return lambda: _env_cloud_key('index={"mode": "cloud"}',
+                                              'index={"api_key": ...}'), {}
             if declared == "local":
                 return None, {}
             raise PageIndexAPIError(
@@ -174,19 +181,20 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
     "managed", "own", or None (nothing declared beyond the overrides)."""
     from .types import PAGEINDEX_CLOUD
     if isinstance(chat, str):
-        if chat.strip().lower() == PAGEINDEX_CLOUD:
+        word = chat.strip().lower()
+        if word in (PAGEINDEX_CLOUD, "cloud"):
             return "managed", {}
-        if chat.strip().lower() in _RESERVED_MODE_WORDS:
+        if word == "local":
+            return "own", {}
+        if word in _RESERVED_MODE_WORDS:
             raise PageIndexAPIError(
-                f'chat="{chat}" is a reserved word — a bare string here is '
-                "your own model name (e.g. \"openai/gpt-5.2\"). For the "
-                'managed chat write "pageindex-cloud" or '
-                '{"mode": "cloud"}.')
+                f'chat="{chat}" is not a mode word — the managed chat is '
+                'chat="cloud".')
         if chat.strip():
-            return "own", {"chat_model": chat.strip()}
+            return "own", {"chat_model": chat}
         raise PageIndexAPIError(
             "chat is an empty string — pass a model name, or "
-            '"pageindex-cloud" for the managed chat.')
+            '"cloud" for the managed chat.')
     if isinstance(chat, dict):
         # None-valued keys mean "absent", exactly like the flat arguments.
         conf = {name: value for name, value in chat.items()
@@ -198,8 +206,7 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
                 ("chat is an empty dict" if not conf else
                  f"Unknown chat keys ({', '.join(sorted(unknown))})")
                 + ' — chat takes "model" and "backend" (your own model), '
-                'or {"mode": "cloud"} / "pageindex-cloud" for the managed '
-                "chat.")
+                'or {"mode": "cloud"} / "cloud" for the managed chat.')
         if declared == "cloud":
             if conf:
                 raise PageIndexAPIError(
@@ -244,27 +251,28 @@ class PageIndexClient:
 
     ``index=`` / ``chat=`` are the grouped spelling of the same flat
     arguments — a string as shorthand, a dict for the full config; each
-    side picks one spelling per client. ``index="pageindex-cloud"`` is
-    the keyless cloud spelling (the key comes from the
-    ``PAGEINDEX_API_KEY`` environment variable — which is read only when
-    the code explicitly says cloud; a bare ``PageIndexClient()`` stays
-    local regardless of the environment).
+    side picks one spelling per client. ``index="cloud"`` (or the label
+    ``"pageindex-cloud"``) is the keyless cloud spelling (the key comes
+    from the ``PAGEINDEX_API_KEY`` environment variable — which is read
+    only when the code explicitly says cloud; a bare ``PageIndexClient()``
+    stays local regardless of the environment).
 
     Args:
         api_key (str, optional): PageIndex cloud API key
             (https://dash.pageindex.ai/api-keys). Omit for local mode.
         index (str | dict, optional): The index side, grouped —
-            ``"pageindex-cloud"`` (cloud, key from the environment), a
-            local index model name, or a dict: ``{"api_key": ...}`` for
-            cloud, ``{"model", "summary_model", "backend",
-            "storage_path"}`` for local. An optional ``"mode"`` key
-            (``"cloud"`` / ``"local"``) states the side and must agree
-            with the other keys; ``{"mode": "cloud"}`` alone reads the
-            key from the environment. Not combinable with this side's
-            flat arguments.
+            ``"cloud"`` / ``"pageindex-cloud"`` (cloud, key from the
+            environment), ``"local"``, a local index model name, or a
+            dict: ``{"api_key": ...}`` for cloud, ``{"model",
+            "summary_model", "backend", "storage_path"}`` for local. An
+            optional ``"mode"`` key (``"cloud"`` / ``"local"``) states
+            the side and must agree with the other keys; ``{"mode":
+            "cloud"}`` alone reads the key from the environment. Not
+            combinable with this side's flat arguments.
         chat (str | dict, optional): The chat side, grouped — a model
-            name (your own model), ``"pageindex-cloud"`` (managed chat,
-            cloud clients only), or ``{"model", "backend"}``. An
+            name (your own model), ``"cloud"`` / ``"pageindex-cloud"``
+            (managed chat, cloud clients only), ``"local"`` (your own
+            model, the default one), or ``{"model", "backend"}``. An
             optional ``"mode"`` key states the side: ``{"mode":
             "cloud"}`` alone is the managed chat, ``"local"`` is your
             own model and must agree with the other keys. Not
@@ -324,6 +332,8 @@ class PageIndexClient:
 
     BASE_URL = "https://api.pageindex.ai"
 
+    _pin: Optional[str] = None  # the pinned subclasses' index side
+
     def __init__(
         self,
         api_key: Optional[str] = None,
@@ -364,8 +374,9 @@ class PageIndexClient:
         if model is not None and (index is not None or chat is not None):
             raise PageIndexAPIError(
                 "model= sets both roles at once, so no slot can absorb "
-                "it — split it into index_model= and chat_model= to "
-                "combine with index=/chat=.")
+                'it — name the model inside the slot ({"model": ...}) '
+                "and use index_model= / chat_model= for a side written "
+                "flat.")
         if index is not None and index_flat:
             raise PageIndexAPIError(
                 "index= and the flat index-side arguments "
@@ -377,18 +388,30 @@ class PageIndexClient:
                 f"({', '.join(sorted(chat_flat))}) are two spellings of "
                 "the same thing — use one or the other.")
         # ``mode=`` is a cross-check, not a spelling: it combines with
-        # either spelling of the index side and must agree with it.
-        declared = _declared_mode(mode, "client")
+        # either spelling of the index side and must agree with it. The
+        # pinned classes declare the side by class; their errors name the
+        # class, never a mode= the user did not write.
+        declared = _declared_mode(mode, "client") or self._pin
+        pinned = type(self).__name__ if self._pin else None
         if index is not None:
             cloud_key, index_conf = _resolve_index_slot(index)
             if declared == "local" and cloud_key is not None:
                 raise PageIndexAPIError(
+                    f"{pinned} pins local documents — that index= selects "
+                    "cloud documents. Drop it, or use PageIndexCloudClient."
+                    if pinned else
                     'mode="local" disagrees with index= — that index '
                     "selects cloud documents. Drop one of them.")
             if declared == "cloud" and cloud_key is None:
                 raise PageIndexAPIError(
+                    f"{pinned} pins cloud documents — that index= "
+                    "configures the local store. Drop it, or use "
+                    "PageIndexLocalClient."
+                    if pinned else
                     'mode="cloud" disagrees with index= — that index '
                     "configures the local store. Drop one of them.")
+            if callable(cloud_key):
+                cloud_key = cloud_key()
         else:
             cloud_key = api_key
             if declared == "local" and api_key is not None:
@@ -404,18 +427,24 @@ class PageIndexClient:
         else:
             chat_mode = "own" if chat_flat else None
             chat_conf = chat_flat
-        # Every spelling lands here: wrong types and empty values refuse
-        # loudly — an empty chat-side value must never silently select
-        # own-model chat.
-        for conf in (index_conf, chat_conf):
+        # Every spelling lands here: strings are stripped, wrong types and
+        # empty values refuse loudly — an empty chat-side value must never
+        # silently select own-model chat.
+        for side, slot, conf in (("index", index, index_conf),
+                                 ("chat", chat, chat_conf)):
             for name, value in conf.items():
+                # Slot keys are the flat names with the side prefix off.
+                shown = (f'{side}["{name.removeprefix(side + "_")}"]'
+                         if slot is not None else name)
                 if not isinstance(value, _ARG_TYPES[name]):
                     raise PageIndexAPIError(
-                        f"{name} must be a {_ARG_TYPES[name][0].__name__}, "
+                        f"{shown} must be a {_ARG_TYPES[name][0].__name__}, "
                         f"got {type(value).__name__}.")
-                if not (value.strip() if isinstance(value, str) else value):
+                if isinstance(value, str):
+                    value = conf[name] = value.strip()
+                if not value:
                     raise PageIndexAPIError(
-                        f"{name} is empty — it configures nothing. Pass a "
+                        f"{shown} is empty — it configures nothing. Pass a "
                         "real value, or drop the argument.")
 
         if cloud_key is not None:
@@ -445,11 +474,18 @@ class PageIndexClient:
                 self.chat_backend = None
         else:
             if chat_mode == "managed":
+                if pinned:
+                    exits = (f"{pinned} pins local documents: use "
+                             "PageIndexCloudClient (or PageIndexClient("
+                             "api_key=...))")
+                else:
+                    exits = ('Go cloud (api_key=... or index="cloud")'
+                             + (' and drop mode="local"' if mode is not None
+                                else ""))
                 raise PageIndexAPIError(
                     "The managed chat needs cloud documents — it cannot "
-                    "read the local store. Go cloud (api_key=... or "
-                    'index="pageindex-cloud"), or set your own chat model '
-                    "instead.")
+                    f"read the local store. {exits}, or set your own chat "
+                    "model instead.")
             from .utils import ConfigLoader
             overrides = {name: value for name, value in
                          {**index_conf, **chat_conf}.items()
@@ -477,8 +513,12 @@ class PageIndexClient:
     @property
     def _local_chat(self) -> bool:
         # Derived, never stored: own-model chat is exactly "a chat model
-        # is configured" (None on a managed-chat client).
-        return getattr(self, "chat_model", None) is not None
+        # is configured" (None on a managed-chat client). Blank configures
+        # nothing — the constructor refuses it, and assignment must agree.
+        model = getattr(self, "chat_model", None)
+        if isinstance(model, str):
+            return bool(model.strip())
+        return model is not None
 
     @property
     def retrieve_model(self):
@@ -1273,7 +1313,7 @@ class PageIndexClient:
                 include_management=include_management),
             "tools": self.as_openai_tools(include_management, doc_id=scope),
         }
-        model = model or getattr(self, "chat_model", None)
+        model = model or (self.chat_model if self._local_chat else None)
         if model:
             config["model"] = _agents_sdk_model_name(model)
             if config["model"].startswith("litellm/"):
@@ -1566,36 +1606,44 @@ class PageIndexCloudClient(PageIndexClient):
     the environment: ``PageIndexCloudClient()`` reads PAGEINDEX_API_KEY.
     The shortest env-key cloud spelling."""
 
+    _pin = "cloud"
+
     def __init__(
         self,
         api_key: Optional[str] = None,
         *,
+        index: Optional[Union[dict[str, Any], str]] = None,
         chat: Optional[Union[dict[str, Any], str]] = None,
         chat_model: Optional[str] = None,
         retrieve_model: Optional[str] = None,
         chat_backend: Optional[dict[str, Any]] = None,
     ):
-        if api_key is None:
-            # .env keys arrive via utils' import-time load_dotenv().
-            from . import utils  # noqa: F401
-            api_key = os.environ.get("PAGEINDEX_API_KEY")
-        if not api_key:
-            raise PageIndexAPIError(
-                "PageIndexCloudClient requires a PageIndex API key — pass "
-                "api_key=..., or export PAGEINDEX_API_KEY. Get one at "
-                "https://dash.pageindex.ai/api-keys."
-            )
-        super().__init__(api_key, chat=chat, chat_model=chat_model,
-                         retrieve_model=retrieve_model,
+        if index is None:
+            if api_key is None:
+                # .env keys arrive via utils' import-time load_dotenv().
+                from . import utils  # noqa: F401
+                api_key = os.environ.get("PAGEINDEX_API_KEY")
+            if not api_key:
+                raise PageIndexAPIError(
+                    "PageIndexCloudClient requires a PageIndex API key — "
+                    "pass api_key=..., or export PAGEINDEX_API_KEY. Get one "
+                    "at https://dash.pageindex.ai/api-keys."
+                )
+        super().__init__(api_key, index=index, chat=chat,
+                         chat_model=chat_model, retrieve_model=retrieve_model,
                          chat_backend=chat_backend)
 
 
 class PageIndexLocalClient(PageIndexClient):
     """Local mode — no api_key parameter, no cloud access."""
 
+    _pin = "local"
+
     def __init__(
         self,
         *,
+        index: Optional[Union[dict[str, Any], str]] = None,
+        chat: Optional[Union[dict[str, Any], str]] = None,
         index_model: Optional[str] = None,
         chat_model: Optional[str] = None,
         model: Optional[str] = None,
@@ -1605,7 +1653,8 @@ class PageIndexLocalClient(PageIndexClient):
         index_backend: Optional[dict[str, Any]] = None,
         chat_backend: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(None, index_model=index_model, chat_model=chat_model,
+        super().__init__(None, index=index, chat=chat,
+                         index_model=index_model, chat_model=chat_model,
                          model=model, summary_model=summary_model,
                          retrieve_model=retrieve_model, storage_path=storage_path,
                          index_backend=index_backend, chat_backend=chat_backend)

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -58,25 +58,213 @@ def _agents_sdk_model_name(model: str) -> str:
     return f"litellm/{model}"
 
 
+_LOCAL_INDEX_KEYS = ("model", "summary_model", "backend", "storage_path")
+
+# Bare mode words would otherwise parse as model names — a silent wrong
+# mode. Reserved: they error with the real spellings instead.
+_RESERVED_MODE_WORDS = {"cloud", "local", "hosted", "managed"}
+
+
+def _env_cloud_key(spelling: str) -> str:
+    key = os.environ.get("PAGEINDEX_API_KEY")
+    if not key:
+        raise PageIndexAPIError(
+            f"{spelling} reads the PageIndex API key from the "
+            "PAGEINDEX_API_KEY environment variable, which is not set — "
+            "export it, or pass the key inline (api_key=...).")
+    return key
+
+
+def _declared_type(value, side: str):
+    if value not in (None, "cloud", "local"):
+        raise PageIndexAPIError(
+            f'{side} "type" must be "cloud" or "local", not {value!r}.')
+    return value
+
+
+def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
+    """The ``index=`` slot as (cloud api_key, local overrides). A dict
+    declares its side by its keys; an optional "type" states it and must
+    agree. Keyless cloud spellings ("pageindex-cloud", {"type": "cloud"})
+    read the key from the environment."""
+    from .types import PAGEINDEX_CLOUD
+    if isinstance(index, str):
+        # Normalized compare: a case/whitespace variant of the label must
+        # never fall through and silently become a model name.
+        if index.strip().lower() == PAGEINDEX_CLOUD:
+            return _env_cloud_key('index="pageindex-cloud"'), {}
+        if index.strip().lower() in _RESERVED_MODE_WORDS:
+            raise PageIndexAPIError(
+                f'index="{index}" is not a mode word — a bare string here '
+                "is a local index model name. For cloud documents write "
+                '"pageindex-cloud", index={"type": "cloud"} (key from '
+                'PAGEINDEX_API_KEY) or {"api_key": ...}; local is the '
+                "default.")
+        if index.strip():
+            return None, {"index_model": index}
+        raise PageIndexAPIError(
+            "index is an empty string — pass a local index model name, "
+            'or "pageindex-cloud".')
+    if isinstance(index, dict):
+        conf = dict(index)
+        declared = _declared_type(conf.pop("type", None), "index")
+        if not conf:
+            if declared == "cloud":
+                return _env_cloud_key('index={"type": "cloud"}'), {}
+            if declared == "local":
+                return None, {}
+            raise PageIndexAPIError(
+                "index is an empty dict — its keys pick the side: "
+                '{"api_key": ...} for cloud documents, or '
+                f"{', '.join(_LOCAL_INDEX_KEYS)} for the local store.")
+        unknown = set(conf) - {"api_key"} - set(_LOCAL_INDEX_KEYS)
+        if unknown:
+            raise PageIndexAPIError(
+                f"Unknown index keys ({', '.join(sorted(unknown))}) — "
+                'cloud takes "api_key"; local takes '
+                f"{', '.join(_LOCAL_INDEX_KEYS)}.")
+        if "api_key" in conf:
+            if declared == "local":
+                raise PageIndexAPIError(
+                    'index declares type "local" but carries api_key — '
+                    "an API key means cloud documents. Drop one of them.")
+            if len(conf) > 1:
+                raise PageIndexAPIError(
+                    "index mixes cloud and local keys — cloud documents "
+                    'take {"api_key": ...} alone; the cloud pipeline does '
+                    "its own indexing.")
+            key = conf["api_key"]
+            if not key or not isinstance(key, str):
+                raise PageIndexAPIError(
+                    'index["api_key"] must be a non-empty string.')
+            return key, {}
+        if declared == "cloud":
+            raise PageIndexAPIError(
+                'index declares type "cloud" but carries local keys '
+                f"({', '.join(sorted(conf))}) — the cloud pipeline does "
+                'its own indexing; cloud takes "api_key" only.')
+        mapped = {"index_model": conf.get("model"),
+                  "summary_model": conf.get("summary_model"),
+                  "index_backend": conf.get("backend"),
+                  "storage_path": conf.get("storage_path")}
+        return None, {name: value for name, value in mapped.items()
+                      if value is not None}
+    raise PageIndexAPIError("index must be a string or a dict.")
+
+
+def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
+    """The ``chat=`` slot as (mode, own-model overrides) — mode is
+    "managed", "own", or None (nothing declared beyond the overrides)."""
+    from .types import PAGEINDEX_CLOUD
+    if isinstance(chat, str):
+        if chat.strip().lower() == PAGEINDEX_CLOUD:
+            return "managed", {}
+        if chat.strip().lower() in _RESERVED_MODE_WORDS:
+            raise PageIndexAPIError(
+                f'chat="{chat}" is not a mode word — a bare string here is '
+                "your own model name (e.g. \"openai/gpt-5.2\"). For the "
+                'managed chat write "pageindex-cloud" or '
+                '{"type": "cloud"}.')
+        if chat.strip():
+            return "own", {"chat_model": chat}
+        raise PageIndexAPIError(
+            "chat is an empty string — pass a model name, or "
+            '"pageindex-cloud" for the managed chat.')
+    if isinstance(chat, dict):
+        conf = dict(chat)
+        declared = _declared_type(conf.pop("type", None), "chat")
+        unknown = set(conf) - {"model", "backend"}
+        if (not conf and declared is None) or unknown:
+            raise PageIndexAPIError(
+                ("chat is an empty dict" if not conf else
+                 f"Unknown chat keys ({', '.join(sorted(unknown))})")
+                + ' — chat takes "model" and "backend" (your own model), '
+                'or {"type": "cloud"} / "pageindex-cloud" for the managed '
+                "chat.")
+        if declared == "cloud":
+            if conf:
+                raise PageIndexAPIError(
+                    'chat declares type "cloud" but carries '
+                    f"({', '.join(sorted(conf))}) — the managed chat "
+                    "selects its own model. Drop the type, or the keys.")
+            return "managed", {}
+        mapped = {"chat_model": conf.get("model"),
+                  "chat_backend": conf.get("backend")}
+        return "own", {name: value for name, value in mapped.items()
+                       if value is not None}
+    raise PageIndexAPIError("chat must be a string or a dict.")
+
+
 class PageIndexClient:
     """
     Python SDK client for PageIndex.
 
-    Cloud mode (an ``api_key`` is given) talks to the PageIndex API at
-    api.pageindex.ai, exactly like the 0.2.x SDK. Local mode (no ``api_key``)
-    runs the same operations on your machine: documents are indexed with the
-    open-source PageIndex pipeline using your own LLM provider key (e.g.
-    ``OPENAI_API_KEY`` in the environment) and stored under ``storage_path``.
+    Two independent sides, each locally run or cloud-managed:
+
+    - **index** — where documents live. With an ``api_key`` they live in
+      your PageIndex cloud account, indexed by the managed pipeline,
+      exactly like the 0.2.x SDK. Without one they are indexed on your
+      machine by the open-source pipeline (your own LLM provider key,
+      e.g. ``OPENAI_API_KEY``) and stored under ``storage_path``.
+    - **chat** — who answers. With a chat model configured
+      (``chat_model=`` / ``chat=``), the document-QA agent runs in your
+      process against your own model and credentials — in both index
+      modes. On a cloud client with no chat model, the managed cloud
+      chat answers.
+
+    ``api_key`` moves your documents, never your model: ``chat_model``
+    always means your own model on your own keys. The fourth combination
+    (local documents + managed chat) cannot be expressed — the managed
+    chat cannot read your disk.
+
+    Usage:
+        client = PageIndexClient()                  # local docs + your model
+        client = PageIndexClient(api_key="...")     # cloud docs + managed chat
+        client = PageIndexClient(api_key="...",     # cloud docs + your model
+                                 chat_model="openai/gpt-5.2")
+
+    ``index=`` / ``chat=`` are the grouped spelling of the same flat
+    arguments — a string as shorthand, a dict for the full config; each
+    side picks one spelling per client. ``index="pageindex-cloud"`` is
+    the keyless cloud spelling (the key comes from the
+    ``PAGEINDEX_API_KEY`` environment variable — which is read only when
+    the code explicitly says cloud; a bare ``PageIndexClient()`` stays
+    local regardless of the environment).
 
     Args:
         api_key (str, optional): PageIndex cloud API key
             (https://dash.pageindex.ai/api-keys). Omit for local mode.
+        index (str | dict, optional): The index side, grouped —
+            ``"pageindex-cloud"`` (cloud, key from the environment), a
+            local index model name, or a dict: ``{"api_key": ...}`` for
+            cloud, ``{"model", "summary_model", "backend",
+            "storage_path"}`` for local. An optional ``"type"`` key
+            (``"cloud"`` / ``"local"``) states the side and must agree
+            with the other keys; ``{"type": "cloud"}`` alone reads the
+            key from the environment. Not combinable with this side's
+            flat arguments.
+        chat (str | dict, optional): The chat side, grouped — a model
+            name (your own model), ``"pageindex-cloud"`` (managed chat,
+            cloud clients only), or ``{"model", "backend"}``. An
+            optional ``"type"`` key states the side: ``{"type":
+            "cloud"}`` alone is the managed chat, ``"local"`` is your
+            own model and must agree with the other keys. Not
+            combinable with this side's flat arguments.
+        type (str, optional): Client-level declaration of where the
+            documents live — ``"cloud"`` or ``"local"`` — checked
+            against the other arguments (``type="local"`` with an
+            api_key errors). ``type="cloud"`` alone reads the key from
+            the ``PAGEINDEX_API_KEY`` environment variable. Always
+            optional: the arguments themselves already carry the mode.
         index_model (str, optional): Local mode only — LLM used to index
             documents (structure and summaries). Defaults to the SDK
             default (fast and cheap).
-        chat_model (str, optional): Local mode only — the model the chat
-            surfaces (``chat``, ``chat_completions``, ``responses``)
-            default to, exposed as ``client.chat_model``. Chat names
+        chat_model (str, optional): Your own model for the chat surfaces
+            (``chat``, ``chat_completions``, ``responses``), exposed as
+            ``client.chat_model`` — on a cloud client, setting it runs
+            the document-QA agent in your process over the cloud
+            documents (page content then flows through your process to
+            your model provider). Chat names
             route through LiteLLM and mean what LiteLLM says they mean;
             bare names are OpenAI-compatible shorthand, and
             ``openai/Qwen/...`` is the form for an OpenAI-compatible
@@ -104,12 +292,8 @@ class PageIndexClient:
             door runs, in that door's vocabulary (see each method) —
             ``api_key`` / ``base_url`` mean the same thing on all three.
 
-    Usage:
-        client = PageIndexClient(api_key="...")   # cloud
-        client = PageIndexClient()                # local
-
-    PageIndexCloudClient / PageIndexLocalClient pin the mode at construction
-    instead of inferring it from api_key.
+    PageIndexCloudClient / PageIndexLocalClient pin the index side at
+    construction instead of inferring it from api_key.
 
     Local mode differences (all documented per method): indexing is
     synchronous, only PDFs are supported, and folders / ``beta_headers`` /
@@ -123,6 +307,9 @@ class PageIndexClient:
         self,
         api_key: Optional[str] = None,
         *,
+        index: Optional[Union[dict[str, Any], str]] = None,
+        chat: Optional[Union[dict[str, Any], str]] = None,
+        type: Optional[str] = None,
         index_model: Optional[str] = None,
         chat_model: Optional[str] = None,
         model: Optional[str] = None,
@@ -137,40 +324,100 @@ class PageIndexClient:
                 "api_key is an empty string. Pass a real PageIndex API key for "
                 "cloud mode, or omit api_key entirely for local mode."
             )
-        model_args = {"index_model": index_model, "chat_model": chat_model,
-                      "model": model, "summary_model": summary_model,
-                      "retrieve_model": retrieve_model}
-        if api_key is not None:
-            local_only = dict(model_args, storage_path=storage_path,
-                              index_backend=index_backend,
-                              chat_backend=chat_backend)
-            passed = [name for name, value in local_only.items() if value is not None]
-            if passed:
+        # Each side picks one spelling — its slot, or the flat arguments.
+        # ``model`` sets every role, so it claims both sides.
+        index_flat: dict[str, Any] = {
+            name: value for name, value in
+            (("api_key", api_key), ("type", type),
+             ("index_model", index_model),
+             ("summary_model", summary_model),
+             ("index_backend", index_backend),
+             ("storage_path", storage_path), ("model", model))
+            if value is not None}
+        chat_flat: dict[str, Any] = {
+            name: value for name, value in
+            (("chat_model", chat_model),
+             ("retrieve_model", retrieve_model),
+             ("chat_backend", chat_backend), ("model", model))
+            if value is not None}
+        if index is not None and index_flat:
+            raise PageIndexAPIError(
+                "index= and the flat index-side arguments "
+                f"({', '.join(sorted(index_flat))}) are two spellings of "
+                "the same thing — use one or the other.")
+        if chat is not None and chat_flat:
+            raise PageIndexAPIError(
+                "chat= and the flat chat-side arguments "
+                f"({', '.join(sorted(chat_flat))}) are two spellings of "
+                "the same thing — use one or the other.")
+        if index is not None:
+            cloud_key, index_conf = _resolve_index_slot(index)
+        else:
+            declared = _declared_type(index_flat.pop("type", None), "client")
+            cloud_key = api_key
+            if declared == "local" and api_key is not None:
                 raise PageIndexAPIError(
-                    f"Local-mode arguments ({', '.join(passed)}) cannot be "
-                    "combined with api_key — remove them, or omit api_key to "
-                    "run locally."
-                )
-            self.api_key = api_key
+                    'type="local" conflicts with api_key — an API key '
+                    "means cloud documents. Drop one of them.")
+            if declared == "cloud" and cloud_key is None:
+                cloud_key = _env_cloud_key('type="cloud"')
+            index_conf = {name: value for name, value in index_flat.items()
+                          if name != "api_key"}
+        if chat is not None:
+            chat_mode, chat_conf = _resolve_chat_slot(chat)
+        else:
+            chat_mode = "own" if chat_flat else None
+            chat_conf = chat_flat
+
+        if cloud_key is not None:
+            if index_conf:
+                raise PageIndexAPIError(
+                    "Cloud documents are indexed by the PageIndex pipeline "
+                    "— the index-side arguments "
+                    f"({', '.join(sorted(index_conf))}) have nothing to "
+                    "configure there; remove them. (chat_model= / chat= "
+                    "stay yours: they run the chat agent in your process "
+                    "with your own model.)")
+            self.api_key = cloud_key
             from .cloud_api import CloudAPI
             self._api = CloudAPI(self)
+            self._local_chat = chat_mode == "own"
+            if self._local_chat:
+                from .utils import ConfigLoader
+                overrides = {name: value for name, value in chat_conf.items()
+                             if name in ("chat_model", "retrieve_model")
+                             and value}
+                opt = ConfigLoader().load(overrides or None)
+                self.chat_model = opt.chat_model
+                self.chat_backend = chat_conf.get("chat_backend")
+                _preload_litellm()
         else:
+            if chat_mode == "managed":
+                raise PageIndexAPIError(
+                    "The managed chat needs cloud documents — it cannot "
+                    "read the local store. Go cloud (api_key=... or "
+                    'index="pageindex-cloud"), or set your own chat model '
+                    "instead.")
             from .utils import ConfigLoader
-            overrides = {key: value for key, value in model_args.items()
-                         if value}
+            overrides = {name: value for name, value in
+                         {**index_conf, **chat_conf}.items()
+                         if name in ("model", "index_model", "summary_model",
+                                     "chat_model", "retrieve_model")
+                         and value}
             opt = ConfigLoader().load(overrides or None)
             self.model = opt.model
             self.index_model = opt.index_model
             self.summary_model = opt.summary_model
             self.chat_model = opt.chat_model
-            self.chat_backend = chat_backend
-            self.storage_path = storage_path or ".pageindex"
+            self.chat_backend = chat_conf.get("chat_backend")
+            self.storage_path = index_conf.get("storage_path") or ".pageindex"
+            self._local_chat = True
             from .local_api import LocalAPI
             self._api = LocalAPI(
                 storage_path=self.storage_path,
                 model=self.model,
                 summary_model=self.summary_model,
-                index_backend=index_backend,
+                index_backend=index_conf.get("index_backend"),
             )
             # LiteLLM's multi-second import would otherwise land on the
             # first chat call; failures resurface there with real context.
@@ -415,7 +662,7 @@ class PageIndexClient:
         """
         Ask a question about your documents, get the answer.
 
-        Thin sugar over ``chat_completions()`` in both modes — same
+        Thin sugar over ``chat_completions()`` in every mode — same
         engine, same wire, minus the envelope. Multi-turn: keep your own
         role/content list of the visible conversation (append each answer
         as an assistant message) and pass it back. For usage accounting,
@@ -428,9 +675,10 @@ class PageIndexClient:
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls.
             stream: Yield the answer as text chunks as it is produced.
-            model: Local only — backend model name (defaults to
-                ``chat_model``).
-            reasoning_effort: Local only — how hard the model thinks
+            model: Own-model chat only — backend model name (defaults
+                to ``chat_model``).
+            reasoning_effort: Own-model chat only — how hard the model
+                thinks
                 (``"low"`` / ``"medium"`` / ``"high"``; what a backend
                 accepts is its own). Unset sends nothing — the model's
                 default behavior applies.
@@ -472,9 +720,13 @@ class PageIndexClient:
         """
         PageIndex Chat Completions: document QA in one call.
 
-        Cloud: the hosted chat endpoint. Local: a managed document-QA agent
-        run over the local tools against your own LLM backend, routed
-        through LiteLLM — model names mean what LiteLLM says they mean.
+        With no chat model configured (a plain cloud client): the managed
+        hosted chat endpoint. With one — local mode, or a cloud client
+        constructed with ``chat_model=``/``chat=`` (own-model chat) — a
+        managed document-QA agent runs in your process over the mode's
+        tools (local store, or the live cloud tool set) against your own
+        LLM backend, routed through LiteLLM — model names mean what
+        LiteLLM says they mean.
         Bare names are OpenAI-compatible shorthand (the OpenAI SDK's usual
         env config — OPENAI_API_KEY, OPENAI_BASE_URL — selects the
         backend, so any OpenAI-compatible server works; write
@@ -493,11 +745,11 @@ class PageIndexClient:
         Args:
             messages: Conversation messages with 'role' and 'content' keys,
                 or a bare query string (it becomes a single user message).
-                Local also accepts system/developer messages — their content
-                is appended to the managed system prompt. Local takes text
-                history only: tool-role turns are rejected (the cloud
-                endpoint forwards them verbatim), and message fields beyond
-                role/content are dropped.
+                Own-model chat also accepts system/developer messages —
+                their content is appended to the managed system prompt —
+                and takes text history only: tool-role turns are rejected
+                (the managed endpoint forwards them verbatim), and message
+                fields beyond role/content are dropped.
             stream: Enable streaming responses.
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls — the
@@ -506,33 +758,33 @@ class PageIndexClient:
             temperature: Sampling temperature, passed through to the model.
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
-            enable_citations: Cloud-only — local mode raises (citations need
-                block-level OCR data local mode does not store).
-            model: Local only — backend model name (defaults to
-                ``chat_model``). The cloud endpoint selects its own.
-            max_turns: Local only — cap on agent turns per call.
-            top_p: Local only — nucleus sampling, passed through to the
+            enable_citations: Managed chat only — own-model chat raises
+                (the in-process engine has no citation machinery).
+            model: Own-model chat only — backend model name (defaults to
+                ``chat_model``). The managed endpoint selects its own.
+            max_turns: Own-model chat only — cap on agent turns per call.
+            top_p: Own-model chat only — nucleus sampling, passed through to the
                 model.
-            max_tokens: Local only — per-call output cap, passed through;
+            max_tokens: Own-model chat only — per-call output cap, passed through;
                 it bounds each backend call in the agent loop (the way
                 max_turns bounds the loop), not the whole run.
-            reasoning_effort: Local only — passed through verbatim as
+            reasoning_effort: Own-model chat only — passed through verbatim as
                 LiteLLM's ``reasoning_effort``; each provider maps it to
                 its own thinking control, and the values mean what the
                 backend says they mean. Unset sends nothing (the
                 backend's default applies).
-            extra_body: Local only — extra request fields beyond this
+            extra_body: Own-model chat only — extra request fields beyond this
                 method's parameters, merged last so they win.
                 OpenAI-compatible backends take them verbatim in the
                 request body; LiteLLM-routed providers take them as
                 LiteLLM's own params (mapped or refused per provider).
                 Credentials belong in ``backend``, never here.
-            extra_headers: Local only — extra HTTP headers merged into
+            extra_headers: Own-model chat only — extra HTTP headers merged into
                 each backend request; caller headers win. One exception:
                 LiteLLM's anthropic adapter owns the ``anthropic-beta``
                 header (your value is dropped there) — use ``messages()``
                 for Anthropic beta flags.
-            backend: Local only — connection overrides for this call's
+            backend: Own-model chat only — connection overrides for this call's
                 backend, merged over the client's ``chat_backend``
                 (per-call keys win). Keys are LiteLLM's own connection
                 params — ``api_key``, ``base_url``, ``api_version``,
@@ -550,8 +802,7 @@ class PageIndexClient:
                     "messages must be a non-empty string or a list of "
                     "message dicts.")
             messages = [{"role": "user", "content": messages}]
-        from .cloud_api import CloudAPI
-        if not isinstance(self._api, CloudAPI):
+        if self._local_chat:
             from .local_chat import run_chat_completions
             return run_chat_completions(
                 self, messages, stream=stream, doc_id=doc_id,
@@ -567,10 +818,14 @@ class PageIndexClient:
                 or backend is not None):
             raise PageIndexAPIError(
                 "model, max_turns, top_p, max_tokens, reasoning_effort, "
-                "extra_body, extra_headers and backend are local-mode "
-                "parameters — the cloud chat endpoint selects its own model."
+                "extra_body, extra_headers and backend drive your own chat "
+                "model, which this client does not configure — construct "
+                "the client with chat_model=... (or chat=...) to run the "
+                "agent in your process, or drop them to use the managed "
+                "chat endpoint, which selects its own model."
             )
-        return self._api.chat_completions(
+        from .cloud_api import CloudAPI
+        return cast(CloudAPI, self._api).chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
             temperature=temperature, stream_metadata=stream_metadata,
             enable_citations=enable_citations,
@@ -595,7 +850,9 @@ class PageIndexClient:
         """
         Document QA over the OpenAI Responses protocol — the agentic surface.
 
-        Local only for now. Drives your backend's /responses end to end (no
+        Own-model chat only — local mode, or a cloud client constructed
+        with ``chat_model=``/``chat=``. Drives your backend's /responses
+        end to end (no
         translation layer). The envelope is official Responses shape —
         ``output`` carries the model-produced items and parses with the
         openai SDK types — and the whole process transcript (including the
@@ -650,11 +907,11 @@ class PageIndexClient:
                 ``api_key``, ``base_url``, ``organization``, … — passed
                 verbatim; unknown keys raise.
         """
-        from .cloud_api import CloudAPI
-        if isinstance(self._api, CloudAPI):
+        if not self._local_chat:
             raise PageIndexAPIError(
-                "responses is not available on PageIndex cloud yet — it is "
-                "a local-mode surface for now."
+                "responses() drives your own chat model — construct the "
+                "client with chat_model=... (or chat=...); the managed "
+                "cloud chat serves chat_completions() only."
             )
         from .local_chat import run_responses
         return run_responses(
@@ -686,7 +943,9 @@ class PageIndexClient:
         """
         Document QA over the Anthropic Messages protocol — Claude-native.
 
-        Local only for now. Drives Anthropic's /v1/messages via the
+        Own-model chat only — local mode, or a cloud client constructed
+        with ``chat_model=``/``chat=``. Drives Anthropic's /v1/messages
+        via the
         Anthropic SDK's own tool runner (requires ``pageindex[anthropic]``;
         ANTHROPIC_API_KEY selects the backend). ``tool_use``/``tool_result``
         round-trip is the format's native behavior: the response is the
@@ -736,11 +995,11 @@ class PageIndexClient:
                 ``api_key``, ``base_url``, ``auth_token``, … — passed
                 verbatim; unknown keys raise.
         """
-        from .cloud_api import CloudAPI
-        if isinstance(self._api, CloudAPI):
+        if not self._local_chat:
             raise PageIndexAPIError(
-                "messages is not available on PageIndex cloud yet — it is "
-                "a local-mode surface for now."
+                "messages() drives your own chat model — construct the "
+                "client with chat_model=... (or chat=...); the managed "
+                "cloud chat serves chat_completions() only."
             )
         from .local_chat import run_messages
         return run_messages(
@@ -907,8 +1166,9 @@ class PageIndexClient:
 
         Sugar over the explicit form — ``agent_instructions`` (with
         ``doc_id`` targeting) as the instructions and
-        ``as_openai_tools`` as the tools; local clients also carry their
-        configured ``chat_model`` (cloud omits ``model`` so the
+        ``as_openai_tools`` as the tools; clients with a configured
+        ``chat_model`` — local mode, or cloud with ``chat_model=`` —
+        also carry it (a plain cloud client omits ``model`` so the
         framework default applies). To customize further, switch to
         those methods directly. You run this config in your own
         environment, so its model auth comes from there —
@@ -1235,13 +1495,18 @@ class PageIndexClient:
 
 
 class PageIndexCloudClient(PageIndexClient):
-    """Cloud mode — requires a real API key at construction."""
+    """Cloud mode — the class name says cloud, so the key may come from
+    the environment: ``PageIndexCloudClient()`` reads PAGEINDEX_API_KEY.
+    The shortest env-key cloud spelling."""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: Optional[str] = None):
+        if api_key is None:
+            api_key = os.environ.get("PAGEINDEX_API_KEY")
         if not api_key:
             raise PageIndexAPIError(
-                "PageIndexCloudClient requires a PageIndex API key — get one "
-                "at https://dash.pageindex.ai/api-keys."
+                "PageIndexCloudClient requires a PageIndex API key — pass "
+                "api_key=..., or export PAGEINDEX_API_KEY. Get one at "
+                "https://dash.pageindex.ai/api-keys."
             )
         super().__init__(api_key)
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -65,14 +65,27 @@ _LOCAL_INDEX_KEYS = ("model", "summary_model", "backend", "storage_path")
 _RESERVED_MODE_WORDS = {"cloud", "local", "hosted", "managed"}
 
 
-def _env_cloud_key(spelling: str) -> str:
+def _env_cloud_key(spelling: str, inline: str = "api_key=...") -> str:
+    # .env support lives in utils' import-time load_dotenv(): load it
+    # before the read, or a key in .env is visible only by import order.
+    from . import utils  # noqa: F401
     key = os.environ.get("PAGEINDEX_API_KEY")
     if not key:
         raise PageIndexAPIError(
             f"{spelling} reads the PageIndex API key from the "
             "PAGEINDEX_API_KEY environment variable, which is not set — "
-            "export it, or pass the key inline (api_key=...).")
+            f"export it, or pass the key inline ({inline}).")
     return key
+
+
+# One argument vocabulary regardless of spelling: every value is shape-
+# checked in the constructor, so a wrong type or an empty value refuses
+# there as a PageIndexAPIError — never later, never silently.
+_ARG_TYPES: "dict[str, tuple[type, ...]]" = {
+    "model": (str,), "index_model": (str,), "summary_model": (str,),
+    "chat_model": (str,), "retrieve_model": (str,),
+    "storage_path": (str, os.PathLike), "index_backend": (dict,),
+    "chat_backend": (dict,)}
 
 
 def _declared_type(value, side: str):
@@ -92,7 +105,8 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
         # Normalized compare: a case/whitespace variant of the label must
         # never fall through and silently become a model name.
         if index.strip().lower() == PAGEINDEX_CLOUD:
-            return _env_cloud_key('index="pageindex-cloud"'), {}
+            return _env_cloud_key('index="pageindex-cloud"',
+                                  'index={"api_key": ...}'), {}
         if index.strip().lower() in _RESERVED_MODE_WORDS:
             raise PageIndexAPIError(
                 f'index="{index}" is not a mode word — a bare string here '
@@ -101,16 +115,19 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
                 'PAGEINDEX_API_KEY) or {"api_key": ...}; local is the '
                 "default.")
         if index.strip():
-            return None, {"index_model": index}
+            return None, {"index_model": index.strip()}
         raise PageIndexAPIError(
             "index is an empty string — pass a local index model name, "
             'or "pageindex-cloud".')
     if isinstance(index, dict):
-        conf = dict(index)
+        # None-valued keys mean "absent", exactly like the flat arguments.
+        conf = {name: value for name, value in index.items()
+                if value is not None}
         declared = _declared_type(conf.pop("type", None), "index")
         if not conf:
             if declared == "cloud":
-                return _env_cloud_key('index={"type": "cloud"}'), {}
+                return _env_cloud_key('index={"type": "cloud"}',
+                                      'index={"api_key": ...}'), {}
             if declared == "local":
                 return None, {}
             raise PageIndexAPIError(
@@ -166,12 +183,14 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
                 'managed chat write "pageindex-cloud" or '
                 '{"type": "cloud"}.')
         if chat.strip():
-            return "own", {"chat_model": chat}
+            return "own", {"chat_model": chat.strip()}
         raise PageIndexAPIError(
             "chat is an empty string — pass a model name, or "
             '"pageindex-cloud" for the managed chat.')
     if isinstance(chat, dict):
-        conf = dict(chat)
+        # None-valued keys mean "absent", exactly like the flat arguments.
+        conf = {name: value for name, value in chat.items()
+                if value is not None}
         declared = _declared_type(conf.pop("type", None), "chat")
         unknown = set(conf) - {"model", "backend"}
         if (not conf and declared is None) or unknown:
@@ -278,16 +297,17 @@ class PageIndexClient:
         summary_model (str, optional): Local mode only — legacy: overrides
             the model used for node summaries and document descriptions;
             ``index_model`` covers this.
-        retrieve_model (str, optional): Local mode only — legacy name for
-            ``chat_model``.
+        retrieve_model (str, optional): Legacy name for ``chat_model`` —
+            same meaning everywhere, cloud clients included.
         storage_path (str, optional): Local mode only — directory where
             indexed documents are stored. Defaults to ``./.pageindex``.
         index_backend (dict, optional): Local mode only — connection
             overrides for the indexing lane's LLM calls. Keys are
             LiteLLM's own connection params — ``api_key``, ``api_base``,
             ``api_version``, ``aws_*``, … — passed through verbatim.
-        chat_backend (dict, optional): Local mode only — default
-            connection overrides for the chat surfaces; a call's own
+        chat_backend (dict, optional): Default connection overrides for
+            the chat surfaces — a chat-side argument like ``chat_model``,
+            so on a cloud client it selects own-model chat. A call's own
             ``backend`` keys win over it. The dict reaches whichever
             door runs, in that door's vocabulary (see each method) —
             ``api_key`` / ``base_url`` mean the same thing on all three.
@@ -340,6 +360,11 @@ class PageIndexClient:
              ("retrieve_model", retrieve_model),
              ("chat_backend", chat_backend), ("model", model))
             if value is not None}
+        if model is not None and (index is not None or chat is not None):
+            raise PageIndexAPIError(
+                "model= sets both roles at once, so no slot can absorb "
+                "it — split it into index_model= and chat_model= to "
+                "combine with index=/chat=.")
         if index is not None and index_flat:
             raise PageIndexAPIError(
                 "index= and the flat index-side arguments "
@@ -368,6 +393,21 @@ class PageIndexClient:
         else:
             chat_mode = "own" if chat_flat else None
             chat_conf = chat_flat
+        # Every spelling lands here: wrong types and empty values refuse
+        # loudly — an empty chat-side value must never silently select
+        # own-model chat.
+        for conf in (index_conf, chat_conf):
+            for name, value in conf.items():
+                if not isinstance(value, _ARG_TYPES[name]):
+                    # value.__class__: the ``type=`` parameter shadows the
+                    # builtin in this scope.
+                    raise PageIndexAPIError(
+                        f"{name} must be a {_ARG_TYPES[name][0].__name__}, "
+                        f"got {value.__class__.__name__}.")
+                if not value:
+                    raise PageIndexAPIError(
+                        f"{name} is empty — it configures nothing. Pass a "
+                        "real value, or drop the argument.")
 
         if cloud_key is not None:
             if index_conf:
@@ -381,8 +421,7 @@ class PageIndexClient:
             self.api_key = cloud_key
             from .cloud_api import CloudAPI
             self._api = CloudAPI(self)
-            self._local_chat = chat_mode == "own"
-            if self._local_chat:
+            if chat_mode == "own":
                 from .utils import ConfigLoader
                 overrides = {name: value for name, value in chat_conf.items()
                              if name in ("chat_model", "retrieve_model")
@@ -411,7 +450,6 @@ class PageIndexClient:
             self.chat_model = opt.chat_model
             self.chat_backend = chat_conf.get("chat_backend")
             self.storage_path = index_conf.get("storage_path") or ".pageindex"
-            self._local_chat = True
             from .local_api import LocalAPI
             self._api = LocalAPI(
                 storage_path=self.storage_path,
@@ -422,6 +460,13 @@ class PageIndexClient:
             # LiteLLM's multi-second import would otherwise land on the
             # first chat call; failures resurface there with real context.
             _preload_litellm()
+
+    @property
+    def _local_chat(self) -> bool:
+        # Derived, never stored: own-model chat is exactly "a chat model
+        # is configured", so a post-construction ``client.chat_model = m``
+        # switches the whole client, not half of it.
+        return hasattr(self, "chat_model")
 
     @property
     def retrieve_model(self):
@@ -1501,6 +1546,8 @@ class PageIndexCloudClient(PageIndexClient):
 
     def __init__(self, api_key: Optional[str] = None):
         if api_key is None:
+            # .env keys arrive via utils' import-time load_dotenv().
+            from . import utils  # noqa: F401
             api_key = os.environ.get("PAGEINDEX_API_KEY")
         if not api_key:
             raise PageIndexAPIError(

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -109,7 +109,7 @@ def _resolve_index_slot(index) -> "tuple[Optional[str], dict[str, Any]]":
                                   'index={"api_key": ...}'), {}
         if index.strip().lower() in _RESERVED_MODE_WORDS:
             raise PageIndexAPIError(
-                f'index="{index}" is not a mode word — a bare string here '
+                f'index="{index}" is a reserved word — a bare string here '
                 "is a local index model name. For cloud documents write "
                 '"pageindex-cloud", index={"mode": "cloud"} (key from '
                 'PAGEINDEX_API_KEY) or {"api_key": ...}; local is the '
@@ -178,7 +178,7 @@ def _resolve_chat_slot(chat) -> "tuple[Optional[str], dict[str, Any]]":
             return "managed", {}
         if chat.strip().lower() in _RESERVED_MODE_WORDS:
             raise PageIndexAPIError(
-                f'chat="{chat}" is not a mode word — a bare string here is '
+                f'chat="{chat}" is a reserved word — a bare string here is '
                 "your own model name (e.g. \"openai/gpt-5.2\"). For the "
                 'managed chat write "pageindex-cloud" or '
                 '{"mode": "cloud"}.')

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -170,7 +170,8 @@ def _require_openai_agents(method: str) -> None:
         import agents  # noqa: F401
     except ImportError as exc:
         raise PageIndexAPIError(
-            f"{method} in local mode requires the OpenAI Agents SDK — "
+            f"{method} with your own chat model requires the OpenAI "
+            "Agents SDK — "
             "pip install openai-agents. "
             "messages() runs on the anthropic extra instead."
         ) from exc
@@ -863,7 +864,8 @@ def _require_anthropic() -> None:
         import anthropic  # noqa: F401
     except ImportError as exc:
         raise PageIndexAPIError(
-            "messages in local mode requires the Anthropic SDK — "
+            "messages drives your own chat model and requires the "
+            "Anthropic SDK — "
             "pip install anthropic (or pip install 'pageindex[anthropic]')."
         ) from exc
     try:
@@ -871,7 +873,7 @@ def _require_anthropic() -> None:
         from anthropic.lib.tools import ToolError  # noqa: F401
     except ImportError as exc:
         raise PageIndexAPIError(
-            "messages in local mode requires anthropic >= 0.108.0 (the tool "
+            "messages requires anthropic >= 0.108.0 (the tool "
             "runner with ToolError) — pip install -U anthropic."
         ) from exc
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -401,7 +401,8 @@ def _model_backend_error(exc, lane: str, client=None) -> PageIndexAPIError:
             else "."
         )
     if (getattr(client, "api_key", None)
-            and "api key" in str(exc).lower().replace("_", " ")):
+            and (getattr(exc, "status_code", None) == 401
+                 or "api key" in str(exc).lower().replace("_", " "))):
         message += (
             " — note: your chat model runs in your process on your own "
             "provider credentials; the PageIndex api_key does not cover "
@@ -1063,8 +1064,7 @@ def run_messages(client, messages, model: str,
                     for event in turn_stream:
                         yield event
             except anthropic.AnthropicError as exc:
-                raise PageIndexAPIError(
-                    f"The model backend failed: {exc}") from exc
+                raise _model_backend_error(exc, "messages", client) from exc
             except TypeError as exc:
                 # the SDK's request-time credential-resolution failure
                 if "authentication" not in str(exc).lower():
@@ -1082,8 +1082,7 @@ def run_messages(client, messages, model: str,
     try:
         turns = [turn for turn in runner]
     except anthropic.AnthropicError as exc:
-        raise PageIndexAPIError(
-            f"The model backend failed: {exc}") from exc
+        raise _model_backend_error(exc, "messages", client) from exc
     except TypeError as exc:
         # the SDK's request-time credential-resolution failure
         if "authentication" not in str(exc).lower():

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -10,7 +10,7 @@ import time
 import uuid
 from typing import Any, Iterator, Optional, Union
 
-from .agent_tools import AGENT_INSTRUCTIONS, doc_targeting_block
+from .agent_tools import _base_instructions, doc_targeting_block
 from .errors import PageIndexAPIError
 
 CHAT_HEADER = (
@@ -21,20 +21,24 @@ CHAT_HEADER = (
 
 # ── shared: prompt, doc targeting, validation, sync bridges ──
 
-def _managed_instructions(extra_system: list[str]) -> str:
-    return "\n\n".join([CHAT_HEADER, AGENT_INSTRUCTIONS, *extra_system])
+def _managed_instructions(client, extra_system: list[str]) -> str:
+    # Local: the built-in subset guidance. Own-model chat over cloud
+    # documents: the live instructions the MCP server serves.
+    base: str = _base_instructions(client)
+    return "\n\n".join([CHAT_HEADER, base, *extra_system])
 
 
-def _doc_block(client, doc_id) -> Optional[str]:
+def _doc_block(client, doc_id, scoped: bool) -> Optional[str]:
     if doc_id is None:
         return None
     if not isinstance(doc_id, (str, list)):
         raise PageIndexAPIError("doc_id must be a string or a list of "
                                 "strings.")
-    # scoped: the chat surfaces also pass doc_id into the tool layer, so
-    # name resolution happens inside the allowlist — only a duplicate name
-    # within the targeted set shadows.
-    return doc_targeting_block(client, doc_id, scoped=True)
+    # scoped: local surfaces also pass doc_id into the tool layer, so name
+    # resolution happens inside the allowlist — only a duplicate name
+    # within the targeted set shadows. Cloud tools take no allowlist
+    # (targeting is prompt-level), so the whole library shadows.
+    return doc_targeting_block(client, doc_id, scoped=scoped)
 
 
 def _system_text(content: Any) -> str:
@@ -375,13 +379,16 @@ def _conversation_cache_key(model_name: str, instructions: str, doc_id,
     return "pageindex-" + hashlib.sha256(seed.encode()).hexdigest()[:16]
 
 
-def _model_backend_error(exc, lane: str) -> PageIndexAPIError:
+def _model_backend_error(exc, lane: str, client=None) -> PageIndexAPIError:
     """Wrap a provider failure; the sol-class refusal (chatcmpl rejects
     function tools while reasoning is on) gets its documented exits
     appended, since the fix is a different route, not a retry. The exits
     are per-lane: of the chat lane's three, two are dead ends for a
     responses() caller — it IS the other lane, and its reasoning knob is
-    ``reasoning``, not ``reasoning_effort``."""
+    ``reasoning``, not ``reasoning_effort``. On a cloud client an
+    auth-shaped failure gets the own-model architecture spelled out —
+    the misreading it corrects ("the cloud runs my model") surfaces
+    exactly here."""
     message = f"The model backend failed: {exc}"
     if "Function tools with reasoning_effort" in str(exc):
         message += (
@@ -393,17 +400,24 @@ def _model_backend_error(exc, lane: str) -> PageIndexAPIError:
             "efforts), or call responses() instead." if lane == "chat"
             else "."
         )
+    if (getattr(client, "api_key", None)
+            and "api key" in str(exc).lower().replace("_", " ")):
+        message += (
+            " — note: your chat model runs in your process on your own "
+            "provider credentials; the PageIndex api_key does not cover "
+            "it. Set the provider key (or chat_backend), or drop the "
+            "chat model configuration to use the managed cloud chat.")
     return PageIndexAPIError(message)
 
 
-def _translate_run_error(exc, max_turns, lane) -> PageIndexAPIError:
+def _translate_run_error(exc, max_turns, lane, client=None) -> PageIndexAPIError:
     """The uncaught-run ladder every agent door shares."""
     from agents.exceptions import AgentsException, MaxTurnsExceeded
     if isinstance(exc, MaxTurnsExceeded):
         return _wrap_max_turns(max_turns)
     if isinstance(exc, AgentsException):
         return PageIndexAPIError(f"The agent backend failed: {exc}")
-    return _model_backend_error(exc, lane)
+    return _model_backend_error(exc, lane, client)
 
 
 def _run_kwargs(max_turns) -> dict:
@@ -575,19 +589,22 @@ def run_chat_completions(client, messages, stream: bool = False,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
-            "enable_citations is cloud-only — citations need block-level OCR "
-            "data that local mode does not store."
-        )
+            "enable_citations is cloud-only — it needs the managed chat "
+            + ("endpoint: drop the chat model configuration to use it."
+               if getattr(client, "api_key", None) else
+               "endpoint; local mode does not store the block-level OCR "
+               "data citations need."))
     _require_openai_agents("chat_completions")
     _validate_max_turns(max_turns)
     system_texts, history = _split_chat_messages(messages)
-    block = _doc_block(client, doc_id)
+    scope = client._local_doc_scope(doc_id)
+    block = _doc_block(client, doc_id, scoped=scope is not None)
     items = ([{"role": "user", "content": block}] if block else []) + history
     model_name = model or client.chat_model
     reported_model = _reported_model(model_name)
-    managed = _managed_instructions(system_texts)
+    managed = _managed_instructions(client, system_texts)
     agent = _openai_agent(client, "chat", model_name, managed,
-                          temperature, top_p, doc_ids=doc_id,
+                          temperature, top_p, doc_ids=scope,
                           cache_key=_conversation_cache_key(
                               model_name, managed, doc_id, history),
                           reasoning_effort=reasoning_effort,
@@ -606,7 +623,7 @@ def run_chat_completions(client, messages, stream: bool = False,
                 Runner.run(agent, input=items, **run_kwargs)))
         except (MaxTurnsExceeded, AgentsException,
                 openai.OpenAIError) as exc:
-            raise _translate_run_error(exc, max_turns, "chat") from exc
+            raise _translate_run_error(exc, max_turns, "chat", client) from exc
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex}",
             "object": "chat.completion",
@@ -647,7 +664,7 @@ def run_chat_completions(client, messages, stream: bool = False,
             completed = True
         except (MaxTurnsExceeded, AgentsException,
                 openai.OpenAIError) as exc:
-            raise _translate_run_error(exc, max_turns, "chat") from exc
+            raise _translate_run_error(exc, max_turns, "chat", client) from exc
         finally:
             if not completed and hasattr(streamed, "cancel"):
                 streamed.cancel()  # abandoned/failed: stop the agent task
@@ -690,15 +707,16 @@ def run_responses(client, input, model: Optional[str] = None,
     else:
         raise PageIndexAPIError("input must be a non-empty string or list "
                                 "of item dicts.")
-    block = _doc_block(client, doc_id)
+    scope = client._local_doc_scope(doc_id)
+    block = _doc_block(client, doc_id, scoped=scope is not None)
     conversation = items
     if block:
         items = [{"role": "user", "content": block}] + items
     extra = [instructions] if instructions else []
     model_name = model or client.chat_model
-    managed = _managed_instructions(extra)
+    managed = _managed_instructions(client, extra)
     agent = _openai_agent(client, "responses", model_name, managed,
-                          temperature, top_p, doc_ids=doc_id,
+                          temperature, top_p, doc_ids=scope,
                           cache_key=_conversation_cache_key(
                               model_name, managed, doc_id, conversation),
                           reasoning=reasoning, extra_body=extra_body,
@@ -752,7 +770,7 @@ def run_responses(client, input, model: Optional[str] = None,
         except (MaxTurnsExceeded, AgentsException,
                 openai.OpenAIError) as exc:
             raise _translate_run_error(exc, max_turns,
-                                       "responses") from exc
+                                       "responses", client) from exc
         transcript = result.to_input_list()[len(items):]
         return envelope(transcript, result.raw_responses)
 
@@ -816,11 +834,11 @@ def run_responses(client, input, model: Optional[str] = None,
             if (isinstance(exc, MaxTurnsExceeded)
                     or recorded.get("status") not in ("failed", "incomplete")):
                 raise _translate_run_error(exc, max_turns,
-                                           "responses") from exc
+                                           "responses", client) from exc
             completed = True
         except openai.OpenAIError as exc:
             raise _translate_run_error(exc, max_turns,
-                                       "responses") from exc
+                                       "responses", client) from exc
         finally:
             if not completed and hasattr(streamed, "cancel"):
                 streamed.cancel()  # abandoned/failed: stop the agent task
@@ -888,13 +906,13 @@ def _anthropic_client(backend=None):
     return client
 
 
-def _anthropic_system(extra_system, block: Optional[str]) -> list[dict]:
+def _anthropic_system(client, extra_system, block: Optional[str]) -> list[dict]:
     """System blocks: cache_control marks the stable managed prefix only
     (the API allows 4 breakpoints total — the varying doc block and caller
     blocks must not consume the budget); the doc block and caller system
     content follow as their own blocks."""
     blocks = [{"type": "text",
-               "text": CHAT_HEADER + "\n\n" + AGENT_INSTRUCTIONS,
+               "text": CHAT_HEADER + "\n\n" + _base_instructions(client),
                "cache_control": {"type": "ephemeral"}}]
     if block:
         blocks.append({"type": "text", "text": block})
@@ -1002,14 +1020,15 @@ def run_messages(client, messages, model: str,
             or not all(isinstance(message, dict) for message in messages)):
         raise PageIndexAPIError("messages must be a non-empty string or a "
                                 "list of message dicts.")
-    block = _doc_block(client, doc_id)
+    scope = client._local_doc_scope(doc_id)
+    block = _doc_block(client, doc_id, scoped=scope is not None)
     prepared = [dict(message) for message in messages]
     passthrough = {key: value for key, value in {
         "temperature": temperature, "top_p": top_p, "top_k": top_k,
         "stop_sequences": stop_sequences, "thinking": thinking,
         "extra_body": extra_body, "extra_headers": extra_headers,
     }.items() if value is not None}
-    system_blocks = _anthropic_system(system, block)
+    system_blocks = _anthropic_system(client, system, block)
     # Top-level cache_control: the server re-marks the newest block each
     # turn, so the loop re-reads the growing conversation from cache.
     # Counts toward the 4-breakpoint limit (live-verified 400 past it).
@@ -1028,7 +1047,7 @@ def run_messages(client, messages, model: str,
         max_tokens=max_tokens,
         messages=prepared,
         model=model,
-        tools=build_anthropic_tools(client, doc_ids=doc_id),
+        tools=build_anthropic_tools(client, doc_ids=scope),
         system=system_blocks,
         stream=stream,
         # Bounded like the OpenAI surfaces (their framework default is 10).

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -407,8 +407,11 @@ def _model_backend_error(exc, lane: str, client=None) -> PageIndexAPIError:
         message += (
             " — note: your chat model runs in your process on your own "
             "provider credentials; the PageIndex api_key does not cover "
-            "it. Set the provider key (or chat_backend), or drop the "
-            "chat model configuration to use the managed cloud chat.")
+            "it. Set the provider key (or chat_backend)")
+        message += (
+            ", or drop the chat model configuration to use the managed "
+            "cloud chat." if lane == "chat" else "."
+        )
     return PageIndexAPIError(message)
 
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -1038,6 +1038,9 @@ def run_messages(client, messages, model: str,
     cached: dict[str, Any] = (
         {"cache_control": {"type": "ephemeral"}}
         if _cache_marks(system_blocks, prepared) < 4 else {})
+    # Tools before the transport: on a bridge client building them is
+    # network I/O, and a failure there must not strand the client below.
+    tools = build_anthropic_tools(client, doc_ids=scope)
     merged = _merged_backend(client, backend)
     backend_client = _anthropic_client(merged)
     # Close only a per-call construction: cached clients stay open for
@@ -1050,7 +1053,7 @@ def run_messages(client, messages, model: str,
         max_tokens=max_tokens,
         messages=prepared,
         model=model,
-        tools=build_anthropic_tools(client, doc_ids=scope),
+        tools=tools,
         system=system_blocks,
         stream=stream,
         # Bounded like the OpenAI surfaces (their framework default is 10).

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -594,11 +594,11 @@ def run_chat_completions(client, messages, stream: bool = False,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
-            "enable_citations is cloud-only — it needs the managed chat "
-            + ("endpoint: drop the chat model configuration to use it."
+            "enable_citations needs the managed chat endpoint — "
+            + ("drop the chat model configuration to use it."
                if getattr(client, "api_key", None) else
-               "endpoint; local mode does not store the block-level OCR "
-               "data citations need."))
+               "local mode does not store the block-level OCR data "
+               "citations need."))
     _require_openai_agents("chat_completions")
     _validate_max_turns(max_turns)
     system_texts, history = _split_chat_messages(messages)

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -187,7 +187,7 @@ class McpBridge:
     def list_tools(self) -> list[dict]:
         # Cached per session — every chat turn rebuilds the tool set, and
         # a per-turn tools/list round trip is pure latency. The 404
-        # session-expiry reset clears it.
+        # session-expiry reset clears it; a blank list never enters it.
         with self._lock:
             if self._tools is not None:
                 return self._tools
@@ -201,8 +201,9 @@ class McpBridge:
             tools.extend(result.get("tools") or [])
             next_cursor = result.get("nextCursor")
             if not next_cursor or next_cursor == cursor:
-                with self._lock:
-                    self._tools = tools
+                if tools:
+                    with self._lock:
+                        self._tools = tools
                 return tools
             cursor = next_cursor
         raise PageIndexAPIError(

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -48,6 +48,7 @@ class McpBridge:
         self._session_id: Optional[str] = None
         self._protocol_version: Optional[str] = None
         self._instructions: Optional[str] = None
+        self._tools: Optional[list[dict]] = None
         self._initialized = False
         self._lock = threading.RLock()
         self._next_id = 0
@@ -129,6 +130,7 @@ class McpBridge:
                     self._initialized = False
                     self._session_id = None
                     self._protocol_version = None
+                    self._tools = None  # the set may have changed server-side
             return self._request(method, params, _retry=False)
         if response.status_code >= 400:
             raise PageIndexAPIError(
@@ -183,6 +185,12 @@ class McpBridge:
         return self._instructions
 
     def list_tools(self) -> list[dict]:
+        # Cached per session — every chat turn rebuilds the tool set, and
+        # a per-turn tools/list round trip is pure latency. The 404
+        # session-expiry reset clears it.
+        with self._lock:
+            if self._tools is not None:
+                return self._tools
         tools: list[dict] = []
         cursor: Optional[str] = None
         # A server echoing its cursor (or cycling) must not hang the client:
@@ -193,6 +201,8 @@ class McpBridge:
             tools.extend(result.get("tools") or [])
             next_cursor = result.get("nextCursor")
             if not next_cursor or next_cursor == cursor:
+                with self._lock:
+                    self._tools = tools
                 return tools
             cursor = next_cursor
         raise PageIndexAPIError(

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -48,7 +48,6 @@ class McpBridge:
         self._session_id: Optional[str] = None
         self._protocol_version: Optional[str] = None
         self._instructions: Optional[str] = None
-        self._tools: Optional[list[dict]] = None
         self._initialized = False
         self._lock = threading.RLock()
         self._next_id = 0
@@ -130,7 +129,6 @@ class McpBridge:
                     self._initialized = False
                     self._session_id = None
                     self._protocol_version = None
-                    self._tools = None  # the set may have changed server-side
             return self._request(method, params, _retry=False)
         if response.status_code >= 400:
             raise PageIndexAPIError(
@@ -185,12 +183,6 @@ class McpBridge:
         return self._instructions
 
     def list_tools(self) -> list[dict]:
-        # Cached per session — every chat turn rebuilds the tool set, and
-        # a per-turn tools/list round trip is pure latency. The 404
-        # session-expiry reset clears it; a blank list never enters it.
-        with self._lock:
-            if self._tools is not None:
-                return self._tools
         tools: list[dict] = []
         cursor: Optional[str] = None
         # A server echoing its cursor (or cycling) must not hang the client:
@@ -201,9 +193,6 @@ class McpBridge:
             tools.extend(result.get("tools") or [])
             next_cursor = result.get("nextCursor")
             if not next_cursor or next_cursor == cursor:
-                if tools:
-                    with self._lock:
-                        self._tools = tools
                 return tools
             cursor = next_cursor
         raise PageIndexAPIError(

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -1,0 +1,45 @@
+"""Config shapes for the constructor's ``index=`` / ``chat=`` slots.
+
+The slots are the grouped spelling of the flat constructor arguments —
+same names, same meanings, one spelling per side. A dict declares its
+side by its keys (cloud takes a key, local takes models); an optional
+``"type"`` field states the side explicitly and must agree with the
+other keys. The ``"pageindex-cloud"`` string is the label spelling for
+"this side is managed", used when the API key lives in the environment.
+"""
+from __future__ import annotations
+
+from typing import Literal, TypedDict, Union
+
+PAGEINDEX_CLOUD = "pageindex-cloud"
+
+
+class CloudIndexConfig(TypedDict, total=False):
+    """Documents hosted on PageIndex cloud. ``api_key`` may be omitted —
+    it then comes from the PAGEINDEX_API_KEY environment variable."""
+
+    type: Literal["cloud"]
+    api_key: str
+
+
+class LocalIndexConfig(TypedDict, total=False):
+    """Documents indexed and stored locally."""
+
+    type: Literal["local"]
+    model: str
+    summary_model: str
+    backend: dict
+    storage_path: str
+
+
+class ChatConfig(TypedDict, total=False):
+    """The chat side: ``type: "local"`` (or any model/backend key) is
+    your own model — the agent runs in your process on your keys;
+    ``{"type": "cloud"}`` alone is the managed chat."""
+
+    type: Literal["cloud", "local"]
+    model: str
+    backend: dict
+
+
+IndexConfig = Union[CloudIndexConfig, LocalIndexConfig]

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -5,7 +5,7 @@ the same arguments with the side prefix factored out of the names
 (``index={"model": ...}`` is ``index_model=``), one spelling per side.
 A dict declares its
 side by its keys (cloud takes a key, local takes models); an optional
-``"type"`` field states the side explicitly and must agree with the
+``"mode"`` field states the side explicitly and must agree with the
 other keys. The ``"pageindex-cloud"`` string is the label spelling for
 "this side is managed", used when the API key lives in the environment.
 """
@@ -20,14 +20,14 @@ class CloudIndexConfig(TypedDict, total=False):
     """Documents hosted on PageIndex cloud. ``api_key`` may be omitted —
     it then comes from the PAGEINDEX_API_KEY environment variable."""
 
-    type: Literal["cloud"]
+    mode: Literal["cloud"]
     api_key: str
 
 
 class LocalIndexConfig(TypedDict, total=False):
     """Documents indexed and stored locally."""
 
-    type: Literal["local"]
+    mode: Literal["local"]
     model: str
     summary_model: str
     backend: dict
@@ -35,11 +35,11 @@ class LocalIndexConfig(TypedDict, total=False):
 
 
 class ChatConfig(TypedDict, total=False):
-    """The chat side: ``type: "local"`` (or any model/backend key) is
+    """The chat side: ``mode: "local"`` (or any model/backend key) is
     your own model — the agent runs in your process on your keys;
-    ``{"type": "cloud"}`` alone is the managed chat."""
+    ``{"mode": "cloud"}`` alone is the managed chat."""
 
-    type: Literal["cloud", "local"]
+    mode: Literal["cloud", "local"]
     model: str
     backend: dict
 

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -7,7 +7,7 @@ A dict declares its
 side by its keys (cloud takes a key, local takes models); an optional
 ``"mode"`` field states the side explicitly and must agree with the
 other keys. The ``"pageindex-cloud"`` string is the label spelling for
-"this side is managed", used when the API key lives in the environment.
+"this side is managed" — a synonym of ``"cloud"``.
 """
 from __future__ import annotations
 

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -1,7 +1,9 @@
 """Config shapes for the constructor's ``index=`` / ``chat=`` slots.
 
 The slots are the grouped spelling of the flat constructor arguments —
-same names, same meanings, one spelling per side. A dict declares its
+the same arguments with the side prefix factored out of the names
+(``index={"model": ...}`` is ``index_model=``), one spelling per side.
+A dict declares its
 side by its keys (cloud takes a key, local takes models); an optional
 ``"type"`` field states the side explicitly and must agree with the
 other keys. The ``"pageindex-cloud"`` string is the label spelling for

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -17,8 +17,9 @@ PAGEINDEX_CLOUD = "pageindex-cloud"
 
 
 class CloudIndexConfig(TypedDict, total=False):
-    """Documents hosted on PageIndex cloud. ``api_key`` may be omitted —
-    it then comes from the PAGEINDEX_API_KEY environment variable."""
+    """Documents hosted on PageIndex cloud. ``api_key`` may be omitted
+    when ``mode: "cloud"`` stays — it then comes from the
+    PAGEINDEX_API_KEY environment variable."""
 
     mode: Literal["cloud"]
     api_key: str

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -10,8 +10,8 @@ import PyPDF2
 import copy
 import asyncio
 from io import BytesIO
-from dotenv import load_dotenv
-load_dotenv()
+from dotenv import find_dotenv, load_dotenv
+load_dotenv(find_dotenv(usecwd=True) or None)
 import logging
 import yaml
 from pathlib import Path

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1446,11 +1446,66 @@ def test_list_tools_pagination_is_bounded():
         (params or {}).get("cursor")]
     assert [t["name"] for t in bridge.list_tools()] == ["a", "b"]
 
+    bridge = McpBridge("http://x/mcp", {})  # fresh: the first run caches
     bridge._request = lambda method, params=None: {
         "tools": [],
         "nextCursor": {"c1": "c2"}.get((params or {}).get("cursor"), "c1")}
     with pytest.raises(PageIndexAPIError, match="did not terminate"):
         bridge.list_tools()
+
+
+def test_list_tools_cached_until_session_reset():
+    """Every chat turn rebuilds the tool set — the tools/list round trip
+    must be paid once per session, and the 404 session-expiry reset must
+    refetch (the tool set may have changed server-side)."""
+    import json as json_mod
+    from pageindex.mcp_bridge import McpBridge
+
+    calls = {"list": 0, "call": 0}
+
+    class R:
+        def __init__(self, status, body=None, headers=None):
+            self.status_code = status
+            self._body = body or {}
+            self.headers = {"Content-Type": "application/json",
+                            **(headers or {})}
+            self.text = json_mod.dumps(self._body)
+            self.content = self.text.encode()
+
+        def json(self):
+            return self._body
+
+    def fake_post(payload, session_id=None, protocol_version=None):
+        rid, method = payload.get("id"), payload.get("method")
+        if method == "initialize":
+            return R(200, {"jsonrpc": "2.0", "id": rid,
+                           "result": {"instructions": "I"}},
+                     headers={"Mcp-Session-Id": "s1"})
+        if method == "notifications/initialized":
+            return R(202)
+        if method == "tools/list":
+            calls["list"] += 1
+            return R(200, {"jsonrpc": "2.0", "id": rid,
+                           "result": {"tools": [{"name": f"t{calls['list']}"}]}})
+        if method == "tools/call":
+            calls["call"] += 1
+            if calls["call"] == 1 and session_id:
+                return R(404)  # the spec's expired-session status
+            return R(200, {"jsonrpc": "2.0", "id": rid,
+                           "result": {"content": [{"type": "text",
+                                                   "text": "ok"}]}})
+        raise AssertionError(f"unexpected method {method}")
+
+    bridge = McpBridge("http://x/mcp", {})
+    bridge._post = fake_post
+    assert [t["name"] for t in bridge.list_tools()] == ["t1"]
+    assert [t["name"] for t in bridge.list_tools()] == ["t1"]
+    assert calls["list"] == 1
+    # Session expires mid-conversation: the next call re-initializes and
+    # the tool cache goes with it.
+    assert bridge.call_tool("get_document", {"doc_name": "r.pdf"}) == ("ok", False)
+    assert [t["name"] for t in bridge.list_tools()] == ["t2"]
+    assert calls["list"] == 2
 
 
 def test_mcp_bridge_protocol(monkeypatch):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2647,3 +2647,22 @@ def test_agent_tools_doc_id_refused_on_cloud():
     cloud = PageIndexCloudClient(api_key="pi-test-key")
     with pytest.raises(PageIndexAPIError, match="local tools only"):
         cloud.agent_tools(doc_id="pi-a")
+
+
+def test_cloud_tool_list_empty_raises(monkeypatch):
+    """An empty tools/list must raise like empty instructions does: a
+    zero-tool agent answers from the model's own knowledge instead of
+    the documents, with nothing to signal it."""
+    import pageindex.mcp_bridge as mcp_bridge
+
+    class _ToollessBridge:
+        def __init__(self, url, headers):
+            pass
+
+        def list_tools(self):
+            return []
+
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _ToollessBridge)
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+    with pytest.raises(PageIndexAPIError, match="no tools"):
+        cloud.as_openai_tools()

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1508,6 +1508,26 @@ def test_list_tools_cached_until_session_reset():
     assert calls["list"] == 2
 
 
+def test_list_tools_empty_page_is_not_cached():
+    """A blank tools/list (a deploy blip, a gate misconfiguration) must not
+    stick for the session: the next call refetches; only a real list caches."""
+    from pageindex.mcp_bridge import McpBridge
+
+    bridge = McpBridge("http://x/mcp", {})
+    pages = iter([{"tools": []}, {"tools": [{"name": "t"}]}])
+    calls = {"list": 0}
+
+    def fake_request(method, params=None):
+        calls["list"] += 1
+        return next(pages)
+
+    bridge._request = fake_request
+    assert bridge.list_tools() == []
+    assert [t["name"] for t in bridge.list_tools()] == ["t"]
+    assert [t["name"] for t in bridge.list_tools()] == ["t"]
+    assert calls["list"] == 2
+
+
 def test_mcp_bridge_protocol(monkeypatch):
     import requests as requests_mod
     from pageindex.mcp_bridge import McpBridge

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1446,86 +1446,11 @@ def test_list_tools_pagination_is_bounded():
         (params or {}).get("cursor")]
     assert [t["name"] for t in bridge.list_tools()] == ["a", "b"]
 
-    bridge = McpBridge("http://x/mcp", {})  # fresh: the first run caches
     bridge._request = lambda method, params=None: {
         "tools": [],
         "nextCursor": {"c1": "c2"}.get((params or {}).get("cursor"), "c1")}
     with pytest.raises(PageIndexAPIError, match="did not terminate"):
         bridge.list_tools()
-
-
-def test_list_tools_cached_until_session_reset():
-    """Every chat turn rebuilds the tool set — the tools/list round trip
-    must be paid once per session, and the 404 session-expiry reset must
-    refetch (the tool set may have changed server-side)."""
-    import json as json_mod
-    from pageindex.mcp_bridge import McpBridge
-
-    calls = {"list": 0, "call": 0}
-
-    class R:
-        def __init__(self, status, body=None, headers=None):
-            self.status_code = status
-            self._body = body or {}
-            self.headers = {"Content-Type": "application/json",
-                            **(headers or {})}
-            self.text = json_mod.dumps(self._body)
-            self.content = self.text.encode()
-
-        def json(self):
-            return self._body
-
-    def fake_post(payload, session_id=None, protocol_version=None):
-        rid, method = payload.get("id"), payload.get("method")
-        if method == "initialize":
-            return R(200, {"jsonrpc": "2.0", "id": rid,
-                           "result": {"instructions": "I"}},
-                     headers={"Mcp-Session-Id": "s1"})
-        if method == "notifications/initialized":
-            return R(202)
-        if method == "tools/list":
-            calls["list"] += 1
-            return R(200, {"jsonrpc": "2.0", "id": rid,
-                           "result": {"tools": [{"name": f"t{calls['list']}"}]}})
-        if method == "tools/call":
-            calls["call"] += 1
-            if calls["call"] == 1 and session_id:
-                return R(404)  # the spec's expired-session status
-            return R(200, {"jsonrpc": "2.0", "id": rid,
-                           "result": {"content": [{"type": "text",
-                                                   "text": "ok"}]}})
-        raise AssertionError(f"unexpected method {method}")
-
-    bridge = McpBridge("http://x/mcp", {})
-    bridge._post = fake_post
-    assert [t["name"] for t in bridge.list_tools()] == ["t1"]
-    assert [t["name"] for t in bridge.list_tools()] == ["t1"]
-    assert calls["list"] == 1
-    # Session expires mid-conversation: the next call re-initializes and
-    # the tool cache goes with it.
-    assert bridge.call_tool("get_document", {"doc_name": "r.pdf"}) == ("ok", False)
-    assert [t["name"] for t in bridge.list_tools()] == ["t2"]
-    assert calls["list"] == 2
-
-
-def test_list_tools_empty_page_is_not_cached():
-    """A blank tools/list (a deploy blip, a gate misconfiguration) must not
-    stick for the session: the next call refetches; only a real list caches."""
-    from pageindex.mcp_bridge import McpBridge
-
-    bridge = McpBridge("http://x/mcp", {})
-    pages = iter([{"tools": []}, {"tools": [{"name": "t"}]}])
-    calls = {"list": 0}
-
-    def fake_request(method, params=None):
-        calls["list"] += 1
-        return next(pages)
-
-    bridge._request = fake_request
-    assert bridge.list_tools() == []
-    assert [t["name"] for t in bridge.list_tools()] == ["t"]
-    assert [t["name"] for t in bridge.list_tools()] == ["t"]
-    assert calls["list"] == 2
 
 
 def test_mcp_bridge_protocol(monkeypatch):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2653,6 +2653,7 @@ def test_cloud_tool_list_empty_raises(monkeypatch):
     """An empty tools/list must raise like empty instructions does: a
     zero-tool agent answers from the model's own knowledge instead of
     the documents, with nothing to signal it."""
+    pytest.importorskip("agents")
     import pageindex.mcp_bridge as mcp_bridge
 
     class _ToollessBridge:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -153,12 +153,80 @@ def test_bridge_cloud_docs_own_model():
     from pageindex import PageIndexCloudClient, PageIndexLocalClient
     assert not PageIndexCloudClient("k")._local_chat
     assert PageIndexLocalClient()._local_chat
-    # The cloud pinned class pins only the index side: the chat side
-    # stays free, same vocabulary as PageIndexClient.
+    # The pinned classes pin only the index side: the chat side stays
+    # free, same vocabulary as PageIndexClient.
     pinned = PageIndexCloudClient("k", chat_model="openai/m")
     assert pinned._local_chat and pinned.chat_model == "openai/m"
     assert PageIndexCloudClient("k", chat={"model": "m"}).chat_model == "m"
+    assert PageIndexLocalClient(chat={"model": "m"}).chat_model == "m"
     assert not PageIndexCloudClient("k", chat="pageindex-cloud")._local_chat
+
+
+def test_local_pinned_class_takes_index_slot(tmp_path, monkeypatch):
+    """The local pinned class takes the grouped spelling of the index
+    vocabulary it already takes flat; a cloud index= is refused in the
+    class's name, never a cloud client."""
+    from pageindex import PageIndexLocalClient
+    client = PageIndexLocalClient(
+        index={"model": "i", "storage_path": str(tmp_path / "a")})
+    assert client.index_model == "i"
+    assert client.storage_path == str(tmp_path / "a")
+    assert PageIndexLocalClient(index="i").index_model == "i"
+    # The mode= disagreement fires before any environment read.
+    monkeypatch.setattr("pageindex.client._env_cloud_key", lambda *a: (
+        pytest.fail("environment read before the mode cross-check")))
+    for cloud in ("cloud", "pageindex-cloud", {"api_key": "k"},
+                  {"mode": "cloud"}):
+        with pytest.raises(PageIndexAPIError,
+                           match="PageIndexLocalClient pins local documents"):
+            PageIndexLocalClient(index=cloud)
+
+
+def test_cloud_pinned_class_takes_index_slot(monkeypatch):
+    """The cloud pinned class takes index= for the key; a local index= is
+    refused in the class's name, never a local client."""
+    from pageindex import PageIndexCloudClient
+    assert PageIndexCloudClient(index={"api_key": "k"}).api_key == "k"
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexCloudClient(index="cloud").api_key == "pi-env"
+    for local in ("local", "i-model", {"model": "m"}, {"storage_path": "/x"}):
+        with pytest.raises(PageIndexAPIError,
+                           match="PageIndexCloudClient pins cloud documents"):
+            PageIndexCloudClient(index=local)
+    with pytest.raises(PageIndexAPIError, match="two spellings"):
+        PageIndexCloudClient("k", index={"api_key": "k"})
+    monkeypatch.delenv("PAGEINDEX_API_KEY")
+    with pytest.raises(PageIndexAPIError, match='index="cloud" reads'):
+        PageIndexCloudClient(index="cloud")
+
+
+def test_pinned_class_errors_name_a_reachable_exit():
+    """The pinned classes have no mode= (and Local no api_key=): their
+    refusals name the class and an exit that class can take, never a
+    remedy that only PageIndexClient accepts. An explicit mode="local"
+    is named the same way — the exit has to drop it."""
+    from pageindex import PageIndexCloudClient, PageIndexLocalClient
+    with pytest.raises(PageIndexAPIError) as err:
+        PageIndexLocalClient(chat="cloud")
+    message = str(err.value)
+    assert "PageIndexLocalClient pins local documents" in message
+    assert 'index="cloud"' not in message and "mode=" not in message
+    # The exits it names construct.
+    assert not PageIndexCloudClient("k", chat="cloud")._local_chat
+    assert not PageIndexClient(api_key="k", chat="cloud")._local_chat
+    assert PageIndexLocalClient(chat="m")._local_chat
+    with pytest.raises(PageIndexAPIError, match='and drop mode="local"'):
+        PageIndexClient(mode="local", chat="cloud")
+    with pytest.raises(PageIndexAPIError) as err:
+        PageIndexClient(chat="cloud")
+    assert "mode=" not in str(err.value)
+
+
+def test_mode_words_normalize_like_the_label(monkeypatch):
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexClient(mode=" Cloud ").api_key == "pi-env"
+    assert not hasattr(PageIndexClient(index={"mode": "LOCAL"}), "api_key")
+    assert not PageIndexClient(api_key="k", chat={"mode": "Cloud"})._local_chat
 
 
 def test_cloud_index_args_still_rejected():
@@ -256,11 +324,16 @@ def test_slot_validation_errors(monkeypatch):
     assert PageIndexClient(index=" Pageindex-Cloud ").api_key == "pi-env"
     assert not PageIndexClient(index={"api_key": "k"},
                                chat="PAGEINDEX-CLOUD")._local_chat
-    # Bare mode words never parse as model names — no silent wrong mode.
-    for word in ("cloud", "local", "Hosted", " cloud "):
-        with pytest.raises(PageIndexAPIError, match="reserved word"):
+    # Bare mode words are the label's short form; near-synonyms point at
+    # the real word instead of parsing as model names.
+    assert PageIndexClient(index=" Cloud ").api_key == "pi-env"
+    assert not hasattr(PageIndexClient(index="local"), "api_key")
+    assert not PageIndexClient(api_key="k", chat="cloud")._local_chat
+    assert PageIndexClient(api_key="k", chat="local")._local_chat
+    for word in ("Hosted", " managed "):
+        with pytest.raises(PageIndexAPIError, match="not a mode word"):
             PageIndexClient(index=word)
-        with pytest.raises(PageIndexAPIError, match="reserved word"):
+        with pytest.raises(PageIndexAPIError, match="not a mode word"):
             PageIndexClient(chat=word)
 
 
@@ -352,15 +425,23 @@ def test_empty_values_refused_never_silent():
         PageIndexClient(index={"model": None})
 
 
-def test_model_umbrella_names_split_for_slots():
+def test_model_umbrella_names_split_for_slots(tmp_path):
     """model= sets both roles, so no slot can absorb it — the error
-    teaches the split instead of calling disjoint things one spelling."""
+    teaches a rewrite that works: the model inside the slot, the flat
+    role name for the other side."""
     for kwargs in ({"model": "m", "chat": {"backend": {"base_url": "u"}}},
                    {"model": "m", "index": {"storage_path": "/x"}},
                    {"model": "m", "chat": "c"}):
         with pytest.raises(PageIndexAPIError,
-                           match="split it into index_model= and chat_model="):
+                           match="name the model inside the slot"):
             PageIndexClient(**kwargs)
+    # Following the remedy constructs a working client.
+    client = PageIndexClient(
+        index={"model": "m", "storage_path": str(tmp_path)}, chat_model="m")
+    assert client.index_model == client.chat_model == "m"
+    client = PageIndexClient(
+        index_model="m", chat={"model": "m", "backend": {"base_url": "u"}})
+    assert client.index_model == client.chat_model == "m"
 
 
 def test_post_construction_chat_model_switches_whole_client():
@@ -393,9 +474,9 @@ def test_keyless_cloud_hint_matches_the_spelling(monkeypatch):
 
 def test_argument_type_errors_are_pageindex_errors():
     for kwargs, msg in (({"index": {"storage_path": 5}},
-                         "storage_path must be a str"),
+                         r'index\["storage_path"\] must be a str'),
                         ({"chat": {"backend": "x"}},
-                         "chat_backend must be a dict"),
+                         r'chat\["backend"\] must be a dict'),
                         ({"chat_backend": "x"}, "chat_backend must be a dict"),
                         ({"chat_model": 5}, "chat_model must be a str"),
                         ({"index_backend": ["x"]},
@@ -404,9 +485,14 @@ def test_argument_type_errors_are_pageindex_errors():
             PageIndexClient(**kwargs)
 
 
-def test_slot_strings_are_stripped():
-    assert PageIndexClient(chat=" openai/m ").chat_model == "openai/m"
-    assert PageIndexClient(index=" i-model ").index_model == "i-model"
+def test_strings_are_stripped_in_every_spelling():
+    for client in (PageIndexClient(index=" i-model ", chat=" openai/m "),
+                   PageIndexClient(index={"model": " i-model "},
+                                   chat={"model": " openai/m "}),
+                   PageIndexClient(index_model=" i-model ",
+                                   chat_model=" openai/m ")):
+        assert client.index_model == "i-model"
+        assert client.chat_model == "openai/m"
 
 
 def test_managed_chat_client_reads_none_not_attribute_error():
@@ -1816,3 +1902,23 @@ def test_mode_declaration_in_chat_dict():
         PageIndexClient(chat={"mode": "cloud"})
     with pytest.raises(PageIndexAPIError, match=r"Unknown chat keys \(type\)"):
         PageIndexClient(api_key="pi-k", chat={"type": "cloud"})
+
+
+def test_blank_chat_model_assignment_stays_managed():
+    """The constructor refuses chat_model="" as configuring nothing, so
+    the assignment path must agree — cfg.get("chat_model", "") otherwise
+    opens the bridge and hands LiteLLM a nameless model."""
+    client = PageIndexClient(api_key="pi-k")
+    for blank in ("", "   "):
+        client.chat_model = blank
+        assert not client._local_chat, repr(blank)
+    client.retrieve_model = ""
+    assert not client._local_chat
+
+
+def test_blank_chat_model_carries_no_model_into_agent_config():
+    """Same rule at the config door: a blank chat_model must not become
+    a model literally named "   " in the returned config."""
+    client = PageIndexClient()
+    client.chat_model = "   "
+    assert "model" not in client.openai_agent_config()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -287,8 +287,8 @@ def test_env_key_reads_load_dotenv():
         "import pageindex",
         "from pageindex import PageIndexClient, PageIndexCloudClient",
         "for build in (lambda: PageIndexClient(index='pageindex-cloud'),",
-        "              lambda: PageIndexClient(type='cloud'),",
-        "              lambda: PageIndexClient(index={'type': 'cloud'}),",
+        "              lambda: PageIndexClient(mode='cloud'),",
+        "              lambda: PageIndexClient(index={'mode': 'cloud'}),",
         "              lambda: PageIndexCloudClient()):",
         "    sys.modules.pop('pageindex.utils', None)",
         "    pageindex.__dict__.pop('utils', None)",
@@ -359,12 +359,12 @@ def test_keyless_cloud_hint_matches_the_spelling(monkeypatch):
         PageIndexClient(index="pageindex-cloud")
     assert 'index={"api_key": ...}' in str(err.value)
     with pytest.raises(PageIndexAPIError) as err:
-        PageIndexClient(index={"type": "cloud"})
+        PageIndexClient(index={"mode": "cloud"})
     assert 'index={"api_key": ...}' in str(err.value)
     with pytest.raises(PageIndexAPIError) as err:
-        PageIndexClient(type="cloud")
+        PageIndexClient(mode="cloud")
     assert "(api_key=...)" in str(err.value)
-    assert PageIndexClient(type="cloud", api_key="pi-k").api_key == "pi-k"
+    assert PageIndexClient(mode="cloud", api_key="pi-k").api_key == "pi-k"
 
 
 def test_argument_type_errors_are_pageindex_errors():
@@ -1722,68 +1722,73 @@ def test_expand_queries_nodes_concurrently(monkeypatch):
     assert inflight["peak"] <= 32
 
 
-def test_type_declaration_top_level(monkeypatch):
-    """type= states where documents live; always optional, always
-    checked, and type="cloud" alone reads the env key."""
+def test_mode_declaration_top_level(monkeypatch):
+    """mode= states where documents live; always optional, always
+    checked, and mode="cloud" alone reads the env key."""
     monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
-    assert PageIndexClient(type="cloud").api_key == "pi-env"
-    assert not PageIndexClient(type="cloud")._local_chat
-    bridge = PageIndexClient(type="cloud", chat_model="openai/m")
+    assert PageIndexClient(mode="cloud").api_key == "pi-env"
+    assert not PageIndexClient(mode="cloud")._local_chat
+    bridge = PageIndexClient(mode="cloud", chat_model="openai/m")
     assert bridge._local_chat and bridge.api_key == "pi-env"
-    agreed = PageIndexClient(api_key="pi-x", type="cloud")
+    agreed = PageIndexClient(api_key="pi-x", mode="cloud")
     assert agreed.api_key == "pi-x"
-    local = PageIndexClient(type="local")
+    local = PageIndexClient(mode="local")
     assert local._local_chat and not hasattr(local, "api_key")
 
     monkeypatch.delenv("PAGEINDEX_API_KEY")
     with pytest.raises(PageIndexAPIError, match="PAGEINDEX_API_KEY"):
-        PageIndexClient(type="cloud")
+        PageIndexClient(mode="cloud")
     with pytest.raises(PageIndexAPIError, match="conflicts with api_key"):
-        PageIndexClient(api_key="k", type="local")
+        PageIndexClient(api_key="k", mode="local")
     with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
-        PageIndexClient(type="banana")
+        PageIndexClient(mode="banana")
 
-    # type= beside index= is the same cross-check: agreement passes,
+    # mode= beside index= is the same cross-check: agreement passes,
     # disagreement errors, and the vocabulary check still comes first.
-    assert PageIndexClient(type="local", index="m").index_model == "m"
-    assert PageIndexClient(type="cloud",
+    assert PageIndexClient(mode="local", index="m").index_model == "m"
+    assert PageIndexClient(mode="cloud",
                            index={"api_key": "pi-x"}).api_key == "pi-x"
     with pytest.raises(PageIndexAPIError, match="disagrees with index="):
-        PageIndexClient(type="cloud", index="m")
+        PageIndexClient(mode="cloud", index="m")
     with pytest.raises(PageIndexAPIError, match="disagrees with index="):
-        PageIndexClient(type="local", index={"api_key": "k"})
+        PageIndexClient(mode="local", index={"api_key": "k"})
     with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
-        PageIndexClient(type="banana", index="m")
+        PageIndexClient(mode="banana", index="m")
 
 
-def test_type_declaration_in_index_dict(monkeypatch):
+def test_mode_declaration_in_index_dict(monkeypatch):
     monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
-    assert PageIndexClient(index={"type": "cloud"}).api_key == "pi-env"
+    assert PageIndexClient(index={"mode": "cloud"}).api_key == "pi-env"
     assert PageIndexClient(
-        index={"type": "cloud", "api_key": "pi-x"}).api_key == "pi-x"
-    typed = PageIndexClient(index={"type": "local", "model": "i"})
-    assert typed.index_model == "i"
-    assert not hasattr(PageIndexClient(index={"type": "local"}), "api_key")
+        index={"mode": "cloud", "api_key": "pi-x"}).api_key == "pi-x"
+    declared = PageIndexClient(index={"mode": "local", "model": "i"})
+    assert declared.index_model == "i"
+    assert not hasattr(PageIndexClient(index={"mode": "local"}), "api_key")
 
-    with pytest.raises(PageIndexAPIError, match='type "cloud" but carries'):
-        PageIndexClient(index={"type": "cloud", "model": "i"})
-    with pytest.raises(PageIndexAPIError, match='type "local" but carries'):
-        PageIndexClient(index={"type": "local", "api_key": "k"})
+    with pytest.raises(PageIndexAPIError, match='mode "cloud" but carries'):
+        PageIndexClient(index={"mode": "cloud", "model": "i"})
+    with pytest.raises(PageIndexAPIError, match='mode "local" but carries'):
+        PageIndexClient(index={"mode": "local", "api_key": "k"})
     with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
-        PageIndexClient(index={"type": "hosted"})
+        PageIndexClient(index={"mode": "hosted"})
+    # The key is "mode"; the pre-release "type" is just an unknown key.
+    with pytest.raises(PageIndexAPIError, match=r"Unknown index keys \(type\)"):
+        PageIndexClient(index={"type": "cloud"})
 
 
-def test_type_declaration_in_chat_dict():
-    managed = PageIndexClient(api_key="pi-k", chat={"type": "cloud"})
+def test_mode_declaration_in_chat_dict():
+    managed = PageIndexClient(api_key="pi-k", chat={"mode": "cloud"})
     assert not managed._local_chat
-    # {"type": "local"} alone declares own-model chat — default model.
+    # {"mode": "local"} alone declares own-model chat — default model.
     from pageindex.utils import DEFAULT_CHAT_MODEL
-    own = PageIndexClient(api_key="pi-k", chat={"type": "local"})
+    own = PageIndexClient(api_key="pi-k", chat={"mode": "local"})
     assert own._local_chat and own.chat_model == DEFAULT_CHAT_MODEL
-    typed = PageIndexClient(chat={"type": "local", "model": "m"})
-    assert typed.chat_model == "m"
+    declared = PageIndexClient(chat={"mode": "local", "model": "m"})
+    assert declared.chat_model == "m"
 
-    with pytest.raises(PageIndexAPIError, match='type "cloud" but carries'):
-        PageIndexClient(api_key="pi-k", chat={"type": "cloud", "model": "m"})
+    with pytest.raises(PageIndexAPIError, match='mode "cloud" but carries'):
+        PageIndexClient(api_key="pi-k", chat={"mode": "cloud", "model": "m"})
     with pytest.raises(PageIndexAPIError, match="cannot read the local store"):
-        PageIndexClient(chat={"type": "cloud"})
+        PageIndexClient(chat={"mode": "cloud"})
+    with pytest.raises(PageIndexAPIError, match=r"Unknown chat keys \(type\)"):
+        PageIndexClient(api_key="pi-k", chat={"type": "cloud"})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1919,6 +1919,7 @@ def test_blank_chat_model_assignment_stays_managed():
 def test_blank_chat_model_carries_no_model_into_agent_config():
     """Same rule at the config door: a blank chat_model must not become
     a model literally named "   " in the returned config."""
+    pytest.importorskip("agents")
     client = PageIndexClient()
     client.chat_model = "   "
     assert "model" not in client.openai_agent_config()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -109,19 +109,158 @@ def test_model_resolution_covers_every_generation(tmp_path):
         assert client.retrieve_model == client.chat_model, kwargs
 
 
-def test_explicit_mode_clients(tmp_path):
+def test_explicit_mode_clients(tmp_path, monkeypatch):
     from pageindex import PageIndexCloudClient, PageIndexLocalClient
 
+    monkeypatch.delenv("PAGEINDEX_API_KEY", raising=False)
     for bad_key in (None, ""):
         with pytest.raises(PageIndexAPIError, match="requires a PageIndex API key"):
             PageIndexCloudClient(bad_key)
     cloud = PageIndexCloudClient("k")
     assert cloud.api_key == "k" and isinstance(cloud, PageIndexClient)
+    # The class name says cloud, so the env key may fill the value —
+    # the shortest env-key cloud construction. Explicit "" still raises.
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexCloudClient().api_key == "pi-env"
+    assert PageIndexCloudClient("k").api_key == "k"
+    with pytest.raises(PageIndexAPIError, match="requires a PageIndex API key"):
+        PageIndexCloudClient("")
 
     local = PageIndexLocalClient(model="m", storage_path=str(tmp_path / "s"))
     assert local.model == "m" and isinstance(local, PageIndexClient)
     with pytest.raises(TypeError):
         PageIndexLocalClient("k")
+
+
+# ── constructor matrix: two sides, one spelling each ──
+
+
+def test_bridge_cloud_docs_own_model():
+    """chat-side arguments on a cloud client select own-model chat."""
+    from pageindex.utils import DEFAULT_CHAT_MODEL
+    client = PageIndexClient(api_key="pi-k", chat_model="openai/m")
+    assert client.api_key == "pi-k" and client._local_chat
+    assert client.chat_model == "openai/m" and client.chat_backend is None
+    assert not PageIndexClient(api_key="pi-k")._local_chat
+    # Only the backend given: the chat model falls back to the default.
+    partial = PageIndexClient(api_key="pi-k", chat_backend={"api_key": "x"})
+    assert partial._local_chat and partial.chat_model == DEFAULT_CHAT_MODEL
+    # The pinned classes carry the flag too.
+    from pageindex import PageIndexCloudClient, PageIndexLocalClient
+    assert not PageIndexCloudClient("k")._local_chat
+    assert PageIndexLocalClient()._local_chat
+
+
+def test_cloud_index_args_still_rejected():
+    with pytest.raises(PageIndexAPIError, match="index_model"):
+        PageIndexClient(api_key="k", index_model="m")
+    # ``model`` claims both sides, so the index side rejects it — the
+    # error points at the chat-side spelling that stays available.
+    with pytest.raises(PageIndexAPIError, match="stay yours"):
+        PageIndexClient(api_key="k", model="m")
+
+
+def test_index_slot_spellings(tmp_path, monkeypatch):
+    client = PageIndexClient(index="i-model")
+    assert client.index_model == "i-model" and client._local_chat
+    assert not hasattr(client, "api_key")
+
+    full = PageIndexClient(index={"model": "i", "summary_model": "s",
+                                  "backend": {"api_key": "b"},
+                                  "storage_path": str(tmp_path / "s")})
+    assert (full.index_model, full.summary_model) == ("i", "s")
+    assert full.storage_path == str(tmp_path / "s")
+
+    inline = PageIndexClient(index={"api_key": "pi-k"})
+    assert inline.api_key == "pi-k" and not inline._local_chat
+
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexClient(index="pageindex-cloud").api_key == "pi-env"
+    # An inline key wins over the environment (env is never consulted).
+    assert PageIndexClient(index={"api_key": "pi-x"}).api_key == "pi-x"
+    monkeypatch.delenv("PAGEINDEX_API_KEY")
+    with pytest.raises(PageIndexAPIError, match="PAGEINDEX_API_KEY"):
+        PageIndexClient(index="pageindex-cloud")
+
+
+def test_chat_slot_spellings():
+    assert PageIndexClient(chat="openai/m").chat_model == "openai/m"
+    full = PageIndexClient(chat={"model": "m", "backend": {"base_url": "u"}})
+    assert (full.chat_model, full.chat_backend) == ("m", {"base_url": "u"})
+
+    bridge = PageIndexClient(index={"api_key": "k"}, chat="openai/m")
+    assert bridge._local_chat and bridge.api_key == "k"
+    managed = PageIndexClient(index={"api_key": "k"}, chat="pageindex-cloud")
+    assert not managed._local_chat
+    # The impossible cell: local documents cannot feed the managed chat.
+    with pytest.raises(PageIndexAPIError, match="cannot read the local store"):
+        PageIndexClient(chat="pageindex-cloud")
+
+
+def test_slot_flat_equivalence(tmp_path):
+    """The slots are the grouped spelling of the flat arguments — same
+    names, same resolution."""
+    flat = PageIndexClient(index_model="i", chat_model="c",
+                           chat_backend={"k": 1},
+                           storage_path=str(tmp_path / "a"))
+    slot = PageIndexClient(
+        index={"model": "i", "storage_path": str(tmp_path / "a")},
+        chat={"model": "c", "backend": {"k": 1}})
+    for attr in ("model", "index_model", "summary_model", "chat_model",
+                 "chat_backend", "storage_path", "_local_chat"):
+        assert getattr(flat, attr) == getattr(slot, attr), attr
+
+
+def test_same_side_double_spelling_rejected():
+    for kwargs in ({"api_key": "k", "index": {"api_key": "k"}},
+                   {"index": "m", "index_model": "m"},
+                   {"index": "m", "storage_path": "/x"},
+                   {"chat": "m", "chat_model": "m"},
+                   {"chat": "m", "model": "m"}):
+        with pytest.raises(PageIndexAPIError, match="two spellings"):
+            PageIndexClient(**kwargs)
+    # Mixing tiers across sides is fine — the rule is per side.
+    assert PageIndexClient(api_key="k", chat={"model": "m"})._local_chat
+
+
+def test_slot_validation_errors(monkeypatch):
+    for bad, msg in [({}, "empty dict"),
+                     ({"api_key": "k", "model": "m"}, "mixes cloud and local"),
+                     ({"nope": 1}, "Unknown index keys"),
+                     ({"api_key": ""}, "non-empty string")]:
+        with pytest.raises(PageIndexAPIError, match=msg):
+            PageIndexClient(index=bad)
+    for bad, msg in [({}, "empty dict"), ({"nope": 1}, "Unknown chat keys")]:
+        with pytest.raises(PageIndexAPIError, match=msg):
+            PageIndexClient(chat=bad)
+    with pytest.raises(PageIndexAPIError, match="string or a dict"):
+        PageIndexClient(index=5)
+    with pytest.raises(PageIndexAPIError, match="string or a dict"):
+        PageIndexClient(chat=5)
+    with pytest.raises(PageIndexAPIError, match="empty string"):
+        PageIndexClient(index="  ")
+    with pytest.raises(PageIndexAPIError, match="empty string"):
+        PageIndexClient(chat=" ")
+    # Case/whitespace variants of the label never fall through to a
+    # silent model name.
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexClient(index=" Pageindex-Cloud ").api_key == "pi-env"
+    assert not PageIndexClient(index={"api_key": "k"},
+                               chat="PAGEINDEX-CLOUD")._local_chat
+    # Bare mode words never parse as model names — no silent wrong mode.
+    for word in ("cloud", "local", "Hosted", " cloud "):
+        with pytest.raises(PageIndexAPIError, match="not a mode word"):
+            PageIndexClient(index=word)
+        with pytest.raises(PageIndexAPIError, match="not a mode word"):
+            PageIndexClient(chat=word)
+
+
+def test_bare_client_ignores_env_key(monkeypatch):
+    """PAGEINDEX_API_KEY never moves the documents on its own — only code
+    that explicitly says cloud reads it."""
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    client = PageIndexClient()
+    assert not hasattr(client, "api_key") and client._local_chat
 
 
 # ── local: indexing and reading ──
@@ -1207,11 +1346,14 @@ def test_custom_provider_map_passes_provider_precheck(monkeypatch):
     assert _litellm_model("my-llm/model-a") == "my-llm/model-a"
 
 
-def test_backend_args_are_local_only():
-    with pytest.raises(PageIndexAPIError, match="chat_backend"):
-        PageIndexClient(api_key="pi-k", chat_backend={"api_key": "x"})
+def test_index_backend_is_local_only_chat_backend_selects_own_model():
+    """index_backend has nothing to configure on cloud (the managed
+    pipeline indexes); chat_backend is a chat-side argument, so on a
+    cloud client it selects own-model chat like chat_model does."""
     with pytest.raises(PageIndexAPIError, match="index_backend"):
         PageIndexClient(api_key="pi-k", index_backend={"api_key": "x"})
+    client = PageIndexClient(api_key="pi-k", chat_backend={"api_key": "x"})
+    assert client._local_chat and client.chat_backend == {"api_key": "x"}
 
 
 def test_chat_wraps_answerless_cloud_reply(monkeypatch):
@@ -1444,3 +1586,60 @@ def test_expand_queries_nodes_concurrently(monkeypatch):
                                        do_expand=True))
     assert inflight["peak"] > 1
     assert inflight["peak"] <= 32
+
+
+def test_type_declaration_top_level(monkeypatch):
+    """type= states where documents live; always optional, always
+    checked, and type="cloud" alone reads the env key."""
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexClient(type="cloud").api_key == "pi-env"
+    assert not PageIndexClient(type="cloud")._local_chat
+    bridge = PageIndexClient(type="cloud", chat_model="openai/m")
+    assert bridge._local_chat and bridge.api_key == "pi-env"
+    agreed = PageIndexClient(api_key="pi-x", type="cloud")
+    assert agreed.api_key == "pi-x"
+    local = PageIndexClient(type="local")
+    assert local._local_chat and not hasattr(local, "api_key")
+
+    monkeypatch.delenv("PAGEINDEX_API_KEY")
+    with pytest.raises(PageIndexAPIError, match="PAGEINDEX_API_KEY"):
+        PageIndexClient(type="cloud")
+    with pytest.raises(PageIndexAPIError, match="conflicts with api_key"):
+        PageIndexClient(api_key="k", type="local")
+    with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
+        PageIndexClient(type="banana")
+    with pytest.raises(PageIndexAPIError, match="two spellings"):
+        PageIndexClient(type="local", index="m")
+
+
+def test_type_declaration_in_index_dict(monkeypatch):
+    monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
+    assert PageIndexClient(index={"type": "cloud"}).api_key == "pi-env"
+    assert PageIndexClient(
+        index={"type": "cloud", "api_key": "pi-x"}).api_key == "pi-x"
+    typed = PageIndexClient(index={"type": "local", "model": "i"})
+    assert typed.index_model == "i"
+    assert not hasattr(PageIndexClient(index={"type": "local"}), "api_key")
+
+    with pytest.raises(PageIndexAPIError, match='type "cloud" but carries'):
+        PageIndexClient(index={"type": "cloud", "model": "i"})
+    with pytest.raises(PageIndexAPIError, match='type "local" but carries'):
+        PageIndexClient(index={"type": "local", "api_key": "k"})
+    with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
+        PageIndexClient(index={"type": "hosted"})
+
+
+def test_type_declaration_in_chat_dict():
+    managed = PageIndexClient(api_key="pi-k", chat={"type": "cloud"})
+    assert not managed._local_chat
+    # {"type": "local"} alone declares own-model chat — default model.
+    from pageindex.utils import DEFAULT_CHAT_MODEL
+    own = PageIndexClient(api_key="pi-k", chat={"type": "local"})
+    assert own._local_chat and own.chat_model == DEFAULT_CHAT_MODEL
+    typed = PageIndexClient(chat={"type": "local", "model": "m"})
+    assert typed.chat_model == "m"
+
+    with pytest.raises(PageIndexAPIError, match='type "cloud" but carries'):
+        PageIndexClient(api_key="pi-k", chat={"type": "cloud", "model": "m"})
+    with pytest.raises(PageIndexAPIError, match="cannot read the local store"):
+        PageIndexClient(chat={"type": "cloud"})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,9 +256,9 @@ def test_slot_validation_errors(monkeypatch):
                                chat="PAGEINDEX-CLOUD")._local_chat
     # Bare mode words never parse as model names — no silent wrong mode.
     for word in ("cloud", "local", "Hosted", " cloud "):
-        with pytest.raises(PageIndexAPIError, match="not a mode word"):
+        with pytest.raises(PageIndexAPIError, match="reserved word"):
             PageIndexClient(index=word)
-        with pytest.raises(PageIndexAPIError, match="not a mode word"):
+        with pytest.raises(PageIndexAPIError, match="reserved word"):
             PageIndexClient(chat=word)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,11 +2,13 @@
 import asyncio
 import importlib
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
@@ -302,11 +304,31 @@ def test_env_key_reads_load_dotenv():
     assert out.stdout.strip() == "ok"
 
 
+def test_env_key_found_from_cwd(tmp_path):
+    """A pip-installed SDK lives in site-packages; the user's .env lives
+    at their project root. A bare load_dotenv() searches upward from
+    utils.py, so it found a checkout's .env and never an installed
+    user's. A script file, not -c: dotenv treats a file-less __main__ as
+    interactive and searches from the cwd regardless."""
+    (tmp_path / ".env").write_text("PAGEINDEX_API_KEY=pi-dotenv-cwd\n")
+    (tmp_path / "app.py").write_text(
+        "from pageindex import PageIndexCloudClient\n"
+        "print('ok' if PageIndexCloudClient().api_key == 'pi-dotenv-cwd'\n"
+        "      else 'other')\n")
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)}
+    env.pop("PAGEINDEX_API_KEY", None)
+    out = subprocess.run([sys.executable, "app.py"], cwd=tmp_path, env=env,
+                         capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "ok"
+
+
 def test_empty_values_refused_never_silent():
     """An empty value configures nothing — pre-fix, an empty chat-side
     value on a cloud client silently selected own-model chat on the
     default model."""
-    for kwargs in ({"chat_model": ""}, {"retrieve_model": ""},
+    for kwargs in ({"chat_model": ""}, {"chat_model": " "},
+                   {"retrieve_model": ""},
                    {"chat_backend": {}}, {"model": ""},
                    {"index_model": ""}, {"index_backend": {}},
                    {"storage_path": ""}):
@@ -318,6 +340,8 @@ def test_empty_values_refused_never_silent():
                 PageIndexClient(api_key="pi-k", **kwargs)
     with pytest.raises(PageIndexAPIError, match="configures nothing"):
         PageIndexClient(api_key="pi-k", chat={"model": ""})
+    with pytest.raises(PageIndexAPIError, match="configures nothing"):
+        PageIndexClient(api_key="pi-k", chat={"model": " "})
     with pytest.raises(PageIndexAPIError, match="configures nothing"):
         PageIndexClient(chat={"backend": {}})
     # None-valued slot keys mean "absent", exactly like the flat args —

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,6 +151,12 @@ def test_bridge_cloud_docs_own_model():
     from pageindex import PageIndexCloudClient, PageIndexLocalClient
     assert not PageIndexCloudClient("k")._local_chat
     assert PageIndexLocalClient()._local_chat
+    # The cloud pinned class pins only the index side: the chat side
+    # stays free, same vocabulary as PageIndexClient.
+    pinned = PageIndexCloudClient("k", chat_model="openai/m")
+    assert pinned._local_chat and pinned.chat_model == "openai/m"
+    assert PageIndexCloudClient("k", chat={"model": "m"}).chat_model == "m"
+    assert not PageIndexCloudClient("k", chat="pageindex-cloud")._local_chat
 
 
 def test_cloud_index_args_still_rejected():
@@ -1724,8 +1730,18 @@ def test_type_declaration_top_level(monkeypatch):
         PageIndexClient(api_key="k", type="local")
     with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
         PageIndexClient(type="banana")
-    with pytest.raises(PageIndexAPIError, match="two spellings"):
-        PageIndexClient(type="local", index="m")
+
+    # type= beside index= is the same cross-check: agreement passes,
+    # disagreement errors, and the vocabulary check still comes first.
+    assert PageIndexClient(type="local", index="m").index_model == "m"
+    assert PageIndexClient(type="cloud",
+                           index={"api_key": "pi-x"}).api_key == "pi-x"
+    with pytest.raises(PageIndexAPIError, match="disagrees with index="):
+        PageIndexClient(type="cloud", index="m")
+    with pytest.raises(PageIndexAPIError, match="disagrees with index="):
+        PageIndexClient(type="local", index={"api_key": "k"})
+    with pytest.raises(PageIndexAPIError, match='"cloud" or "local"'):
+        PageIndexClient(type="banana", index="m")
 
 
 def test_type_declaration_in_index_dict(monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -385,6 +385,18 @@ def test_slot_strings_are_stripped():
     assert PageIndexClient(index=" i-model ").index_model == "i-model"
 
 
+def test_managed_chat_client_reads_none_not_attribute_error():
+    """The docstring advertises client.chat_model on every client; a
+    managed-chat client answers None (the endpoint picks its own model)."""
+    client = PageIndexClient(api_key="pi-k")
+    assert client.chat_model is None
+    assert client.retrieve_model is None
+    assert client.chat_backend is None
+    assert not client._local_chat
+    client.chat_model = "openai/m"  # and the switch still flips
+    assert client._local_chat
+
+
 # ── local: indexing and reading ──
 
 def test_submit_and_get_tree(local_client, indexed_doc, tmp_path, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,8 @@ import importlib
 import json
 import re
 import shutil
+import subprocess
+import sys
 import types
 
 import pytest
@@ -215,8 +217,7 @@ def test_same_side_double_spelling_rejected():
     for kwargs in ({"api_key": "k", "index": {"api_key": "k"}},
                    {"index": "m", "index_model": "m"},
                    {"index": "m", "storage_path": "/x"},
-                   {"chat": "m", "chat_model": "m"},
-                   {"chat": "m", "model": "m"}):
+                   {"chat": "m", "chat_model": "m"}):
         with pytest.raises(PageIndexAPIError, match="two spellings"):
             PageIndexClient(**kwargs)
     # Mixing tiers across sides is fine — the rule is per side.
@@ -261,6 +262,121 @@ def test_bare_client_ignores_env_key(monkeypatch):
     monkeypatch.setenv("PAGEINDEX_API_KEY", "pi-env")
     client = PageIndexClient()
     assert not hasattr(client, "api_key") and client._local_chat
+
+
+def test_env_key_reads_load_dotenv():
+    """The SDK's .env support is pageindex.utils' import-time
+    load_dotenv(); every spelling that reads PAGEINDEX_API_KEY must
+    trigger it, or a key in .env is visible only when something else
+    imported utils first. The sentinel finder stands in for the .env
+    file: importing pageindex.utils makes the key appear."""
+    probe = "\n".join([
+        "import importlib.abc, os, sys",
+        "class Sentinel(importlib.abc.MetaPathFinder):",
+        "    def find_spec(self, name, path=None, target=None):",
+        "        if name == 'pageindex.utils':",
+        "            os.environ.setdefault('PAGEINDEX_API_KEY', 'pi-dotenv')",
+        "        return None",
+        "sys.meta_path.insert(0, Sentinel())",
+        "import pageindex",
+        "from pageindex import PageIndexClient, PageIndexCloudClient",
+        "for build in (lambda: PageIndexClient(index='pageindex-cloud'),",
+        "              lambda: PageIndexClient(type='cloud'),",
+        "              lambda: PageIndexClient(index={'type': 'cloud'}),",
+        "              lambda: PageIndexCloudClient()):",
+        "    sys.modules.pop('pageindex.utils', None)",
+        "    pageindex.__dict__.pop('utils', None)",
+        "    os.environ.pop('PAGEINDEX_API_KEY', None)",
+        "    assert build().api_key == 'pi-dotenv', build",
+        "print('ok')",
+    ])
+    out = subprocess.run([sys.executable, "-c", probe],
+                         capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "ok"
+
+
+def test_empty_values_refused_never_silent():
+    """An empty value configures nothing — pre-fix, an empty chat-side
+    value on a cloud client silently selected own-model chat on the
+    default model."""
+    for kwargs in ({"chat_model": ""}, {"retrieve_model": ""},
+                   {"chat_backend": {}}, {"model": ""},
+                   {"index_model": ""}, {"index_backend": {}},
+                   {"storage_path": ""}):
+        with pytest.raises(PageIndexAPIError, match="configures nothing"):
+            PageIndexClient(**kwargs)
+        if next(iter(kwargs)) in ("chat_model", "retrieve_model",
+                                  "chat_backend"):
+            with pytest.raises(PageIndexAPIError, match="configures nothing"):
+                PageIndexClient(api_key="pi-k", **kwargs)
+    with pytest.raises(PageIndexAPIError, match="configures nothing"):
+        PageIndexClient(api_key="pi-k", chat={"model": ""})
+    with pytest.raises(PageIndexAPIError, match="configures nothing"):
+        PageIndexClient(chat={"backend": {}})
+    # None-valued slot keys mean "absent", exactly like the flat args —
+    # a slot left with nothing real is the empty-dict error.
+    with pytest.raises(PageIndexAPIError, match="empty dict"):
+        PageIndexClient(api_key="pi-k", chat={"model": None})
+    with pytest.raises(PageIndexAPIError, match="empty dict"):
+        PageIndexClient(index={"model": None})
+
+
+def test_model_umbrella_names_split_for_slots():
+    """model= sets both roles, so no slot can absorb it — the error
+    teaches the split instead of calling disjoint things one spelling."""
+    for kwargs in ({"model": "m", "chat": {"backend": {"base_url": "u"}}},
+                   {"model": "m", "index": {"storage_path": "/x"}},
+                   {"model": "m", "chat": "c"}):
+        with pytest.raises(PageIndexAPIError,
+                           match="split it into index_model= and chat_model="):
+            PageIndexClient(**kwargs)
+
+
+def test_post_construction_chat_model_switches_whole_client():
+    """chat_model is documented as assignable; the mode must follow the
+    attribute, never a stale construction-time snapshot."""
+    client = PageIndexClient(api_key="pi-k")
+    assert not client._local_chat
+    client.chat_model = "openai/m"
+    assert client._local_chat
+    legacy = PageIndexClient(api_key="pi-k")
+    legacy.retrieve_model = "m2"  # the 0.2.9 write path
+    assert legacy._local_chat and legacy.chat_model == "m2"
+
+
+def test_keyless_cloud_hint_matches_the_spelling(monkeypatch):
+    """Following the error's own remedy must construct a working client
+    — the index= spellings cannot combine with flat api_key=."""
+    monkeypatch.delenv("PAGEINDEX_API_KEY", raising=False)
+    with pytest.raises(PageIndexAPIError) as err:
+        PageIndexClient(index="pageindex-cloud")
+    assert 'index={"api_key": ...}' in str(err.value)
+    with pytest.raises(PageIndexAPIError) as err:
+        PageIndexClient(index={"type": "cloud"})
+    assert 'index={"api_key": ...}' in str(err.value)
+    with pytest.raises(PageIndexAPIError) as err:
+        PageIndexClient(type="cloud")
+    assert "(api_key=...)" in str(err.value)
+    assert PageIndexClient(type="cloud", api_key="pi-k").api_key == "pi-k"
+
+
+def test_argument_type_errors_are_pageindex_errors():
+    for kwargs, msg in (({"index": {"storage_path": 5}},
+                         "storage_path must be a str"),
+                        ({"chat": {"backend": "x"}},
+                         "chat_backend must be a dict"),
+                        ({"chat_backend": "x"}, "chat_backend must be a dict"),
+                        ({"chat_model": 5}, "chat_model must be a str"),
+                        ({"index_backend": ["x"]},
+                         "index_backend must be a dict")):
+        with pytest.raises(PageIndexAPIError, match=msg):
+            PageIndexClient(**kwargs)
+
+
+def test_slot_strings_are_stripped():
+    assert PageIndexClient(chat=" openai/m ").chat_model == "openai/m"
+    assert PageIndexClient(index=" i-model ").index_model == "i-model"
 
 
 # ── local: indexing and reading ──

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2298,6 +2298,40 @@ def test_bridge_auth_failure_error_teaches_architecture():
         local_chat._model_backend_error(exc, "chat", local))
     assert "provider credentials" not in str(
         local_chat._model_backend_error(Exception("boom"), "chat", bridge))
+    # 401-shaped failures carry no "api key" text on some providers
+    # (Anthropic says x-api-key): the status code is the signal.
+    denied = Exception("invalid x-api-key")
+    denied.status_code = 401
+    assert "your own provider credentials" in str(
+        local_chat._model_backend_error(denied, "messages", bridge))
+
+
+@needs_anthropic
+def test_messages_auth_failure_teaches_architecture(bridge_client,
+                                                    monkeypatch):
+    """The auth note must reach the messages door too — both its paths
+    wrap provider failures through _model_backend_error."""
+    client, _ = bridge_client
+
+    def handler(request):
+        return anthropic_httpx.Response(
+            401, json={"type": "error",
+                       "error": {"type": "authentication_error",
+                                 "message": "invalid x-api-key"}})
+
+    def fresh_fake(backend=None):
+        # per call: run_messages closes a per-call transport it owns
+        return anthropic.Anthropic(
+            api_key="test",
+            http_client=anthropic_httpx.Client(
+                transport=anthropic_httpx.MockTransport(handler)))
+
+    monkeypatch.setattr(local_chat, "_anthropic_client", fresh_fake)
+    with pytest.raises(PageIndexAPIError, match="provider credentials"):
+        client.messages("q", model="claude-test", max_tokens=100)
+    with pytest.raises(PageIndexAPIError, match="provider credentials"):
+        list(client.messages("q", model="claude-test", max_tokens=100,
+                             stream=True))
 
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -14,8 +14,8 @@ except ImportError:  # older anthropic rides classic httpx
     anthropic_httpx = httpx
 
 import pageindex.local_chat as local_chat
-from pageindex import (PageIndexAPIError, PageIndexCloudClient,
-                       PageIndexLocalClient)
+from pageindex import (PageIndexAPIError, PageIndexClient,
+                       PageIndexCloudClient, PageIndexLocalClient)
 from pageindex.local_chat import CHAT_HEADER
 from pageindex.local_store import DocStore
 
@@ -242,7 +242,7 @@ def test_chat_completions_accepts_query_string(client, store_path, fake_model):
 @needs_agents
 def test_chat_completions_validation(client, store_path, fake_model):
     fake_model([[_msg_item("ok")]])
-    with pytest.raises(PageIndexAPIError, match="cloud-only"):
+    with pytest.raises(PageIndexAPIError, match="managed chat endpoint"):
         client.chat_completions([{"role": "user", "content": "x"}],
                                 enable_citations=True)
     with pytest.raises(PageIndexAPIError, match="responses\\(\\) or messages"):
@@ -875,9 +875,17 @@ def test_max_turns_rejects_non_positive(client, store_path, fake_model):
 
 def test_enable_citations_rejected_before_framework_check(client, monkeypatch):
     monkeypatch.setitem(sys.modules, "agents", None)
-    with pytest.raises(PageIndexAPIError, match="cloud-only"):
+    with pytest.raises(PageIndexAPIError, match="managed chat endpoint"):
         client.chat_completions([{"role": "user", "content": "x"}],
                                 enable_citations=True)
+    # A cloud own-model client is told the real gate — managed vs own
+    # chat — never "cloud-only": it is on the cloud.
+    cloud = PageIndexClient(api_key="pi-k", chat_model="m")
+    with pytest.raises(PageIndexAPIError) as err:
+        cloud.chat_completions([{"role": "user", "content": "x"}],
+                               enable_citations=True)
+    assert "cloud-only" not in str(err.value)
+    assert "drop the chat model" in str(err.value)
 
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -284,32 +284,30 @@ def test_chat_completions_missing_framework(client, monkeypatch):
 
 def test_cloud_guards():
     cloud = PageIndexCloudClient(api_key="pi-test-key")
-    with pytest.raises(PageIndexAPIError, match="local-mode parameters"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}], model="m")
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                reasoning_effort="low")
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                extra_body={"service_tier": "auto"})
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}], top_p=0.9)
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                max_tokens=256)
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat("x", reasoning_effort="low")
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                backend={"api_key": "k"})
-    with pytest.raises(PageIndexAPIError, match="local-mode"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                extra_headers={"x-beta": "1"})
-    with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
-                                                "cloud yet"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.responses("x")
-    with pytest.raises(PageIndexAPIError, match="not available on PageIndex "
-                                                "cloud yet"):
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.messages([{"role": "user", "content": "x"}], model="m",
                        max_tokens=10)
 
@@ -2182,3 +2180,166 @@ def test_default_max_tokens_respects_output_ceilings():
                 {"type": "enabled", "budget_tokens": 10000}) == 18192
     assert lift("claude-sonnet-4-5",
                 {"type": "enabled", "budget_tokens": True}) == 8192
+
+
+# ── own-model chat over cloud documents (the bridge) ──
+
+
+class FakeBridge:
+    """Stands in for the cloud MCP bridge: one read tool, live
+    instructions, recorded calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def instructions(self):
+        return "CLOUD LIVE INSTRUCTIONS"
+
+    def list_tools(self):
+        return [{"name": "get_document",
+                 "description": "Cloud get_document",
+                 "inputSchema": {"type": "object", "properties": {
+                     "doc_name": {"type": "string"}}}}]
+
+    def call_tool(self, name, arguments):
+        self.calls.append((name, arguments))
+        return json.dumps({"status": "success",
+                           "data": {"doc": "cloud-doc"}}), False
+
+
+@pytest.fixture
+def bridge_client(monkeypatch):
+    import pageindex.agent_tools as agent_tools
+    from pageindex import PageIndexClient
+    bridge = FakeBridge()
+    monkeypatch.setattr(agent_tools, "_cloud_bridge",
+                        lambda client, gated=True: bridge)
+    client = PageIndexClient(api_key="pi-k", chat_model="fake-model")
+    return client, bridge
+
+
+@needs_agents
+def test_bridge_chat_runs_engine_over_cloud_tools(bridge_client, fake_model):
+    """A cloud client with its own chat model runs the in-process agent:
+    tools come from the live cloud MCP set, instructions from the MCP
+    server — not the local subset."""
+    client, bridge = bridge_client
+    fake = fake_model([
+        [_call_item("get_document", {"doc_name": "r.pdf"})],
+        [_msg_item("The answer")],
+    ])
+    result = client.chat_completions("What?")
+    assert result["choices"][0]["message"]["content"] == "The answer"
+    assert bridge.calls == [("get_document", {"doc_name": "r.pdf"})]
+    assert fake.instructions[0].startswith(CHAT_HEADER)
+    assert "CLOUD LIVE INSTRUCTIONS" in fake.instructions[0]
+    assert "READING WORKFLOW" not in fake.instructions[0]
+    # The tool result made it back into turn 2.
+    assert "cloud-doc" in json.dumps(fake.inputs[1])
+
+
+@needs_agents
+def test_bridge_doc_id_targets_at_prompt_level(bridge_client, fake_model,
+                                               monkeypatch):
+    """On cloud tools there is no local allowlist: doc_id becomes the
+    prompt-level targeting block only. (Had the tool layer received the
+    doc_ids, _require_local_scope would raise on a cloud client — this
+    call succeeding is the proof it did not.)"""
+    client, _ = bridge_client
+    monkeypatch.setattr(client, "get_document",
+                        lambda doc_id: {"name": "r.pdf", "description": "d",
+                                        "status": "completed",
+                                        "metadata": None})
+    monkeypatch.setattr(
+        client, "list_documents",
+        lambda **kw: {"documents": [{"id": "pi-a", "name": "r.pdf"}],
+                      "total": 1})
+    fake = fake_model([[_msg_item("ok")]])
+    client.chat_completions("q", doc_id="pi-a")
+    first = fake.inputs[0][0]
+    assert "specified document" in first["content"]
+    assert "r.pdf" in first["content"]
+
+
+def test_bridge_gate_and_citations(monkeypatch):
+    from pageindex import PageIndexClient
+    client = PageIndexClient(api_key="pi-k", chat_model="m")
+    with pytest.raises(PageIndexAPIError, match="drop the chat model"):
+        client.chat_completions("x", enable_citations=True)
+
+    called = {}
+
+    def fake_responses(client_arg, *args, **kwargs):
+        called["responses"] = client_arg
+        return {}
+
+    def fake_messages(client_arg, *args, **kwargs):
+        called["messages"] = client_arg
+        return {}
+
+    monkeypatch.setattr(local_chat, "run_responses", fake_responses)
+    monkeypatch.setattr(local_chat, "run_messages", fake_messages)
+    client.responses("q")
+    client.messages("q", model="mm")
+    assert called["responses"] is client and called["messages"] is client
+
+
+def test_bridge_auth_failure_error_teaches_architecture():
+    """The misreading ("the cloud runs my model") surfaces as a missing
+    provider key — that error is where the architecture gets spelled out,
+    and only there: local clients and non-auth failures stay untouched."""
+    from pageindex import PageIndexClient
+    bridge = PageIndexClient(api_key="pi-k", chat_model="m")
+    local = PageIndexLocalClient()
+    exc = Exception("The api_key client option must be set")
+    assert "your own provider credentials" in str(
+        local_chat._model_backend_error(exc, "chat", bridge))
+    assert "provider credentials" not in str(
+        local_chat._model_backend_error(exc, "chat", local))
+    assert "provider credentials" not in str(
+        local_chat._model_backend_error(Exception("boom"), "chat", bridge))
+
+
+@needs_agents
+def test_bridge_responses_lane_runs_cloud_tools(bridge_client, fake_model):
+    """The Responses door on a bridge client: same engine, cloud tools,
+    live instructions."""
+    client, bridge = bridge_client
+    fake = fake_model([
+        [_call_item("get_document", {"doc_name": "r.pdf"})],
+        [_msg_item("Done")],
+    ])
+    result = client.responses("What?")
+    assert result["object"] == "response" and result["status"] == "completed"
+    assert "Done" in json.dumps(result["output"])
+    assert bridge.calls == [("get_document", {"doc_name": "r.pdf"})]
+    assert "CLOUD LIVE INSTRUCTIONS" in fake.instructions[0]
+    assert fake_model.state["protocols"][0][0] == "responses"
+
+
+@needs_anthropic
+def test_bridge_messages_lane_runs_cloud_tools(bridge_client, fake_anthropic):
+    """The Messages door on a bridge client: cloud MCP tools on the wire,
+    live instructions in the cached system prefix."""
+    client, bridge = bridge_client
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "The answer"}],
+                           "end_turn"),
+    ])
+    result = client.messages("What?", model="claude-test", max_tokens=64)
+    assert result["content"][0]["text"] == "The answer"
+    wire = calls[0]
+    assert wire["tools"][0]["name"] == "get_document"
+    system_text = json.dumps(wire["system"])
+    assert "CLOUD LIVE INSTRUCTIONS" in system_text
+    assert "READING WORKFLOW" not in system_text
+
+
+@needs_agents
+def test_bridge_openai_agent_config_carries_configured_model(bridge_client):
+    """A bridge client's openai_agent_config carries its chat_model —
+    same semantics as local; a plain cloud client still omits model."""
+    client, _ = bridge_client
+    config = client.openai_agent_config()
+    assert config["model"] == "fake-model"
+    assert "CLOUD LIVE INSTRUCTIONS" in config["instructions"]

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2334,6 +2334,37 @@ def test_messages_auth_failure_teaches_architecture(bridge_client,
                              stream=True))
 
 
+@needs_anthropic
+def test_messages_no_backend_leak_when_tool_build_fails(bridge_client,
+                                                        monkeypatch):
+    """build_anthropic_tools is network I/O on a bridge client — a
+    failure there must not strand an opened per-call transport."""
+    client, _ = bridge_client
+    made = []
+
+    class FakeAnthropic:
+        def __init__(self):
+            self.closed = False
+            self.beta = types.SimpleNamespace(messages=types.SimpleNamespace(
+                tool_runner=lambda **kw: iter(())))
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(local_chat, "_anthropic_client",
+                        lambda backend=None: made.append(FakeAnthropic())
+                        or made[-1])
+
+    def boom(client, doc_ids=None):
+        raise PageIndexAPIError("Could not reach the PageIndex MCP server")
+
+    monkeypatch.setattr(
+        "pageindex.integrations.anthropic_sdk.build_anthropic_tools", boom)
+    with pytest.raises(PageIndexAPIError, match="MCP server"):
+        client.messages("q", model="claude-test", max_tokens=100)
+    assert all(fake.closed for fake in made)
+
+
 @needs_agents
 def test_bridge_responses_lane_runs_cloud_tools(bridge_client, fake_model):
     """The Responses door on a bridge client: same engine, cloud tools,

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2306,6 +2306,24 @@ def test_bridge_auth_failure_error_teaches_architecture():
         local_chat._model_backend_error(denied, "messages", bridge))
 
 
+def test_bridge_auth_note_managed_exit_is_chat_lane_only():
+    """The managed-chat exit ("drop the chat model") is real only for
+    chat_completions(); responses() and messages() refuse a client
+    without an own model, so on those lanes the note keeps the
+    credentials advice and drops the exit that would send the caller in
+    a circle."""
+    from pageindex import PageIndexClient
+    bridge = PageIndexClient(api_key="pi-k", chat_model="m")
+    denied = Exception("invalid x-api-key")
+    denied.status_code = 401
+    chat = str(local_chat._model_backend_error(denied, "chat", bridge))
+    assert "drop the chat model" in chat
+    for lane in ("responses", "messages"):
+        text = str(local_chat._model_backend_error(denied, lane, bridge))
+        assert "your own provider credentials" in text
+        assert "drop the chat model" not in text
+
+
 @needs_anthropic
 def test_messages_auth_failure_teaches_architecture(bridge_client,
                                                     monkeypatch):


### PR DESCRIPTION
One client, two independent switches: **`api_key` decides where your documents live; a configured chat model decides who answers.** Their free combination opens the third mode — cloud documents, your own model — and the impossible fourth (local documents + managed chat) stays unspellable.

```python
PageIndexClient(index_model="gpt-5-mini", chat_model="openai/gpt-5.2")  # local: free, your models
PageIndexClient(api_key="pi-...", chat_model="openai/gpt-5.2")          # cloud docs, keep your model
PageIndexClient(api_key="pi-...")                                        # fully managed
```

Each step of that ladder changes one thing. `chat_model` means the same thing everywhere — your model, on your keys, in your process; `api_key` moves your documents, never your model.

## New configuration surface

- **`index=` / `chat=` slots** — string shorthand or grouped dict, 1:1 with the flat arguments (same names, same meanings). One spelling per side; sides mix freely.
- **Optional `"mode"`** — top-level (`mode="cloud"`) or inside either dict. Always omittable, checked against the content (disagreement errors), meaningful alone: `mode="cloud"` / `index={"mode": "cloud"}` are keyless cloud spellings.
- **`PAGEINDEX_API_KEY`** is read only when the code explicitly says cloud — `PageIndexCloudClient()` (now the shortest env-key construction), `mode="cloud"`, `"cloud"` / `"pageindex-cloud"`, `{"mode": "cloud"}`. A bare `PageIndexClient()` stays local no matter what the environment holds.
- **Mode words** — `"cloud"` and `"local"` are accepted wherever `"pageindex-cloud"` is (`index=`, `chat=`, `mode=`, `{"mode": ...}`), any case/whitespace; the near-synonyms `"hosted"` / `"managed"` error pointing at the real word instead of silently parsing as a model name.
- **The pinned classes take the slots** — `PageIndexLocalClient(index=..., chat=...)` and `PageIndexCloudClient(index=...)` accept the grouped spelling of the flat vocabulary they already take; a slot that picks the other side is refused in the class's name, and the mode cross-check runs before any environment read.
- **Typed shapes** — `IndexConfig` / `CloudIndexConfig` / `LocalIndexConfig` / `ChatConfig` ship as optional annotations (Literal-typed `mode` fields give checkers a discriminated union). The constructor keeps accepting plain dicts. The package ships `py.typed`, so installed callers' checkers see them.
- **Strict validation** — unknown keys, mixed sides, empty dicts, mode/content conflicts, and missing keys all fail loudly with the legal vocabulary in the message. Nothing is ever silently guessed. Strings are stripped in every spelling, and a slot value's error names the slot key (`index["model"]`), not the flat argument.

## The bridge (cloud documents + your model)

The same in-process document-QA engine that local mode runs, fed by the live cloud MCP tool set and the MCP server's own instructions. `chat()`, `chat_completions()`, `responses()` and `messages()` all work. Semantics, documented on the surfaces:

- Page content flows through your process to your model provider, on your provider credentials (an auth-shaped backend failure explains exactly this).
- `doc_id` targets at the prompt level (the tool-layer allowlist is local-store only).
- `enable_citations` stays managed-only.
- An empty MCP tools/list raises, like empty instructions — a zero-tool agent would answer from the model's own knowledge with nothing to signal it.

## Compatibility

Not strictly additive:

- `chat_backend={}`, `index_backend={}`, `storage_path=""`, `model=""` — and every other value that configures nothing (`""`, whitespace-only strings, `{}`) — now refuse at construction; main accepted them in local mode.
- On a cloud client, `client.retrieve_model = m` (0.2.9's write path) now selects own-model chat instead of doing nothing (a blank value keeps the managed chat); `api_key + chat_model` and `api_key + chat_backend` graduate from a constructor error into the bridge.
- Error-path guidance is reworded throughout.

## Tests

432 passing (main's 393 untouched, 39 new). New coverage: constructor matrix, slot/mode/env rules, mode words, the pinned classes' slots, and bridge execution on all three chat lanes against a fake MCP bridge. A 28,000-combination constructor sweep confirms every input either builds a consistent client or raises `PageIndexAPIError` — never a third kind of failure. Construction touches no network; clients stay picklable.


