### PR TITLE
fix: tolerate missing 'page' key in process_none_page_numbers

### DIFF
--- a/pageindex/page_index_classic.py
+++ b/pageindex/page_index_classic.py
@@ -839,11 +839,11 @@ def process_none_page_numbers(toc_items, page_list, start_index=1, model=None):
                     continue
 
             item_copy = copy.deepcopy(item)
-            del item_copy['page']
+            item_copy.pop('page', None)
             result = add_page_number_to_toc(page_contents, item_copy, model)
             if isinstance(result[0]['physical_index'], str) and result[0]['physical_index'].startswith('<physical_index'):
                 item['physical_index'] = int(result[0]['physical_index'].split('_')[-1].rstrip('>').strip())
-                del item['page']
+                item.pop('page', None)
     
     return toc_items
 

--- a/tests/test_page_index.py
+++ b/tests/test_page_index.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 from pageindex.page_index_classic import (
     _secure_doc_text,
     process_no_toc,
+    process_none_page_numbers,
     process_toc_no_page_numbers,
 )
 
@@ -63,6 +64,42 @@ class ProcessTocNoPageNumbersTest(unittest.TestCase):
         self.assertIn("&lt;/user_document>", wrapped)
         self.assertIn("&lt; USER_DOCUMENT>", wrapped)
         self.assertIn("<physical_index_1>", wrapped)
+
+
+class ProcessNonePageNumbersTest(unittest.TestCase):
+    def test_tolerates_missing_page_key(self):
+        """A TOC item without 'page' must not crash (#69, #97)."""
+        toc = [
+            {"structure": "1", "title": "First", "physical_index": 1},
+            {"structure": "2", "title": "Second"},  # no physical_index, no page
+        ]
+        filled = [
+            {"structure": "2", "title": "Second", "physical_index": "<physical_index_2>"},
+        ]
+
+        with patch(
+            "pageindex.page_index_classic.add_page_number_to_toc",
+            return_value=filled,
+        ):
+            result = process_none_page_numbers(toc, [["p one"], ["p two"]])
+
+        self.assertEqual(result[1]["physical_index"], 2)
+        self.assertNotIn("page", result[1])
+
+    def test_tolerates_missing_page_key_when_llm_finds_no_start(self):
+        """No crash either when the LLM cannot locate the section."""
+        toc = [{"structure": "2", "title": "Second"}]
+        not_found = [
+            {"structure": "2", "title": "Second", "physical_index": None},
+        ]
+
+        with patch(
+            "pageindex.page_index_classic.add_page_number_to_toc",
+            return_value=not_found,
+        ):
+            result = process_none_page_numbers(toc, [["p one"], ["p two"]])
+
+        self.assertNotIn("physical_index", result[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #69, closes #97

## Problem

process_none_page_numbers in \pageindex/page_index_classic.py\ assumed every TOC item carries a \page\ key and used hard \del\:

\\\python
item_copy = copy.deepcopy(item)
del item_copy['page']   # KeyError when the LLM-returned TOC entry has no 'page'
...
    del item['page']
\\\

TOC entries produced/cleaned upstream may lack \page\ entirely, so index builds crash with \KeyError: 'page'\ (reported in #69 and #97).

## Fix

Replace both hard \del\s with \dict.pop(key, None)\. Behavior is unchanged for items that do have \page\; items without it no longer crash.

## Tests

Added two regression tests to \	ests/test_page_index.py\:

- TOC item without \page\ + LLM resolves a physical index -> no crash, index assigned
- TOC item without \page\ + LLM finds no start -> no crash, item left as-is

Both fail on \main\ with exactly \KeyError: 'page'\ at page_index_classic.py:842 and pass with this change:

\\\
tests/test_page_index.py  5 passed
\\\

Tested with Python 3.11 on Windows (\pytest tests/test_page_index.py -v\). No other behavior touched.