### PR TITLE
fix: the LiteLLM lanes hide litellm's bridge usage warning

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1323,8 +1323,10 @@ class PageIndexClient:
             if config["model"].startswith("litellm/"):
                 # The runner resolves this model through LiteLLM in the
                 # caller's process, outside our completion helpers.
-                from .utils import _repair_litellm_types
+                from .utils import (_mute_litellm_bridge_usage_warning,
+                                    _repair_litellm_types)
                 _repair_litellm_types()
+                _mute_litellm_bridge_usage_warning()
                 # Marks follow this lane's routing: the SDK strips litellm/
                 # and LiteLLM resolves the rest (bare claude-* → Anthropic);
                 # names without the prefix ride the SDK's OpenAI provider.

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -216,8 +216,10 @@ def _openai_model(protocol: str, model_name: str, backend=None):
             f"'{model_name}' routes through LiteLLM, but litellm is not "
             "installed. Run:  pip install 'litellm>=1.97'"
         )
-    from .utils import _litellm_model, _repair_litellm_types
+    from .utils import (_litellm_model, _mute_litellm_bridge_usage_warning,
+                        _repair_litellm_types)
     _repair_litellm_types()
+    _mute_litellm_bridge_usage_warning()
     try:
         wire = _litellm_model(model_name)
     except litellm.NotFoundError as exc:

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -45,6 +45,19 @@ def _repair_litellm_types() -> None:
     except Exception:
         pass  # best-effort: a failed repair leaves litellm's own error
 
+
+def _mute_litellm_bridge_usage_warning() -> None:
+    """litellm's chat→Responses bridge (e.g. OpenAI gpt-5.4+ with function
+    tools) logs a chat-shaped usage dict inside a ResponseAPIUsage field
+    (litellm_logging._get_assembled_streaming_response, 1.97–1.98), and
+    pydantic reports it on every streamed turn. Hide exactly that message;
+    every other warning still surfaces."""
+    import warnings
+    warnings.filterwarnings(
+        "ignore",
+        message=r"Pydantic serializer warnings:\s+"
+                r"(PydanticSerializationUnexpectedValue\()?Expected `ResponseAPIUsage`")
+
 # Backward compatibility: support CHATGPT_API_KEY as alias for OPENAI_API_KEY
 if not os.getenv("OPENAI_API_KEY") and os.getenv("CHATGPT_API_KEY"):
     import warnings

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -872,14 +872,17 @@ def test_non_string_doc_name_stays_not_found(client, store_path):
     assert is_error and payload["errorCode"] == "NOT_FOUND"
 
 
-def test_openai_agent_config_repairs_litellm_types(tmp_path, monkeypatch):
+@pytest.mark.parametrize("repair", ["_repair_litellm_types",
+                                    "_mute_litellm_bridge_usage_warning"])
+def test_openai_agent_config_repairs_litellm_types(tmp_path, monkeypatch,
+                                                   repair):
     """The BYO path resolves its model through LiteLLM in the caller's
-    process, outside our completion helpers — the py3.10 type repair must
+    process, outside our completion helpers — the LiteLLM repairs must
     run at config time, and only for LiteLLM-routed models."""
     pytest.importorskip("agents")
     import pageindex.utils
     calls = []
-    monkeypatch.setattr(pageindex.utils, "_repair_litellm_types",
+    monkeypatch.setattr(pageindex.utils, repair,
                         lambda: calls.append(True))
     client = PageIndexLocalClient(storage_path=str(tmp_path / "s"),
                                   chat_model="anthropic/claude-x")

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2043,6 +2043,31 @@ def test_litellm_model_still_has_the_fetch_response_seam():
     assert hasattr(LitellmModel, "_fetch_response")
 
 
+@needs_agents
+def test_litellm_lane_hides_the_bridge_usage_warning():
+    """litellm's chat→Responses bridge stores a chat-shaped usage dict in a
+    ResponseAPIUsage field and pydantic reports it on every streamed turn;
+    building the lane's model hides exactly that message — any other
+    mismatch still shows."""
+    pytest.importorskip("litellm")
+    import warnings
+    from litellm.types.llms.openai import ResponsesAPIResponse
+
+    bridged = ResponsesAPIResponse(id="r", created_at=0, output=[])
+    bridged.usage = {"completion_tokens": 1, "prompt_tokens": 1,
+                     "total_tokens": 2}
+    other = ResponsesAPIResponse(id="r", created_at=0, output=[])
+    other.created_at = "later"
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        local_chat._openai_model("chat", "gpt-5.2")
+        bridged.model_dump()
+        other.model_dump()
+    seen = [str(w.message) for w in caught]
+    assert not any("ResponseAPIUsage" in m for m in seen)
+    assert any("Expected `int`" in m for m in seen)
+
+
 def test_openai_protocol_predicate_follows_litellm_routing():
     pytest.importorskip("litellm")
     for name in ("gpt-5", "openai/gpt-4o", "litellm/gpt-4o",


### PR DESCRIPTION
Streaming `chat()` on an OpenAI gpt-5.4+ model with function tools makes litellm re-route chat.completions through the Responses API; when the stream ends its logging stores a chat-shaped usage dict in a `ResponseAPIUsage` field and dumps it, so pydantic prints "Expected ResponseAPIUsage - serialized value may not be as expected" on every streamed turn. litellm does this on purpose (`litellm_logging._get_assembled_streaming_response`, present in 1.97 and 1.98); the answer is unaffected.

- `_mute_litellm_bridge_usage_warning()` (utils.py): one `warnings.filterwarnings` matching exactly that message, both pydantic wordings.
- Registered at both seams that hand a LiteLLM-routed model to openai-agents — `_openai_model()`'s litellm branch and `openai_agent_config()`'s `litellm/` lane — next to `_repair_litellm_types()`.
- Tests: building the chat lane's model hides the message while another serializer mismatch still surfaces (red with the helper stubbed); the config-lane repair test is parametrized over both repairs.

Verified end to end against a fake OpenAI server: `chat(stream=True)` → `/v1/responses` → 0 of this warning; PyPDF2 and other pydantic warnings still print. 437 green on this base; pyright adds nothing on the changed lines.

https://claude.ai/code/session_01APJbbp3jpRxJhvchcU2Aed
