### PR TITLE
docs: reduce README banner image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   
 <a href="https://vectify.ai/pageindex" target="_blank">
-<img width="1471" height="491" alt="pi_github_banner_low" src="https://github.com/user-attachments/assets/acd6838b-4e63-464a-b56b-df318215e74d" />
+<img width="1471" height="491" alt="pi_github_banner_low" src="https://github.com/user-attachments/assets/bae02956-6c4e-4a0b-adea-257b0be4aaa1" />
 </a>
 
 <br/>


### PR DESCRIPTION
## Summary

- Replace the README banner from #436 with an optimized JPEG.
- Preserve the existing 1471 × 491 dimensions and visual appearance.
- Reduce the served image from 857 KB to 203 KB, approximately 76% smaller.

## Testing

- Confirmed the uploaded asset is a 1471 × 491 JPEG.
- Verified the banner URL and surrounding HTML are unchanged apart from the asset ID.
- Not run (documentation image-only change).
