### PR TITLE
docs: README structure and layout pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-- [**Detailed Usage Guide**](#detailed-usage-guide): use PageIndex directly through the client.
-- [**Integrate PageIndex with your own agent**](#integrate-with-your-own-agent): bring PageIndex into an agent you already have.
+Two ways to use PageIndex: (i) directly through the client, or (ii) integrated into an agent you already have.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -128,12 +128,13 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Use PageIndex directly through the client, or integrate its tools into your own agent.
+- [**Detailed Usage Guide**](#detailed-usage-guide): use PageIndex directly through the client.
+- [**Integrate PageIndex with your own agent**](#integrate-with-your-own-agent): bring PageIndex into an agent you already have.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide
 
-Each step expands to its full set of options: model names for any provider, the structure of a built tree index, and the OpenAI- and Anthropic-compatible interfaces behind `chat()`.
+Three steps from a fresh client to answers. Expand each for the full set of options.
 
 <details>
 <summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
@@ -290,7 +291,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 <a id="integrate-with-your-own-agent"></a>
 ### Integrate PageIndex with your own agent
 
-PageIndex's document tools also work inside an agent you already have. Each helper below sets up one framework in a single call:
+PageIndex also works inside an agent you already have. Each helper below sets up one framework in a single call:
 
 <details>
 <summary><h4>OpenAI Agents SDK</h4></summary>

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ To request inline page-level citations, pass a system message together with the 
 
 ```python
 messages = [
-    {"role": "system", "content": """Cite only statements supported by
-        tool outputs using <cite doc="{docName}" page="{pageNumber}"/>"""},
+    {"role": "system", "content": """Cite only statements supported by tool outputs using
+        <cite doc="{docName}" page="{pageNumber}"/>"""},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
   <a href="https://chat.pageindex.ai">🖥️ Chat Platform</a>&nbsp; • &nbsp;
   <a href="https://pageindex.ai/developer">🔌 MCP & API</a>&nbsp; • &nbsp;
   <a href="https://docs.pageindex.ai">📖 Docs</a>&nbsp; • &nbsp;
-  <a href="https://discord.com/invite/VuXuf29EUj">💬 Discord</a>&nbsp; • &nbsp;
   <a href="https://ii2abc2jejf.typeform.com/to/tK3AXl8T">✉️ Contact</a>&nbsp;
 </h4>
   

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 ### TLDR
 
-<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
+<blockquote>PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 It is ideal for financial reports, legal documents, regulatory filings, technical manuals, medical literature, academic textbooks, and any other long, complex professional document.
 
-> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#financebench)).
+> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#leading-on-financebench)).
 
 
 
@@ -394,7 +394,7 @@ Indexing time also scales predictably with document length. In the same local se
 
 Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
 
-### FinanceBench
+### Leading on FinanceBench
 
 PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
 

--- a/README.md
+++ b/README.md
@@ -138,17 +138,21 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.6-luna"`, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
 
+<div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="70%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="80%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
+</div>
 
 Indexing time also scales predictably with document length. In the same local setup, the benchmark documents (9 to 1,098 pages) finished in roughly **13 seconds to 4.5 minutes**.
 
+<div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="70%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="80%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
+</div>
 
 
 
@@ -156,10 +160,12 @@ Indexing time also scales predictably with document length. In the same local se
 
 [**PageIndex-OSS-Benchmark**](https://github.com/VectifyAI/PageIndex-OSS-Benchmark) measures exactly the setup in the quickstart above (`PageIndexClient()` in local mode, flash indexing, no OCR) on 62 lookup questions over 34 PDFs (1,945 pages) drawn from [MMLongBench-Doc-V2](https://github.com/VectifyAI/MMLongBench-Doc-V2). Every question's answer is a fact stated in running text, so a wrong answer is a **retrieval or reading failure**, not a reasoning one.
 
+<div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="70%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="80%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
+</div>
 
 
 Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 Three steps from a fresh client to answers. Expand each for the full set of options.
 
 <details>
-<summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
+<summary><b>⚙️ Step 1: Initialize the client</b></summary>
+<br>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -190,7 +191,8 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 <details>
-<summary><h4>🌲 Step 2: Build the tree index</h4></summary>
+<summary><b>🌲 Step 2: Build the tree index</b></summary>
+<br>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -238,7 +240,8 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 </details>
 
 <details>
-<summary><h4>💬 Step 3: Ask questions</h4></summary>
+<summary><b>💬 Step 3: Ask questions</b></summary>
+<br>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -293,7 +296,8 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 PageIndex can also be integrated into your own agent. Each example below sets up one framework:
 
 <details>
-<summary><h4>OpenAI Agents SDK</h4></summary>
+<summary><b>OpenAI Agents SDK</b></summary>
+<br>
 
 ```python
 from agents import Agent, Runner
@@ -307,7 +311,8 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 </details>
 
 <details>
-<summary><h4>Anthropic SDK tool runner</h4></summary>
+<summary><b>Anthropic SDK tool runner</b></summary>
+<br>
 
 ```python
 runner = anthropic_client.beta.messages.tool_runner(
@@ -321,7 +326,8 @@ runner = anthropic_client.beta.messages.tool_runner(
 </details>
 
 <details>
-<summary><h4>Claude Agent SDK</h4></summary>
+<summary><b>Claude Agent SDK</b></summary>
+<br>
 
 ```python
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
@@ -332,7 +338,8 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 </details>
 
 <details>
-<summary><h4>Other agent frameworks</h4></summary>
+<summary><b>Other agent frameworks</b></summary>
+<br>
 
 ```python
 tools = client.agent_tools()

--- a/README.md
+++ b/README.md
@@ -126,61 +126,6 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 ```
 
 
-# Benchmarks
-
-### Running PageIndex locally
-
-#### Indexing cost and time
-
-Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.6-luna"`, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
-
-<div align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
-</picture>
-</div>
-
-Indexing time also scales predictably with document length. In the same local setup, the benchmark documents (9 to 1,098 pages) finished in roughly **13 seconds to 4.5 minutes**.
-
-<div align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
-</picture>
-</div>
-
-
-
-#### Query cost and accuracy
-
-[**PageIndex-OSS-Benchmark**](https://github.com/VectifyAI/PageIndex-OSS-Benchmark) measures exactly the setup in the quickstart above (`PageIndexClient()` in local mode, flash indexing, no OCR) on 62 lookup questions over 34 PDFs (1,945 pages) drawn from [MMLongBench-Doc-V2](https://github.com/VectifyAI/MMLongBench-Doc-V2). Every question's answer is a fact stated in running text, so a wrong answer is a **retrieval or reading failure**, not a reasoning one.
-
-<div align="center">
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
-</picture>
-</div>
-
-
-Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
-
-### FinanceBench
-
-PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
-
-<div align="center">
-  <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
-    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="70%">
-  </a>
-</div>
-
-Explore the full [benchmark results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
-
-
-
-
 <a id="detailed-usage-guide"></a>
 <details>
 <summary>
@@ -389,6 +334,59 @@ tools = client.agent_tools()
 Each `*_config` helper is sugar over the explicit pieces (`client.agent_instructions()` for the system prompt, `client.as_openai_tools()` / `as_anthropic_tools()` / `as_claude_mcp()` for the tools), so you can swap in your own prompt whenever you need to. Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
 
 </details>
+
+
+# Benchmarks
+
+### Running PageIndex locally
+
+#### Indexing cost and time
+
+Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.6-luna"`, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
+
+<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
+  <img src="assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+</picture>
+</div>
+
+Indexing time also scales predictably with document length. In the same local setup, the benchmark documents (9 to 1,098 pages) finished in roughly **13 seconds to 4.5 minutes**.
+
+<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
+  <img src="assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+</picture>
+</div>
+
+
+
+#### Query cost and accuracy
+
+[**PageIndex-OSS-Benchmark**](https://github.com/VectifyAI/PageIndex-OSS-Benchmark) measures exactly the setup in the quickstart above (`PageIndexClient()` in local mode, flash indexing, no OCR) on 62 lookup questions over 34 PDFs (1,945 pages) drawn from [MMLongBench-Doc-V2](https://github.com/VectifyAI/MMLongBench-Doc-V2). Every question's answer is a fact stated in running text, so a wrong answer is a **retrieval or reading failure**, not a reasoning one.
+
+<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
+  <img src="assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+</picture>
+</div>
+
+
+Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
+
+### FinanceBench
+
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
+
+<div align="center">
+  <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
+    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="70%">
+  </a>
+</div>
+
+Explore the full [benchmark results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
 
 
 # PageIndex Cloud

--- a/README.md
+++ b/README.md
@@ -54,7 +54,24 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
+**C — 当前选定：居中加粗引用块**
+
 <blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read,<br>delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
+
+**NOTE — 蓝色**
+
+> [!NOTE]
+> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
+
+**TIP — 绿色**
+
+> [!TIP]
+> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
+
+**IMPORTANT — 紫色**
+
+> [!IMPORTANT]
+> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 </details>
 <br>
 
-<a id="step-2-build-the-tree-index"></a>
 <details>
-<summary><b>🌲 Step 2: Build the tree index</b></summary>
+<summary><a id="step-2-build-the-tree-index"></a><b>🌲 Step 2: Build the tree index</b></summary>
 <br>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,6 @@ Uses Anthropic's native Messages API and tool runner. Install it with `pip insta
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
 </details>
-<br>
 
 ### Integrate PageIndex with your own agent
 

--- a/README.md
+++ b/README.md
@@ -299,14 +299,26 @@ PageIndex can also be integrated into your own agent. Each example below covers 
 <summary><b>OpenAI Agents SDK</b></summary>
 <br>
 
+Ships with the SDK, no extras needed:
+
 ```python
 from agents import Agent, Runner
 
 agent = Agent(**client.openai_agent_config(doc_id=doc_id))
 result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
+print(result.final_output)
 ```
 
-`openai_agent_config()` provides the instructions and tools required by an OpenAI agent.
+`openai_agent_config()` returns the instructions and tools an `Agent` needs. To use your own prompt or pick tools yourself, assemble the pieces directly:
+
+```python
+agent = Agent(
+    name="PageIndex",
+    instructions=client.agent_instructions(doc_id=doc_id),   # or your own prompt
+    tools=client.as_openai_tools(doc_id=doc_id),              # include_management=True adds deletion
+    model=client.chat_model,                                  # local clients only
+)
+```
 
 </details>
 <br>
@@ -315,14 +327,31 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 <summary><b>Anthropic SDK tool runner</b></summary>
 <br>
 
+Install with `pip install 'pageindex[anthropic]'`:
+
 ```python
-runner = anthropic_client.beta.messages.tool_runner(
+import anthropic
+
+runner = anthropic.Anthropic().beta.messages.tool_runner(
     **client.anthropic_runner_config(model="claude-sonnet-4-6", doc_id=doc_id),
     messages=[{"role": "user", "content": "Summarize the auditor's concerns."}],
 )
+final = runner.until_done()
+print(final.content[-1].text)
 ```
 
-`anthropic_runner_config()` configures Anthropic's native tool runner. Install the integration with `pip install 'pageindex[anthropic]'`.
+`anthropic_runner_config()` fills every `tool_runner` slot except `messages`. The explicit form:
+
+```python
+runner = anthropic.Anthropic().beta.messages.tool_runner(
+    model="claude-sonnet-4-6",
+    max_tokens=8192,
+    system=client.agent_instructions(doc_id=doc_id),
+    tools=client.as_anthropic_tools(doc_id=doc_id),   # asynchronous=True for AsyncAnthropic
+    max_iterations=10,
+    messages=[{"role": "user", "content": "Summarize the auditor's concerns."}],
+)
+```
 
 </details>
 <br>
@@ -331,11 +360,26 @@ runner = anthropic_client.beta.messages.tool_runner(
 <summary><b>Claude Agent SDK</b></summary>
 <br>
 
+Install with `pip install 'pageindex[claude]'`. The Claude Agent SDK is async-native:
+
 ```python
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
+async for message in query(prompt="Summarize the auditor's concerns.", options=options):
+    if isinstance(message, ResultMessage):
+        print(message.result)
 ```
 
-`claude_agent_config()` creates the options for the Claude Agent SDK. Install the integration with `pip install 'pageindex[claude]'`.
+`claude_agent_config()` supplies the system prompt, the PageIndex MCP server, and its tool pre-approval. The explicit form:
+
+```python
+options = ClaudeAgentOptions(
+    system_prompt=client.agent_instructions(doc_id=doc_id),
+    mcp_servers={"pageindex": client.as_claude_mcp(doc_id=doc_id)},
+    allowed_tools=["mcp__pageindex"],
+)
+```
 
 </details>
 <br>
@@ -345,12 +389,12 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 <br>
 
 ```python
-tools = client.agent_tools()
+tools = client.agent_tools(doc_id=doc_id)   # plain functions returning JSON
 ```
 
-`agent_tools()` returns plain Python functions that work with LangChain, PydanticAI, and other agent frameworks.
+`agent_tools()` returns plain Python functions that work with LangChain, PydanticAI, and any other agent framework.
 
-Each `*_config` helper is sugar over the explicit pieces (`client.agent_instructions()` for the system prompt, `client.as_openai_tools()` / `as_anthropic_tools()` / `as_claude_mcp()` for the tools), so you can swap in your own prompt whenever you need to. Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
+Every helper above accepts `doc_id=` to point the agent at specific documents and `include_management=True` to also expose document deletion (off by default). Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Benchmarks
 
-### Open-source PageIndex, running locally
+### Local mode
 
 #### Indexing cost and time
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See the [SDK client usage guide](#a-use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
+See the [SDK client usage guide](#a-use-pageindex-through-the-sdk-client) to configure other models and more options, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
 
 ### Get Answers with Citations
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See [the SDK client guide](#use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#integrate-pageindex-with-your-own-agent).
+See [the SDK client guide](#a-use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
 
 ### Get Answers with Citations
 
@@ -128,9 +128,9 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage Guide
 
-Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
+Two ways to use PageIndex: (a) directly through the SDK client, or (b) integrate it into your own agent.
 
-### Use PageIndex through the SDK client
+### (a) Use PageIndex through the SDK client
 
 End to end in three steps: set up, index, ask. Expand a step below for its full options.
 
@@ -289,7 +289,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 </details>
 
-### Integrate PageIndex with your own agent
+### (b) Integrate PageIndex with your own agent
 
 PageIndex can also be integrated into your own agent. Each example below sets up one framework:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-### In one sentence
+### TL;DR
 
 <blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read,<br>delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See the [Usage Guide](#usage-guide) to configure other models or integrate PageIndex with your own agent.
+See the [SDK client usage guide](#a-use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
 
 ### Get Answers with Citations
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ Indexing time also scales predictably with document length. In the same local se
 
 Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
 
+### PageIndex leads a finance QA benchmark
+
+Mafin 2.5, a reasoning-based RAG system for financial document analysis powered by PageIndex, reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), far ahead of vector-based RAG systems on SEC filings and earnings disclosures.
+
+<div align="center">
+  <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
+    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="90%">
+  </a>
+</div>
+
+Explore the full [benchmark results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-### TLDR
+### tl;dr
 
 <blockquote>PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>, delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 
 ### Use PageIndex through the SDK client
 
-Three steps cover the client end to end. Expand each step for its full set of options.
+Three steps, end to end: set up, index, ask. Expand each step for its full set of options.
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 ### (b) Integrate PageIndex with your own agent
 
-PageIndex can also be integrated into your own agent. Each example below sets up one framework:
+PageIndex can also be integrated into your own agent. Each example below covers one framework:
 
 <details>
 <summary><b>OpenAI Agents SDK</b></summary>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 ### PageIndex leads a finance QA benchmark
 
-PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), vastly outperforming vector-based RAG.
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a financial document QA benchmark, vastly outperforming vector-based RAG.
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 ### TLDR
 
-<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware retrieval</b>, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
+<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 <a id="detailed-usage-guide"></a>
 <details>
-<summary><h3>Detailed Usage Guide</h3></summary>
+<summary><h2>Detailed Usage Guide</h2></summary>
 
-#### ⚙️ Step 1: Initialize the client
+### ⚙️ Step 1: Initialize the client
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -155,7 +155,7 @@ client = PageIndexClient(
 
 `index_model=` / `chat_model=` are the flat spellings of the quickstart's `index=` / `chat=`; either spelling works.
 
-##### Model naming conventions
+#### Model naming conventions
 
 Model names follow [LiteLLM's naming convention](https://docs.litellm.ai/docs/providers). Choose the format that matches your provider:
 
@@ -185,7 +185,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 
-#### 🌲 Step 2: Build the tree index
+### 🌲 Step 2: Build the tree index
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -233,7 +233,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 
 
 
-#### 💬 Step 3: Ask questions
+### 💬 Step 3: Ask questions
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -283,7 +283,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 <a id="integrate-with-your-own-agent"></a>
 <details>
-<summary><h3>Integrate PageIndex with your own agent</h3></summary>
+<summary><h2>Integrate PageIndex with your own agent</h2></summary>
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 

--- a/README.md
+++ b/README.md
@@ -54,22 +54,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-**A — 居中斜体大字（epigraph）**
-
-<h3 align="center"><i>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</i></h3>
-
-**B — GitHub Alert 框**
-
-> [!TIP]
-> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
-
-**C — 引用块 + 居中加粗**
-
-<blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
-
-**D — 现状：普通块引用**
-
-> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
+<blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read,<br>delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 ### (b) Integrate PageIndex with your own agent
 
-PageIndex can also be integrated into your own agent. Each example below covers one framework:
+PageIndex can also be integrated into your own agent. Each example below covers a different framework:
 
 <details>
 <summary><b>OpenAI Agents SDK</b></summary>

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
-    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="90%">
+    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="70%">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 Three steps from a fresh client to answers. Expand each for the full set of options.
 
 <details>
-<summary><b>⚙️ Step 1: Initialize the client</b></summary>
-<br>
+<summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -191,8 +190,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 <details>
-<summary><b>🌲 Step 2: Build the tree index</b></summary>
-<br>
+<summary><h4>🌲 Step 2: Build the tree index</h4></summary>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -240,8 +238,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 </details>
 
 <details>
-<summary><b>💬 Step 3: Ask questions</b></summary>
-<br>
+<summary><h4>💬 Step 3: Ask questions</h4></summary>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -296,8 +293,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 PageIndex can also be integrated into your own agent. Each example below sets up one framework:
 
 <details>
-<summary><b>OpenAI Agents SDK</b></summary>
-<br>
+<summary><h4>OpenAI Agents SDK</h4></summary>
 
 ```python
 from agents import Agent, Runner
@@ -311,8 +307,7 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 </details>
 
 <details>
-<summary><b>Anthropic SDK tool runner</b></summary>
-<br>
+<summary><h4>Anthropic SDK tool runner</h4></summary>
 
 ```python
 runner = anthropic_client.beta.messages.tool_runner(
@@ -326,8 +321,7 @@ runner = anthropic_client.beta.messages.tool_runner(
 </details>
 
 <details>
-<summary><b>Claude Agent SDK</b></summary>
-<br>
+<summary><h4>Claude Agent SDK</h4></summary>
 
 ```python
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
@@ -338,8 +332,7 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 </details>
 
 <details>
-<summary><b>Other agent frameworks</b></summary>
-<br>
+<summary><h4>Other agent frameworks</h4></summary>
 
 ```python
 tools = client.agent_tools()

--- a/README.md
+++ b/README.md
@@ -140,14 +140,14 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="70%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 
 Indexing time also scales predictably with document length. In the same local setup, the benchmark documents (9 to 1,098 pages) finished in roughly **13 seconds to 4.5 minutes**.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="70%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 
 
@@ -158,7 +158,7 @@ Indexing time also scales predictably with document length. In the same local se
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="70%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 <a id="detailed-usage-guide"></a>
 <details>
-<summary><h2>Detailed Usage Guide</h2></summary>
+<summary><h3>Detailed Usage Guide</h3></summary>
 
-### ⚙️ Step 1: Initialize the client
+#### ⚙️ Step 1: Initialize the client
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -155,7 +155,7 @@ client = PageIndexClient(
 
 `index_model=` / `chat_model=` are the flat spellings of the quickstart's `index=` / `chat=`; either spelling works.
 
-#### Model naming conventions
+##### Model naming conventions
 
 Model names follow [LiteLLM's naming convention](https://docs.litellm.ai/docs/providers). Choose the format that matches your provider:
 
@@ -185,7 +185,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 
-### 🌲 Step 2: Build the tree index
+#### 🌲 Step 2: Build the tree index
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -233,7 +233,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 
 
 
-### 💬 Step 3: Ask questions
+#### 💬 Step 3: Ask questions
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -283,7 +283,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 <a id="integrate-with-your-own-agent"></a>
 <details>
-<summary><h2>Integrate PageIndex with your own agent</h2></summary>
+<summary><h3>Integrate PageIndex with your own agent</h3></summary>
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See [the SDK client guide](#a-use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
+See the [Usage Guide](#usage-guide) to configure other models or integrate PageIndex with your own agent.
 
 ### Get Answers with Citations
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
+Two ways to use PageIndex:
+
+- directly through the SDK client
+- integrated into your own agent
 
 <a id="sdk-client"></a>
 ### Use PageIndex through the SDK client

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See the [Detailed Usage Guide](#detailed-usage-guide) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
+See [the SDK client guide](#sdk-client) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
 
 ### Get Answers with Citations
 
@@ -130,8 +130,8 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
 
-<a id="detailed-usage-guide"></a>
-### Detailed Usage Guide
+<a id="sdk-client"></a>
+### Use PageIndex through the SDK client
 
 Three steps from a fresh client to answers. Expand each for the full set of options.
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,12 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
+The quickstart covers the happy path. This section covers the rest: the client step by step, then PageIndex as a set of tools inside your own agent.
+
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide
+
+Expand a step for the full options: model naming for other providers, what a tree looks like, and the protocol surfaces behind `chat()`.
 
 <details>
 <summary><h4>⚙️ Step 1: Initialize the client</h4></summary>

--- a/README.md
+++ b/README.md
@@ -439,8 +439,8 @@ print(client.chat("What was the 2023 operating margin?", doc_id=doc_id))
 
 ### Ready to Try It?
 
-- [Get a PageIndex API Key](https://developer.pageindex.ai/)
-- [Read the PageIndex Cloud Documentation](https://docs.pageindex.ai/)
+- Get a [PageIndex API key](https://developer.pageindex.ai/)
+- Read the [PageIndex Cloud documentation](https://docs.pageindex.ai/)
 
 For dedicated deployment (VPC or on-premises), [contact us](https://ii2abc2jejf.typeform.com/to/gVv7qkaN) or [book a demo](https://calendly.com/pageindex/meet).
 

--- a/README.md
+++ b/README.md
@@ -110,11 +110,9 @@ See the [Detailed Usage Guide](#detailed-usage-guide) to configure other models,
 To request inline page-level citations, pass a system message together with the question:
 
 ```python
-system_prompt = """Cite only statements supported by tool outputs
-using <cite doc="{docName}" page="{pageNumber}"/>"""
-
 messages = [
-    {"role": "system", "content": system_prompt},
+    {"role": "system", "content": """Cite only statements supported
+by tool outputs using <cite doc="{docName}" page="{pageNumber}"/>"""},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex: (i) directly through the client, or (ii) integrated into an agent you already have.
+Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrated into your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 ```
 
 
-# Usage
+# Usage Guide
 
 Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 <a id="integrate-with-your-own-agent"></a>
 ### Integrate PageIndex with your own agent
 
-PageIndex also works inside an agent you already have. Each helper below sets up one framework in a single call:
+PageIndex can also be integrated into your own agent. Each example below sets up one framework:
 
 <details>
 <summary><h4>OpenAI Agents SDK</h4></summary>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 ### PageIndex leads a finance QA benchmark
 
-PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a financial document QA benchmark, far ahead of vector-based RAG systems on SEC filings and earnings disclosures.
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a QA benchmark built on SEC filings and earnings reports, vastly outperforming vector-based RAG.
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ tools = client.agent_tools()
 
 `agent_tools()` returns plain Python functions that work with LangChain, PydanticAI, and other agent frameworks.
 
-</details>
-
 Each `*_config` helper is sugar over the explicit pieces (`client.agent_instructions()` for the system prompt, `client.as_openai_tools()` / `as_anthropic_tools()` / `as_claude_mcp()` for the tools), so you can swap in your own prompt whenever you need to. Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
+
+</details>
 
 
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 Three steps from a fresh client to answers. Expand each for the full set of options.
 
 <details>
-<summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
+<summary><b>⚙️ Step 1: Initialize the client</b></summary>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -190,7 +190,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 <details>
-<summary><h4>🌲 Step 2: Build the tree index</h4></summary>
+<summary><b>🌲 Step 2: Build the tree index</b></summary>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -238,7 +238,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 </details>
 
 <details>
-<summary><h4>💬 Step 3: Ask questions</h4></summary>
+<summary><b>💬 Step 3: Ask questions</b></summary>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -293,7 +293,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 PageIndex can also be integrated into your own agent. Each example below sets up one framework:
 
 <details>
-<summary><h4>OpenAI Agents SDK</h4></summary>
+<summary><b>OpenAI Agents SDK</b></summary>
 
 ```python
 from agents import Agent, Runner
@@ -307,7 +307,7 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 </details>
 
 <details>
-<summary><h4>Anthropic SDK tool runner</h4></summary>
+<summary><b>Anthropic SDK tool runner</b></summary>
 
 ```python
 runner = anthropic_client.beta.messages.tool_runner(
@@ -321,7 +321,7 @@ runner = anthropic_client.beta.messages.tool_runner(
 </details>
 
 <details>
-<summary><h4>Claude Agent SDK</h4></summary>
+<summary><b>Claude Agent SDK</b></summary>
 
 ```python
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
@@ -332,7 +332,7 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 </details>
 
 <details>
-<summary><h4>Other agent frameworks</h4></summary>
+<summary><b>Other agent frameworks</b></summary>
 
 ```python
 tools = client.agent_tools()

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-The quickstart covers the happy path. This section covers the rest: the client step by step, then PageIndex as a set of tools inside your own agent.
+This section goes beyond the quickstart: the client step by step, then how to use PageIndex's tools inside your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
   </a>
 </div>
 
-Explore the full [FinanceBench evaluation results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
+Explore the full FinanceBench [evaluation results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
 
 
 # PageIndex Cloud

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="80%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="85%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -150,7 +150,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="80%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="85%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -163,7 +163,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="80%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="85%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -168,11 +168,11 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 ### FinanceBench
 
-PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a financial document QA benchmark, vastly outperforming vector-based RAG.
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
-    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="80%">
+    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="90%">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <summary><h2>Updates</h2></summary>
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout info instead of built by an LLM.
+- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically from the document's own layout info instead of built by an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex: (i) access it directly through the SDK client, or (ii) integrate it into your own agent.
+Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-### tl;dr
+### TL;DR
 
 <blockquote>PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>, delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Benchmarks
 
-### PageIndex Local
+### Running PageIndex locally
 
 #### Indexing cost and time
 
@@ -137,7 +137,7 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="70%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -146,7 +146,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="70%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -159,7 +159,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="70%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Configure the client step by step, or use PageIndex's tools inside your own agent.
+Use PageIndex directly through the client, or integrate its tools into your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="80%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="70%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -146,7 +146,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="80%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="70%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -159,7 +159,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="80%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="70%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ To request inline page-level citations, pass a system message together with the 
 
 ```python
 messages = [
-    {"role": "system", "content": """Cite only statements supported by tool outputs using
-        <cite doc="{docName}" page="{pageNumber}"/>"""},
+    {"role": "system", "content": """Cite only statements supported by tool outputs
+        using <cite doc="{docName}" page="{pageNumber}"/>"""},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 It is ideal for financial reports, legal documents, regulatory filings, technical manuals, medical literature, academic textbooks, and any other long, complex professional document.
 
-> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#leading-on-financebench)).
+> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#leading-accuracy-on-financebench)).
 
 
 
@@ -394,7 +394,7 @@ Indexing time also scales predictably with document length. In the same local se
 
 Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
 
-### Leading on FinanceBench
+### Leading accuracy on FinanceBench
 
 PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Each `*_config` helper is sugar over the explicit pieces (`client.agent_instruct
 
 #### Indexing cost and time
 
-Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.6-luna"`, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
+Building a tree locally runs **about $0.001 per page** with `gpt-5.6-luna` as the index model, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
 
 <div align="center">
 <picture>

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-### Why it works
-
 > PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
 
 ### Compare with Vector RAG

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 It is ideal for financial reports, legal documents, regulatory filings, technical manuals, medical literature, academic textbooks, and any other long, complex professional document.
 
-> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#benchmarks)).
+> PageIndex achieved **state-of-the-art** [98.7% accuracy](https://github.com/VectifyAI/Mafin2.5-FinanceBench) on FinanceBench (financial document QA benchmark), vastly outperforming vector-based RAG (see [Benchmarks](#financebench)).
 
 
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See [the SDK client guide](#sdk-client) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
+See [the SDK client guide](#use-pageindex-through-the-sdk-client) to configure other models, or [integrate PageIndex with your own agent](#integrate-pageindex-with-your-own-agent).
 
 ### Get Answers with Citations
 
@@ -130,7 +130,6 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
 
-<a id="sdk-client"></a>
 ### Use PageIndex through the SDK client
 
 Three steps from a fresh client to answers. Expand each for the full set of options.
@@ -291,7 +290,6 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 </details>
 
 
-<a id="integrate-with-your-own-agent"></a>
 ### Integrate PageIndex with your own agent
 
 PageIndex can also be integrated into your own agent. Each example below sets up one framework:

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ chat_model = "openrouter/anthropic/claude-sonnet-4-6"
 For model names and API key settings for other providers, see the [LiteLLM provider documentation](https://docs.litellm.ai/docs/providers).
 
 </details>
+<br>
 
 <a id="step-2-build-the-tree-index"></a>
 <details>
@@ -238,6 +239,7 @@ A PageIndex tree looks like a table of contents optimized for LLMs and agents:
 See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/examples/documents) and generated [tree structures](https://github.com/VectifyAI/PageIndex/tree/main/examples/documents/results).
 
 </details>
+<br>
 
 <details>
 <summary><b>💬 Step 3: Ask questions</b></summary>
@@ -309,6 +311,7 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 `openai_agent_config()` provides the instructions and tools required by an OpenAI agent.
 
 </details>
+<br>
 
 <details>
 <summary><b>Anthropic SDK tool runner</b></summary>
@@ -324,6 +327,7 @@ runner = anthropic_client.beta.messages.tool_runner(
 `anthropic_runner_config()` configures Anthropic's native tool runner. Install the integration with `pip install 'pageindex[anthropic]'`.
 
 </details>
+<br>
 
 <details>
 <summary><b>Claude Agent SDK</b></summary>
@@ -336,6 +340,7 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 `claude_agent_config()` creates the options for the Claude Agent SDK. Install the integration with `pip install 'pageindex[claude]'`.
 
 </details>
+<br>
 
 <details>
 <summary><b>Other agent frameworks</b></summary>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 ### PageIndex leads a finance QA benchmark
 
-Mafin 2.5, a reasoning-based RAG system for financial document analysis powered by PageIndex, reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), far ahead of vector-based RAG systems on SEC filings and earnings disclosures.
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a financial document QA benchmark, far ahead of vector-based RAG systems on SEC filings and earnings disclosures.
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">

--- a/README.md
+++ b/README.md
@@ -54,24 +54,9 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-**C — 当前选定：居中加粗引用块**
+### In one sentence
 
 <blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read,<br>delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
-
-**NOTE — 蓝色**
-
-> [!NOTE]
-> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
-
-**TIP — 绿色**
-
-> [!TIP]
-> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
-
-**IMPORTANT — 紫色**
-
-> [!IMPORTANT]
-> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See [Usage](#usage) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
+See the [Detailed Usage Guide](#detailed-usage-guide) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
 
 ### Get Answers with Citations
 
@@ -128,8 +128,11 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
+<a id="detailed-usage-guide"></a>
+### Detailed Usage Guide
+
 <details>
-<summary><h3>⚙️ Step 1: Initialize the client</h3></summary>
+<summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -183,7 +186,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 
 <a id="step-2-build-the-tree-index"></a>
 <details>
-<summary><h3>🌲 Step 2: Build the tree index</h3></summary>
+<summary><h4>🌲 Step 2: Build the tree index</h4></summary>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -231,7 +234,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 </details>
 
 <details>
-<summary><h3>💬 Step 3: Ask questions</h3></summary>
+<summary><h4>💬 Step 3: Ask questions</h4></summary>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -281,12 +284,12 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 
 <a id="integrate-with-your-own-agent"></a>
-<details>
-<summary><h3>Integrate PageIndex with your own agent</h3></summary>
+### Integrate PageIndex with your own agent
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 
-**OpenAI Agents SDK:**
+<details>
+<summary><h4>OpenAI Agents SDK</h4></summary>
 
 ```python
 from agents import Agent, Runner
@@ -297,7 +300,10 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 
 `openai_agent_config()` provides the instructions and tools required by an OpenAI agent.
 
-**Anthropic SDK tool runner:**
+</details>
+
+<details>
+<summary><h4>Anthropic SDK tool runner</h4></summary>
 
 ```python
 runner = anthropic_client.beta.messages.tool_runner(
@@ -308,7 +314,10 @@ runner = anthropic_client.beta.messages.tool_runner(
 
 `anthropic_runner_config()` configures Anthropic's native tool runner. Install the integration with `pip install 'pageindex[anthropic]'`.
 
-**Claude Agent SDK:**
+</details>
+
+<details>
+<summary><h4>Claude Agent SDK</h4></summary>
 
 ```python
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
@@ -316,7 +325,10 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 
 `claude_agent_config()` creates the options for the Claude Agent SDK. Install the integration with `pip install 'pageindex[claude]'`.
 
-**Other agent frameworks:**
+</details>
+
+<details>
+<summary><h4>Other agent frameworks</h4></summary>
 
 ```python
 tools = client.agent_tools()
@@ -324,9 +336,10 @@ tools = client.agent_tools()
 
 `agent_tools()` returns plain Python functions that work with LangChain, PydanticAI, and other agent frameworks.
 
+</details>
+
 Each `*_config` helper is sugar over the explicit pieces (`client.agent_instructions()` for the system prompt, `client.as_openai_tools()` / `as_anthropic_tools()` / `as_claude_mcp()` for the tools), so you can swap in your own prompt whenever you need to. Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
 
-</details>
 
 
 # Benchmarks

--- a/README.md
+++ b/README.md
@@ -390,7 +390,6 @@ from pageindex import PageIndexClient
 os.environ["PAGEINDEX_API_KEY"] = "your-pageindex-key"
 os.environ["OPENAI_API_KEY"] = "your-openai-key"
 
-
 client = PageIndexClient(
     index="cloud",                       # build and store the index in PageIndex Cloud
     chat="gpt-5.6-sol",                  # use your preferred compatible model for chat

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ To request inline page-level citations, pass a system message together with the 
 
 ```python
 messages = [
-    {"role": "system", "content": """Cite only statements supported
-by tool outputs using <cite doc="{docName}" page="{pageNumber}"/>"""},
+    {"role": "system", "content": """Cite only statements supported by
+        tool outputs using <cite doc="{docName}" page="{pageNumber}"/>"""},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 ### TLDR
 
-<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware retrieval</b>, with <b>no vector DBs</b> and <b>no chunking</b>.</blockquote>
+<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware retrieval</b>, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex:
-
-- directly through the SDK client
-- integrated into your own agent
+Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrate it into your own agent.
 
 <a id="sdk-client"></a>
 ### Use PageIndex through the SDK client

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
-### TL;DR
+### TLDR
 
-<blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read,<br>delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
+<blockquote align="center">PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware retrieval</b>, with <b>no vector DBs</b> and <b>no chunking</b>.</blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
 - [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically instead of by an LLM.
-- [**Scale PageIndex to Millions of Documents**](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
+- [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <summary><h2>Updates</h2></summary>
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout instead of being built by an LLM.
+- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout info instead of built by an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Benchmarks
 
-### Local mode
+### PageIndex Local
 
 #### Indexing cost and time
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ See the [Detailed Usage Guide](#detailed-usage-guide) to configure other models,
 To request inline page-level citations, pass a system message together with the question:
 
 ```python
+system_prompt = """Cite only statements supported by tool outputs
+using <cite doc="{docName}" page="{pageNumber}"/>"""
+
 messages = [
-    {"role": "system", "content": 'Cite only statements supported by tool outputs using <cite doc="{docName}" page="{pageNumber}"/>'},
+    {"role": "system", "content": system_prompt},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrated into your own agent.
+Two ways to use PageIndex: (i) call it directly through the SDK client, or (ii) integrate it into your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 </div>
 
 
+**A — 居中斜体大字（epigraph）**
+
+<h3 align="center"><i>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</i></h3>
+
+**B — GitHub Alert 框**
+
+> [!TIP]
+> PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
+
+**C — 引用块 + 居中加粗**
+
+<blockquote align="center"><b>PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.</b></blockquote>
+
+**D — 现状：普通块引用**
+
 > PageIndex is a vectorless, reasoning-based RAG engine that mirrors how humans read, delivering traceable, explainable, and context-aware retrieval, without vector databases or chunking.
 
 ### Compare with Vector RAG

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <summary><h2>Updates</h2></summary>
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout instead of an LLM.
+- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout instead of being built by an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Configure the client step by step, or use PageIndex's tools inside your own agen
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide
 
-Expand a step for the full options: model naming for other providers, what a tree looks like, and the protocol surfaces behind `chat()`.
+Each step expands to its full set of options: model names for any provider, the structure of a built tree index, and the OpenAI- and Anthropic-compatible interfaces behind `chat()`.
 
 <details>
 <summary><h4>⚙️ Step 1: Initialize the client</h4></summary>
@@ -290,7 +290,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 <a id="integrate-with-your-own-agent"></a>
 ### Integrate PageIndex with your own agent
 
-Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
+PageIndex's document tools also work inside an agent you already have. Each helper below sets up one framework in a single call:
 
 <details>
 <summary><h4>OpenAI Agents SDK</h4></summary>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 
 
-## What is PageIndex?
+# What is PageIndex?
 
 Are you frustrated with vector database retrieval accuracy for long and complex documents? Vector-based RAG retrieves by semantic **similarity**. But **similarity ≠ relevance** — what retrieval actually needs is relevance, and relevance requires **reasoning**. On professional documents that demand contextual understanding, domain expertise, and multi-step reasoning, similarity search misses what is relevant but not similar, and returns what is similar but not relevant.
 
@@ -74,7 +74,7 @@ It is ideal for financial reports, legal documents, regulatory filings, technica
 
 
 
-## Quickstart
+# Quickstart
 
 ```bash
 pip install -U pageindex
@@ -126,7 +126,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 ```
 
 
-## Benchmarks
+# Benchmarks
 
 ### Open-source PageIndex, running locally
 
@@ -185,7 +185,7 @@ Explore the full [benchmark results](https://github.com/VectifyAI/Mafin2.5-Finan
 <details>
 <summary>
 
-## Detailed Usage Guide
+# Detailed Usage Guide
 
 </summary>
 
@@ -342,7 +342,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 <details>
 <summary>
 
-## Integrate PageIndex with your own agent
+# Integrate PageIndex with your own agent
 
 </summary>
 
@@ -391,7 +391,7 @@ Each `*_config` helper is sugar over the explicit pieces (`client.agent_instruct
 </details>
 
 
-## PageIndex Cloud
+# PageIndex Cloud
 
 The open-source version is ideal for text-heavy PDFs and local workflows. With **PageIndex Cloud, document indexing and storage run in the cloud**: PageIndex handles parsing, OCR, image understanding, tree-index construction, and managed storage for you. The chat and retrieval layer remains **compatible with your model**, so you can search the cloud-hosted index using the model provider your application already uses.
 
@@ -440,7 +440,7 @@ For dedicated deployment (VPC or on-premises), [contact us](https://ii2abc2jejf.
 
 ---
 
-## ⭐ Support Us
+# ⭐ Support Us
 
 Leave us a star 🌟 if you like our project. Thank you!  
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="90%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="80%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -146,7 +146,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="90%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="80%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -159,7 +159,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="90%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="80%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 
@@ -172,7 +172,7 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
-    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="90%">
+    <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="80%">
   </a>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ from pageindex import PageIndexClient
 
 os.environ["OPENAI_API_KEY"] = "your-openai-key"
 
-client = PageIndexClient(                     
+client = PageIndexClient(
     index="gpt-5.6-luna",               # model to build the tree index
     chat="gpt-5.6-sol",                 # model to search the tree
 )
@@ -258,7 +258,7 @@ Pass a string or role/content history and get the answer back.
 **Stream the answer:**
 
 ```python
-client.chat(question, doc_id=doc_id, stream=True)
+client.chat("...", doc_id=doc_id, stream=True)
 ```
 
 Returns the answer as text chunks.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 <details open>
 <summary><h2>Updates</h2></summary>
 
-- [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically from the document's own layout info instead of built by an LLM.
+- [Aug '26] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
+- [Aug '26] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically from the document's own layout info instead of built by an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 
 ### Use PageIndex through the SDK client
 
-The complete workflow in three steps. Expand each step for its full set of options.
+Three steps cover the client end to end. Expand each step for its full set of options.
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <summary><h2>Updates</h2></summary>
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically instead of by an LLM.
+- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with the structure read from the document's own layout instead of built by an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 <a id="detailed-usage-guide"></a>
 <details>
-<summary><h2>Detailed Usage Guide</h2></summary>
+<summary><h3>Detailed Usage Guide</h3></summary>
 
 ### ⚙️ Step 1: Initialize the client
 
@@ -283,7 +283,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 <a id="integrate-with-your-own-agent"></a>
 <details>
-<summary><h2>Integrate PageIndex with your own agent</h2></summary>
+<summary><h3>Integrate PageIndex with your own agent</h3></summary>
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
   </a>
 </div>
 
-Explore the full [benchmark results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
+Explore the full [FinanceBench evaluation results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
 
 
 # PageIndex Cloud

--- a/README.md
+++ b/README.md
@@ -126,13 +126,11 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 ```
 
 
+# Usage
+
 <a id="detailed-usage-guide"></a>
 <details>
-<summary>
-
-# Detailed Usage Guide
-
-</summary>
+<summary><h2>Detailed Usage Guide</h2></summary>
 
 ### ⚙️ Step 1: Initialize the client
 
@@ -285,11 +283,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 <a id="integrate-with-your-own-agent"></a>
 <details>
-<summary>
-
-# Integrate PageIndex with your own agent
-
-</summary>
+<summary><h2>Integrate PageIndex with your own agent</h2></summary>
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 
 ### Use PageIndex through the SDK client
 
-Three steps from a fresh client to answers. Expand each for the full set of options.
+The complete workflow in three steps. Expand each step for its full set of options.
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 ### PageIndex leads a finance QA benchmark
 
-PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a QA benchmark built on SEC filings and earnings reports, vastly outperforming vector-based RAG.
+PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), vastly outperforming vector-based RAG.
 
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
 - [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically instead of by an LLM.
-- [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents. Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer).
+- [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the 
 
 ### TLDR
 
-<blockquote>PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>,<br>delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
+<blockquote>PageIndex is a <b>vectorless</b>, <b>reasoning-based RAG</b> engine that <b>mirrors how humans read</b>, delivering <b>traceable</b>, <b>explainable</b>, and <b>context-aware</b> retrieval, with <b>no vector DBs</b> or <b>chunking</b>.</blockquote>
 
 ### Compare with Vector RAG
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See the [SDK client usage guide](#a-use-pageindex-through-the-sdk-client) to configure other models and more options, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
+See the [SDK client usage guide](#a-use-pageindex-through-the-sdk-client) to configure other models and more, or [integrate PageIndex with your own agent](#b-integrate-pageindex-with-your-own-agent).
 
 ### Get Answers with Citations
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ print(answer)
 - **`index=`: a basic model is sufficient.** The index model generates the document's tree index. A basic model is sufficient to produce a good tree structure.
 - **`chat=`: use the best model you can afford.** The chat model searches the tree to retrieve information. See [Query cost and accuracy](#query-cost-and-accuracy).
 
-See the [Detailed Usage Guide](#detailed-usage-guide) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
+See [Usage](#usage) to configure other models, or [integrate PageIndex with your own agent](#integrate-with-your-own-agent).
 
 ### Get Answers with Citations
 
@@ -128,11 +128,8 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-<a id="detailed-usage-guide"></a>
 <details>
-<summary><h3>Detailed Usage Guide</h3></summary>
-
-### ⚙️ Step 1: Initialize the client
+<summary><h3>⚙️ Step 1: Initialize the client</h3></summary>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -182,10 +179,11 @@ chat_model = "openrouter/anthropic/claude-sonnet-4-6"
 
 For model names and API key settings for other providers, see the [LiteLLM provider documentation](https://docs.litellm.ai/docs/providers).
 
+</details>
 
 <a id="step-2-build-the-tree-index"></a>
-
-### 🌲 Step 2: Build the tree index
+<details>
+<summary><h3>🌲 Step 2: Build the tree index</h3></summary>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -230,10 +228,10 @@ A PageIndex tree looks like a table of contents optimized for LLMs and agents:
 
 See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/examples/documents) and generated [tree structures](https://github.com/VectifyAI/PageIndex/tree/main/examples/documents/results).
 
+</details>
 
-
-
-### 💬 Step 3: Ask questions
+<details>
+<summary><h3>💬 Step 3: Ask questions</h3></summary>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -280,6 +278,7 @@ Uses Anthropic's native Messages API and tool runner. Install it with `pip insta
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
 </details>
+
 
 <a id="integrate-with-your-own-agent"></a>
 <details>

--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 </summary>
 
-<br>
-
 ### ⚙️ Step 1: Initialize the client
 
 Create a local client and choose the models used for indexing and retrieval:
@@ -339,8 +337,6 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 ## Integrate PageIndex with your own agent
 
 </summary>
-
-<br>
 
 Instead of calling PageIndex's agent, hand PageIndex's tools to yours. One call fills every slot:
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
 - [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with structure extracted heuristically instead of by an LLM.
+- [**Scale PageIndex to Millions of Documents**](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 ## Benchmarks
 
-### Indexing cost and time
+### Open-source PageIndex, running locally
+
+#### Indexing cost and time
 
 Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.6-luna"`, so a 1,000-page textbook costs a little over a dollar and a few minutes, once, and every later question reuses it. PageIndex is designed not to rely heavily on the model used at index time, so in our experiments a basic model does not hurt quality.
 
@@ -150,7 +152,7 @@ Indexing time also scales predictably with document length. In the same local se
 
 
 
-### Query cost and accuracy
+#### Query cost and accuracy
 
 [**PageIndex-OSS-Benchmark**](https://github.com/VectifyAI/PageIndex-OSS-Benchmark) measures exactly the setup in the quickstart above (`PageIndexClient()` in local mode, flash indexing, no OCR) on 62 lookup questions over 34 PDFs (1,945 pages) drawn from [MMLongBench-Doc-V2](https://github.com/VectifyAI/MMLongBench-Doc-V2). Every question's answer is a fact stated in running text, so a wrong answer is a **retrieval or reading failure**, not a reasoning one.
 
@@ -164,7 +166,7 @@ Indexing time also scales predictably with document length. In the same local se
 
 Full results, data, and the runner are in the [benchmark repo](https://github.com/VectifyAI/PageIndex-OSS-Benchmark).
 
-### PageIndex leads a finance QA benchmark
+### FinanceBench
 
 PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944), a financial document QA benchmark, vastly outperforming vector-based RAG.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 <summary><h2>Updates</h2></summary>
 
 - [2026/08] 🔥 [**PageIndex SDK**](#quickstart): `pip install -U pageindex` now ships **local mode**: index, retrieve, and chat entirely on your machine with your own LLM key, or point the same client at PageIndex Cloud with an API key.
-- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, with the structure read from the document's own layout instead of built by an LLM.
+- [2026/08] ⚡ [**PageIndex Flash**](#step-2-build-the-tree-index): tree structure generation from PDFs in seconds, from the document's own layout instead of an LLM.
 - [Scale PageIndex to Millions of Documents](https://pageindex.ai/blog/pageindex-filesystem): *PageIndex File System* is a file-level tree indexing layer that lets PageIndex reason over an entire corpus, not just a single document.
 - [PageIndex Chat](https://chat.pageindex.ai): a human-like document analysis agent for long professional documents.<!-- Also available via [MCP](https://pageindex.ai/developer) or [API](https://pageindex.ai/developer). -->
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 
 ### Use PageIndex through the SDK client
 
-Three steps, end to end: set up, index, ask. Expand each step for its full set of options.
+End to end in three steps: set up, index, ask. Expand any step for its full options.
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-Two ways to use PageIndex: (i) call it directly through the SDK client, or (ii) integrate it into your own agent.
+Two ways to use PageIndex: (i) access it directly through the SDK client, or (ii) integrate it into your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -111,13 +111,7 @@ To request inline page-level citations, pass a system message together with the 
 
 ```python
 messages = [
-    {
-        "role": "system",
-        "content": (
-            'Cite only statements supported by tool outputs using '
-            '<cite doc="{docName}" page="{pageNumber}"/>'
-        ),
-    },
+    {"role": "system", "content": 'Cite only statements supported by tool outputs using <cite doc="{docName}" page="{pageNumber}"/>'},
     {"role": "user", "content": "Summarize the document."},
 ]
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Revenue increased during the reporting period. <cite doc="report.pdf" page="12"/
 
 # Usage
 
-This section goes beyond the quickstart: the client step by step, then how to use PageIndex's tools inside your own agent.
+Configure the client step by step, or use PageIndex's tools inside your own agent.
 
 <a id="detailed-usage-guide"></a>
 ### Detailed Usage Guide

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Building a tree locally runs **about $0.001 per page** with `index_model="gpt-5.
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="85%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <img src="assets/index-cost-light.png" width="90%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -150,7 +150,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="85%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <img src="assets/index-time-light.png" width="90%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -163,7 +163,7 @@ Indexing time also scales predictably with document length. In the same local se
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="85%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <img src="assets/results-light.png" width="90%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Three steps from a fresh client to answers. Expand each for the full set of opti
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>
+<br>
 
 Create a local client and choose the models used for indexing and retrieval:
 
@@ -191,6 +192,7 @@ For model names and API key settings for other providers, see the [LiteLLM provi
 <a id="step-2-build-the-tree-index"></a>
 <details>
 <summary><b>🌲 Step 2: Build the tree index</b></summary>
+<br>
 
 `submit_document` defaults to **Flash** indexing: the structure is extracted from the PDF's own layout (no LLM), and a model is called only for node summaries and the tree-optimization expansion pass. It takes seconds.
 
@@ -239,6 +241,7 @@ See more example [documents](https://github.com/VectifyAI/PageIndex/tree/main/ex
 
 <details>
 <summary><b>💬 Step 3: Ask questions</b></summary>
+<br>
 
 `chat()` is the one-line surface. Underneath it is a document-QA agent, and you can talk to it over whichever protocol your stack already speaks:
 
@@ -294,6 +297,7 @@ PageIndex can also be integrated into your own agent. Each example below sets up
 
 <details>
 <summary><b>OpenAI Agents SDK</b></summary>
+<br>
 
 ```python
 from agents import Agent, Runner
@@ -308,6 +312,7 @@ result = Runner.run_sync(agent, "Summarize the auditor's concerns.")
 
 <details>
 <summary><b>Anthropic SDK tool runner</b></summary>
+<br>
 
 ```python
 runner = anthropic_client.beta.messages.tool_runner(
@@ -322,6 +327,7 @@ runner = anthropic_client.beta.messages.tool_runner(
 
 <details>
 <summary><b>Claude Agent SDK</b></summary>
+<br>
 
 ```python
 options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
@@ -333,6 +339,7 @@ options = ClaudeAgentOptions(**client.claude_agent_config(doc_id=doc_id))
 
 <details>
 <summary><b>Other agent frameworks</b></summary>
+<br>
 
 ```python
 tools = client.agent_tools()

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Are you frustrated with vector database retrieval accuracy for long and complex 
 Inspired by AlphaGo, **[PageIndex](https://vectify.ai/pageindex)** replaces the vector index with a **hierarchical tree index** and lets an LLM **reason** its way through it, the way a human expert turns to and reads the right section of a long report. Retrieval happens in two steps:
 
 1. **Index**: generate a **tree-structure index** for each document
-2. **Retrieve**: **search that tree** with LLM reasoning, agentically
+2. **Retrieve**: agentically **search that tree** with LLM reasoning
 
 <div align="center">
   <a href="https://pageindex.ai/blog/pageindex-intro" target="_blank" title="The PageIndex Framework">

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Uses Anthropic's native Messages API and tool runner. Install it with `pip insta
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
 </details>
-
+<br>
 
 ### Integrate PageIndex with your own agent
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Two ways to use PageIndex: (i) directly through the SDK client, or (ii) integrat
 
 ### Use PageIndex through the SDK client
 
-End to end in three steps: set up, index, ask. Expand any step for its full options.
+End to end in three steps: set up, index, ask. Expand a step below for its full options.
 
 <details>
 <summary><b>⚙️ Step 1: Initialize the client</b></summary>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://chat.pageindex.ai">🖥️ Chat Platform</a>&nbsp; • &nbsp;
   <a href="https://pageindex.ai/developer">🔌 MCP & API</a>&nbsp; • &nbsp;
   <a href="https://docs.pageindex.ai">📖 Docs</a>&nbsp; • &nbsp;
+  <a href="https://pageindex.ai/blog">📝 Blog</a>&nbsp; • &nbsp;
   <a href="https://ii2abc2jejf.typeform.com/to/tK3AXl8T">✉️ Contact</a>&nbsp;
 </h4>
   


### PR DESCRIPTION
Top-level sections use single-hash headings again, with `###` subsections underneath, as the July README did.

- **Usage Guide** section after the Quickstart: (a) the SDK client in three collapsed steps, (b) integration with four agent frameworks, each fold carrying the one-call form, the explicit form, and a printed result.
- **Benchmarks** split into *Running PageIndex locally* (indexing cost and time, query cost and accuracy) and *Leading accuracy on FinanceBench*, the latter restored from the August 19 README.
- **TL;DR** pull quote under the framework diagram, with the claims bolded.
- Charts centered at 75% (FinanceBench chart at its original 70%); header row drops Discord and adds Blog; Updates lists the File System again and dates entries as `[Aug '26]`.
- Smaller fixes: citations example as one plain string, the Flash entry names layout extraction, the Cloud example loses a doubled blank line, link text covers only the noun in "Ready to Try It?", no trailing whitespace in code blocks.

Claude-Session: https://claude.ai/code/session_01BtbxfFP1wdkFou1FMCMA6k