### PR TITLE
docs: hide the FinanceBench accuracy chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,11 +444,13 @@ Full results, data, and the runner are in the [benchmark repo](https://github.co
 
 PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blog/Mafin2.5) on [FinanceBench](https://arxiv.org/abs/2311.11944) (financial document QA benchmark), vastly outperforming vector-based RAG.
 
+<!--
 <div align="center">
   <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
     <img src="https://github.com/user-attachments/assets/571aa074-d803-43c7-80c4-a04254b782a3" width="70%">
   </a>
 </div>
+-->
 
 Explore the full FinanceBench [evaluation results](https://github.com/VectifyAI/Mafin2.5-FinanceBench) and the [blog post](https://vectify.ai/blog/Mafin2.5).
 


### PR DESCRIPTION
Comments out the FinanceBench chart image in the "Leading accuracy on FinanceBench" section. The heading, the 98.7% sentence, and both links stay.

https://claude.ai/code/session_012edjBdTjAM24UAZGyq6TfF