### PR TITLE
docs: add an "Any MCP client" integration item

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner (so `model=` takes a plain Anthropic id, no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner (so `model=` takes a plain model id, no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner (so `model=` takes a plain model id, no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner. Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
@@ -319,6 +319,8 @@ agent = Agent(
     model=client.chat_model,                                  # local clients only
 )
 ```
+
+The Agents SDK resolves `model` itself, so a non-OpenAI name needs its `litellm/` prefix; `openai_agent_config()` adds that, plus prompt-cache settings for Claude models.
 
 </details>
 <br>

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Every helper above accepts `doc_id=` to point the agent at specific documents an
 <summary><b>MCP server</b></summary>
 <br>
 
-PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect directly without the SDK:
+PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect directly to it without the SDK:
 
 ```json
 {
@@ -417,7 +417,7 @@ PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP c
 }
 ```
 
-The same API key and documents work across the MCP server and the REST API; see the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone server: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no hosted server: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic id, no `anthropic/` prefix. Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic id (no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP c
 }
 ```
 
-Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no hosted server: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -400,10 +400,10 @@ Every helper above accepts `doc_id=` to point the agent at specific documents an
 <br>
 
 <details>
-<summary><b>Any MCP client</b></summary>
+<summary><b>MCP server</b></summary>
 <br>
 
-Cloud indexes are also reachable over MCP, so an agent that already speaks the protocol needs no SDK at all:
+PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect to it without the SDK:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 **Use the Anthropic Messages format:**
 
 ```python
-client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
+client.messages("...", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner; a Claude `chat_model` carries over, or pass `model=` directly. Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner; assumes a Claude `chat_model`, otherwise pass `model=`. Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
@@ -335,14 +335,14 @@ Install with `pip install 'pageindex[anthropic]'`:
 import anthropic
 
 runner = anthropic.Anthropic().beta.messages.tool_runner(
-    **client.anthropic_runner_config(model="claude-sonnet-4-6", doc_id=doc_id),
+    **client.anthropic_runner_config(doc_id=doc_id),
     messages=[{"role": "user", "content": "Summarize the auditor's concerns."}],
 )
 final = runner.until_done()
 print(final.content[-1].text)
 ```
 
-`anthropic_runner_config()` fills every `tool_runner` slot except `messages`; a Claude `chat_model` carries over, or pass `model=` directly. The explicit form:
+`anthropic_runner_config()` fills every `tool_runner` slot except `messages`; assumes a Claude `chat_model`, otherwise pass `model=`. The explicit form:
 
 ```python
 runner = anthropic.Anthropic().beta.messages.tool_runner(

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ Every helper above accepts `doc_id=` to point the agent at specific documents an
 }
 ```
 
-Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local mode has no standalone MCP server yet: use `agent_tools()` above, or the [Claude Agent SDK](#claude-agent-sdk)'s in-process MCP server.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local mode has no standalone MCP server yet: use `agent_tools()` above, or the in-process MCP server for the [Claude Agent SDK](#claude-agent-sdk).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ runner = anthropic.Anthropic().beta.messages.tool_runner(
 <summary><a id="claude-agent-sdk"></a><b>Claude Agent SDK</b></summary>
 <br>
 
-Install with `pip install 'pageindex[claude]'`. The Claude Agent SDK is async-native:
+Install with `pip install 'pageindex[claude]'` and set `ANTHROPIC_API_KEY`. The Claude Agent SDK is async-native:
 
 ```python
 from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
@@ -373,10 +373,11 @@ async for message in query(prompt="Summarize the auditor's concerns.", options=o
         print(message.result)
 ```
 
-`claude_agent_config()` supplies the system prompt, the PageIndex MCP server, and its tool pre-approval. The explicit form:
+`claude_agent_config()` supplies the system prompt, the PageIndex MCP server, and its tool pre-approval. The agent runs on Claude only: a Claude `chat_model` carries over, or pass `model=` directly. The explicit form:
 
 ```python
 options = ClaudeAgentOptions(
+    model="claude-sonnet-4-6",                                # optional; the SDK's default otherwise
     system_prompt=client.agent_instructions(doc_id=doc_id),
     mcp_servers={"pageindex": client.as_claude_mcp(doc_id=doc_id)},
     allowed_tools=["mcp__pageindex"],

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP c
 }
 ```
 
-Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or the [Claude Agent SDK](#claude-agent-sdk)'s in-process MCP server.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local mode has no standalone MCP server yet: use `agent_tools()` above, or the [Claude Agent SDK](#claude-agent-sdk)'s in-process MCP server.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner. Install it with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic model id, without the `anthropic/` prefix. Install it with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
@@ -293,7 +293,7 @@ Pass a list of ids to `doc_id` to search several documents at once, and keep it 
 
 ### (b) Integrate PageIndex with your own agent
 
-PageIndex can also be integrated into your own agent. Each example below covers a different framework:
+PageIndex can also be integrated into your own agent. Each item below covers a different integration path:
 
 <details>
 <summary><b>OpenAI Agents SDK</b></summary>

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Every helper above accepts `doc_id=` to point the agent at specific documents an
 <summary><b>MCP server</b></summary>
 <br>
 
-PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect to it without the SDK:
+PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect directly without the SDK:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -397,6 +397,29 @@ tools = client.agent_tools(doc_id=doc_id)   # plain functions returning JSON
 Every helper above accepts `doc_id=` to point the agent at specific documents and `include_management=True` to also expose document deletion (off by default). Locally, `doc_id` is enforced at the tool layer, not just prompted: out-of-scope lookups return `NOT_FOUND`.
 
 </details>
+<br>
+
+<details>
+<summary><b>Any MCP client</b></summary>
+<br>
+
+Cloud indexes are also reachable over MCP, so an agent that already speaks the protocol needs no SDK at all:
+
+```json
+{
+  "mcpServers": {
+    "pageindex": {
+      "type": "http",
+      "url": "https://api.pageindex.ai/mcp",
+      "headers": { "Authorization": "Bearer your-pageindex-key" }
+    }
+  }
+}
+```
+
+The same API key and documents work across the MCP server and the REST API; see the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone server: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
+
+</details>
 
 
 

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP c
 }
 ```
 
-Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or `as_claude_mcp()` for an in-process one.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or the Claude Agent SDK's in-process server.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic model id, without the `anthropic/` prefix. Install it with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic id, no `anthropic/` prefix. Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner, so `model=` takes a plain Anthropic id (no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner (so `model=` takes a plain Anthropic id, no `anthropic/` prefix). Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ agent = Agent(
 <br>
 
 <details>
-<summary><b>Anthropic SDK tool runner</b></summary>
+<summary><b>Anthropic SDK (tool runner)</b></summary>
 <br>
 
 Install with `pip install 'pageindex[anthropic]'`:

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Returns the agent's process transcript in `items`. Append those items to the nex
 client.messages("...", model="claude-sonnet-4-6", doc_id=doc_id)
 ```
 
-Uses Anthropic's native Messages API and tool runner. Install with `pip install 'pageindex[anthropic]'`.
+Uses Anthropic's native Messages API and tool runner; a Claude `chat_model` carries over, or pass `model=` directly. Install with `pip install 'pageindex[anthropic]'`.
 
 Pass a list of ids to `doc_id` to search several documents at once, and keep it identical across a conversation's calls.
 
@@ -342,7 +342,7 @@ final = runner.until_done()
 print(final.content[-1].text)
 ```
 
-`anthropic_runner_config()` fills every `tool_runner` slot except `messages`. The explicit form:
+`anthropic_runner_config()` fills every `tool_runner` slot except `messages`; a Claude `chat_model` carries over, or pass `model=` directly. The explicit form:
 
 ```python
 runner = anthropic.Anthropic().beta.messages.tool_runner(

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Every helper above accepts `doc_id=` to point the agent at specific documents an
 <summary><b>MCP server</b></summary>
 <br>
 
-PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP can connect directly to it without the SDK:
+[PageIndex Cloud](#pageindex-cloud) also runs an MCP server, so any agent or app that supports MCP can connect directly to it without the SDK:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ runner = anthropic.Anthropic().beta.messages.tool_runner(
 <br>
 
 <details>
-<summary><b>Claude Agent SDK</b></summary>
+<summary><a id="claude-agent-sdk"></a><b>Claude Agent SDK</b></summary>
 <br>
 
 Install with `pip install 'pageindex[claude]'`. The Claude Agent SDK is async-native:
@@ -417,7 +417,7 @@ PageIndex Cloud also runs an MCP server, so any agent or app that supports MCP c
 }
 ```
 
-Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or the Claude Agent SDK's in-process server.
+Full details in the [MCP documentation](https://docs.pageindex.ai/mcp). Local indexes have no standalone MCP server yet: use `agent_tools()` above, or the [Claude Agent SDK](#claude-agent-sdk)'s in-process MCP server.
 
 </details>
 


### PR DESCRIPTION
Adds one `<details>` item to **(b) Integrate PageIndex with your own agent**: connecting any MCP-speaking client to the hosted PageIndex MCP server, no SDK involved.

The config snippet matches https://docs.pageindex.ai/mcp verbatim (`https://api.pageindex.ai/mcp`, `type: http`, Bearer auth). The SDK-internal `?tools=read` gate is deliberately left out since the docs do not expose it. The item closes by pointing local users back to `agent_tools()` / `as_claude_mcp()`, so it never implies local mode has a standalone server.

Placed after "Other agent frameworks" so the "Every helper above accepts `doc_id=`…" wrap-up still covers only the SDK helpers. README-only, additive.

https://claude.ai/code/session_01F84VYrC858n9cr5eRjV4Cy