### PR TITLE
docs: the chart images load by absolute URL so PyPI renders them

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,8 @@ Building a tree locally runs **about $0.001 per page** with `gpt-5.6-luna` as th
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-cost-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -419,8 +419,8 @@ Indexing time also scales predictably with document length. In the same local se
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-time-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -432,8 +432,8 @@ Indexing time also scales predictably with document length. In the same local se
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/results-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 
@@ -447,8 +447,8 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
 <div align="center">
 <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/financebench-dark.png">
-  <img src="assets/financebench-light.png" width="70%" alt="FinanceBench accuracy: PageIndex 98.7%, vector RAG 50%.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/financebench-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/financebench-light.png" width="70%" alt="FinanceBench accuracy: PageIndex 98.7%, vector RAG 50%.">
 </picture>
 </a>
 </div>


### PR DESCRIPTION
The next release publishes the reworked README to PyPI (`pyproject.toml` sets `readme = "README.md"`). The four charts that rework added reference `assets/*.png` relatively, and PyPI does not resolve a relative path against the GitHub repo — they would render as broken images on the project page.

Every chart now loads from `raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/...` (all eight URLs verified 200 `image/png`). GitHub renders identically.

The `<picture>`/`<source>` wrappers stay: `readme_renderer`'s whitelist strips them, so PyPI falls back to the `<img>` light variant, while GitHub keeps the dark/light switch.