### PR TITLE
docs: drop stray blank lines in the cloud quickstart snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ client = PageIndexClient(
     index="cloud",                       # build and store the index in PageIndex Cloud
     chat="gpt-5.6-sol",                  # use your preferred compatible model for chat
 )
-
-
 doc_id = client.submit_document("report.pdf", wait=True)["doc_id"]
 print(client.chat("What was the 2023 operating margin?", doc_id=doc_id))
 ```


### PR DESCRIPTION
d1b9fbd replaced the `# The rest of your code stays the same...` comment with an empty line instead of deleting it, leaving a double blank inside the PageIndex Cloud code block. Remove both blanks so the block reads like the local quickstart (`)` directly followed by `doc_id = ...`).

Whitespace-only; no content changes.

https://claude.ai/code/session_01Wh75QagUhr5DPVATjmGrCe