### PR TITLE
Chat process display: labels are the event type names

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -837,9 +837,9 @@ class PageIndexClient:
                 model's default behavior applies.
             show_process: Streamed own-model chat — weave the run into
                 the text stream for display: thinking flows as
-                "[thinking] " sections, each tool call as a "[tool] name
-                arguments" line with its clipped result, and the answer
-                unlabeled. **On by default**, weaving what the mode
+                "[thinking] " sections, each tool call as a "[tool_call]
+                name arguments" line with its "[tool_result]" line, and
+                the answer unlabeled. **On by default**, weaving what the mode
                 serves: the in-process agent's full run; on a managed
                 client, the tool calls the endpoint streams (its wire
                 carries no thinking and no tool results). Pass ``False``

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -847,7 +847,7 @@ class PageIndexClient:
                 streamed answer to the conversation history.
                 ``True`` shows everything; a dict (typed as
                 ``pageindex.ChatProcessOptions``) selects the parts —
-                ``thinking`` / ``tool_calls`` / ``tool_results``, bools
+                ``thinking`` / ``tool_call`` / ``tool_result``, bools
                 defaulting on — and sets ``max_chars``, the per-line
                 summary cap in characters (default 200). Omitted keys
                 keep their defaults, so ``{"thinking": False}`` hides

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -615,8 +615,8 @@ def _clip(text, cap: int = 200) -> str:
     return f"{flat[:cap]}... (+{len(flat) - cap} chars)"
 
 
-_PROCESS_DEFAULTS = {"thinking": True, "tool_calls": True,
-                     "tool_results": True, "max_chars": 200}
+_PROCESS_DEFAULTS = {"thinking": True, "tool_call": True,
+                     "tool_result": True, "max_chars": 200}
 
 
 def _process_options(show_process) -> dict:
@@ -627,16 +627,16 @@ def _process_options(show_process) -> dict:
     if not isinstance(show_process, Mapping):
         raise PageIndexAPIError(
             "show_process must be True, False, or a dict with the keys "
-            "thinking / tool_calls / tool_results (bools) and max_chars "
+            "thinking / tool_call / tool_result (bools) and max_chars "
             "(int).")
     unknown = set(show_process) - set(_PROCESS_DEFAULTS)
     if unknown:
         raise PageIndexAPIError(
             "Unknown show_process keys: "
             f"{', '.join(sorted(map(repr, unknown)))} "
-            "— valid keys: thinking, tool_calls, tool_results, max_chars.")
+            "— valid keys: thinking, tool_call, tool_result, max_chars.")
     options = {**_PROCESS_DEFAULTS, **show_process}
-    for key in ("thinking", "tool_calls", "tool_results"):
+    for key in ("thinking", "tool_call", "tool_result"):
         if not isinstance(options[key], bool):
             raise PageIndexAPIError(f"show_process[{key!r}] must be a bool.")
     cap = options["max_chars"]
@@ -737,7 +737,7 @@ def _weave(events, options) -> Iterator[str]:
                         if section != "thinking" else "")
                 yield head + ev["delta"]
             elif kind == "tool_call":
-                if not options["tool_calls"]:
+                if not options["tool_call"]:
                     continue
                 arguments = ev["arguments"]
                 if not isinstance(arguments, str):
@@ -748,7 +748,7 @@ def _weave(events, options) -> Iterator[str]:
                 line = f"[tool_call] {ev['name']} {clipped}"
                 yield enter("tool") + line.rstrip()
             elif kind == "tool_result":
-                if not options["tool_results"]:
+                if not options["tool_result"]:
                     continue
                 out = _clip(ev["output"], cap)
                 if section == "tool" and ev["call_id"] == last_call:

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -753,7 +753,7 @@ def _weave(events, options) -> Iterator[str]:
                 out = _clip(ev["output"], cap)
                 if section == "tool" and ev["call_id"] == last_call:
                     # directly under its own call line
-                    yield f"\n  [tool_result] {ev['name']}: {out}"
+                    yield f"\n[tool_result] {ev['name']}: {out}"
                 else:
                     # parallel calls, or call lines hidden: standalone,
                     # arguments echoed to say whose result this is

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -702,9 +702,10 @@ async def _chat_events_agen(client, agent, items, run_kwargs):
 
 def _weave(events, options) -> Iterator[str]:
     """Render the typed event stream as display text: a "[thinking] "
-    section per thinking burst, a "[tool] name args" line per call with
-    its clipped result, the answer unlabeled. options=None is the plain
-    answer-only view; closing this generator closes the source."""
+    section per thinking burst, a "[tool_call] name args" line per call
+    with its "[tool_result]" line, the answer unlabeled — labels are the
+    event type names. options=None is the plain answer-only view;
+    closing this generator closes the source."""
     try:
         if options is None:
             for ev in events:
@@ -714,7 +715,7 @@ def _weave(events, options) -> Iterator[str]:
         section = None   # the open flowing section: thinking/answer/tool
         opened = False   # anything yielded yet (first section takes no gap)
         cap = options["max_chars"]
-        last_call = None  # the [tool] line still open for nesting
+        last_call = None  # the [tool_call] line still open for nesting
         call_args = {}    # call_id -> clipped arguments, to label orphans
 
         def enter(kind, label: str = "") -> str:
@@ -744,7 +745,7 @@ def _weave(events, options) -> Iterator[str]:
                 clipped = _clip(arguments, cap)
                 last_call = ev["call_id"]
                 call_args[last_call] = clipped
-                line = f"[tool] {ev['name']} {clipped}"
+                line = f"[tool_call] {ev['name']} {clipped}"
                 yield enter("tool") + line.rstrip()
             elif kind == "tool_result":
                 if not options["tool_results"]:
@@ -752,12 +753,12 @@ def _weave(events, options) -> Iterator[str]:
                 out = _clip(ev["output"], cap)
                 if section == "tool" and ev["call_id"] == last_call:
                     # directly under its own call line
-                    yield f"\n  -> {ev['name']}: {out}"
+                    yield f"\n  [tool_result] {ev['name']}: {out}"
                 else:
                     # parallel calls, or call lines hidden: standalone,
                     # arguments echoed to say whose result this is
                     args = call_args.get(ev["call_id"], "")
-                    head = f"-> {ev['name']} {args}".rstrip()
+                    head = f"[tool_result] {ev['name']} {args}".rstrip()
                     gap = ("\n" if section == "tool" and last_call is None
                            else enter("tool"))
                     yield f"{gap}{head}: {out}"

--- a/pageindex/types.py
+++ b/pageindex/types.py
@@ -51,8 +51,8 @@ class ChatProcessOptions(TypedDict, total=False):
     on (``max_chars``: 200); ``show_process=True`` is all defaults."""
 
     thinking: bool
-    tool_calls: bool
-    tool_results: bool
+    tool_call: bool
+    tool_result: bool
     max_chars: int
 
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -563,7 +563,7 @@ def test_chat_process_managed_weaves_what_the_wire_serves(monkeypatch):
     assert "".join(cloud.chat("q", stream=True, show_process=True)) == text
     cloud, _ = _managed_cloud_with_tool_stream(monkeypatch)
     no_calls = "".join(cloud.chat("q", stream=True,
-                                  show_process={"tool_calls": False}))
+                                  show_process={"tool_call": False}))
     assert no_calls == "Let me check.The answer"
 
 
@@ -635,12 +635,12 @@ def test_chat_process_dict_selects_parts(client, store_path, fake_model):
     assert "[tool_call] get_document" in no_thinking
     assert "[tool_result] get_document: " in no_thinking
 
-    no_calls = run({"tool_calls": False})
+    no_calls = run({"tool_call": False})
     assert "[tool_call]" not in no_calls
     assert "\n\n[tool_result] get_document: " in no_calls  # results stand alone
     assert "[thinking] Need the report" in no_calls
 
-    calls_only = run({"tool_results": False})
+    calls_only = run({"tool_result": False})
     assert "[tool_call] get_document" in calls_only
     assert "[tool_result]" not in calls_only
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -481,7 +481,7 @@ def test_chat_cloud_unwraps_envelope(monkeypatch):
 def test_chat_process_weaves_thinking_and_tools(client, store_path,
                                                 fake_model):
     """show_process=True keeps the plain text stream but weaves the run in:
-    a "[thinking] " section per thinking burst, a "[tool] name args"
+    a "[thinking] " section per thinking burst, a "[tool_call] name args"
     line per call with its clipped result, and the answer unlabeled."""
     seed_doc(store_path, "pi-a", "report.pdf")
     fake = fake_model([
@@ -491,8 +491,8 @@ def test_chat_process_weaves_thinking_and_tools(client, store_path,
     fake.thinking_pieces = ("Need the ", "report")
     text = "".join(client.chat("What status?", stream=True, show_process=True))
     assert text.startswith("[thinking] Need the report")
-    assert '\n\n[tool] get_document {"doc_name": "report.pdf"}' in text
-    assert "\n  -> get_document: " in text
+    assert '\n\n[tool_call] get_document {"doc_name": "report.pdf"}' in text
+    assert "\n  [tool_result] get_document: " in text
     assert text.endswith("\n\nThe answer")
     assert "[answer]" not in text
 
@@ -557,7 +557,7 @@ def test_chat_process_managed_weaves_what_the_wire_serves(monkeypatch):
     text = "".join(cloud.chat("What status?", stream=True))
     assert seen["stream_metadata"] is True
     assert text == ('Let me check.\n\n'
-                    '[tool] get_document {"doc_name": "report.pdf"}\n\n'
+                    '[tool_call] get_document {"doc_name": "report.pdf"}\n\n'
                     'The answer')
     cloud, _ = _managed_cloud_with_tool_stream(monkeypatch)
     assert "".join(cloud.chat("q", stream=True, show_process=True)) == text
@@ -597,7 +597,7 @@ def test_chat_process_managed_open_block_never_leaks(monkeypatch):
                                              show_process=False))
         assert plain == "The answer"
         woven = "".join(cloud_with(tag).chat("q", stream=True))
-        assert '[tool] get_document {"doc_name": "report.pdf"}' in woven
+        assert '[tool_call] get_document {"doc_name": "report.pdf"}' in woven
 
 
 def test_chat_process_managed_non_string_argument_chunk(monkeypatch):
@@ -612,7 +612,7 @@ def test_chat_process_managed_non_string_argument_chunk(monkeypatch):
         _cloud_chunk("The answer"),
     ]))
     text = "".join(cloud.chat("q", stream=True))
-    assert "[tool] get_document" in text
+    assert "[tool_call] get_document" in text
     assert text.endswith("The answer")
 
 
@@ -632,17 +632,17 @@ def test_chat_process_dict_selects_parts(client, store_path, fake_model):
 
     no_thinking = run({"thinking": False})
     assert "[thinking]" not in no_thinking
-    assert "[tool] get_document" in no_thinking
-    assert "-> get_document: " in no_thinking
+    assert "[tool_call] get_document" in no_thinking
+    assert "[tool_result] get_document: " in no_thinking
 
     no_calls = run({"tool_calls": False})
-    assert "[tool]" not in no_calls
-    assert "\n\n-> get_document: " in no_calls  # results stand alone
+    assert "[tool_call]" not in no_calls
+    assert "\n\n[tool_result] get_document: " in no_calls  # results stand alone
     assert "[thinking] Need the report" in no_calls
 
     calls_only = run({"tool_results": False})
-    assert "[tool] get_document" in calls_only
-    assert "-> " not in calls_only
+    assert "[tool_call] get_document" in calls_only
+    assert "[tool_result]" not in calls_only
 
     assert run({}) == run(True)
 
@@ -656,7 +656,8 @@ def test_chat_process_max_chars_caps_lines(client, store_path, fake_model):
     ])
     text = "".join(client.chat("What status?", stream=True,
                                show_process={"max_chars": 10}))
-    line = next(ln for ln in text.splitlines() if ln.startswith("  -> "))
+    line = next(ln for ln in text.splitlines()
+                if ln.startswith("  [tool_result] "))
     body = line.split(": ", 1)[1]
     assert body[10:].startswith("... (+")
 
@@ -740,7 +741,7 @@ def test_chat_stream_shows_process_by_default(client, store_path,
     fake.thinking_pieces = ("Need the report",)
     text = "".join(client.chat("What status?", stream=True))
     assert "[thinking] Need the report" in text
-    assert "[tool] get_document" in text
+    assert "[tool_call] get_document" in text
     fake = fake_model([
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
@@ -847,13 +848,13 @@ def test_chat_process_parallel_calls_pair_results(client, store_path,
     ])
     text = "".join(client.chat("What status?", stream=True,
                                show_process=True))
-    assert "\n  -> " not in text  # nothing nests under the wrong call
-    assert '\n\n-> get_document {"doc_name": "report.pdf"}: ' in text
-    assert '\n-> get_document {"doc_name": "other.pdf"}: ' in text
-    assert '\n\n-> get_document {"doc_name": "other.pdf"}' not in text
+    assert "\n  [tool_result] " not in text  # nothing nests under the wrong call
+    assert '\n\n[tool_result] get_document {"doc_name": "report.pdf"}: ' in text
+    assert '\n[tool_result] get_document {"doc_name": "other.pdf"}: ' in text
+    assert '\n\n[tool_result] get_document {"doc_name": "other.pdf"}' not in text
     for doc in ("report.pdf", "other.pdf"):
         line = next(ln for ln in text.splitlines()
-                    if ln.startswith(f'-> get_document {{"doc_name": '
+                    if ln.startswith(f'[tool_result] get_document {{"doc_name": '
                                      f'"{doc}"}}: '))
         assert f'"{doc}"' in line.split("}: ", 1)[1]
 
@@ -2011,7 +2012,7 @@ def test_chat_stream_abandonment_cancels_pending_turn(client, store_path,
 
     fake._client = _Backend()
     stream = client.chat("q", stream=True)
-    assert next(stream).startswith("[tool] get_document")
+    assert next(stream).startswith("[tool_call] get_document")
     stream.close()
     assert len(pumps) == 1
     pumps[0].join(timeout=3.0)

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -492,7 +492,7 @@ def test_chat_process_weaves_thinking_and_tools(client, store_path,
     text = "".join(client.chat("What status?", stream=True, show_process=True))
     assert text.startswith("[thinking] Need the report")
     assert '\n\n[tool_call] get_document {"doc_name": "report.pdf"}' in text
-    assert "\n  [tool_result] get_document: " in text
+    assert '"report.pdf"}\n[tool_result] get_document: ' in text
     assert text.endswith("\n\nThe answer")
     assert "[answer]" not in text
 
@@ -657,7 +657,7 @@ def test_chat_process_max_chars_caps_lines(client, store_path, fake_model):
     text = "".join(client.chat("What status?", stream=True,
                                show_process={"max_chars": 10}))
     line = next(ln for ln in text.splitlines()
-                if ln.startswith("  [tool_result] "))
+                if ln.startswith("[tool_result] "))
     body = line.split(": ", 1)[1]
     assert body[10:].startswith("... (+")
 
@@ -848,7 +848,9 @@ def test_chat_process_parallel_calls_pair_results(client, store_path,
     ])
     text = "".join(client.chat("What status?", stream=True,
                                show_process=True))
-    assert "\n  [tool_result] " not in text  # nothing nests under the wrong call
+    # no result rides directly under a call that is not its own — the
+    # bare paired form is absent, every result echoes its arguments
+    assert "\n[tool_result] get_document: " not in text
     assert '\n\n[tool_result] get_document {"doc_name": "report.pdf"}: ' in text
     assert '\n[tool_result] get_document {"doc_name": "other.pdf"}: ' in text
     assert '\n\n[tool_result] get_document {"doc_name": "other.pdf"}' not in text


### PR DESCRIPTION
Three naming rulings on the v0.2.13 chat process display, cherry-picked from `feat/chat-process-display` (payload verified byte-identical):

- Woven text labels are the event type names: `[tool_call]` / `[tool_result]` replace `[tool]` and the `->` arrow.
- `tool_result` lines sit flush left — no nesting indent.
- One vocabulary: the `show_process` dict keys are the event type names too — `thinking` / `tool_call` / `tool_result` (+ `max_chars`), singular, matching `.events` and the labels.

**Release-notes material (breaking vs v0.2.13, one-day exposure, fail-loud):** `show_process={"tool_calls": ...}` / `{"tool_results": ...}` now raise with the valid keys named in the error; streamed process labels changed shape. `ChatProcessOptions` field names follow.

Not for immediate release — ships with the next version. Docs PR VectifyAI/pageindex-docs#46 already carries this naming and stays on hold until then.

465 tests green, without-frameworks leg simulated, pyright flat.

https://claude.ai/code/session_014GN8u3zdH3RpeftHZChavP