### PR TITLE
chat(protocol=): the protocol doors move behind the front door

### DIFF
--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1621,7 +1621,8 @@ def doc_targeting_block(client, doc_id, scoped: bool = False) -> Optional[str]:
     """The doc_id targeting text: names, metadata, and the directive to work
     within those documents. Shared by agent_instructions and the local chat
     surfaces (a leading conversation item on the OpenAI surfaces, a system
-    block on messages()). Raises when a doc_id's name is shadowed by a newer
+    block on the Messages lane). Raises when a doc_id's name is shadowed by a
+    newer
     same-name document — the name-addressed tools could not reach it. With
     ``scoped`` (surfaces whose tools resolve names inside the doc_id
     allowlist) only a same-name duplicate within the targeted set

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -530,6 +530,21 @@ class PageIndexClient:
             return bool(model.strip())
         return model is not None
 
+    def _require_own_chat(self, lane: str) -> None:
+        # The one refusal for chat(protocol=...), the doors behind it, and
+        # instructions: shared, so the doors cannot drift from chat().
+        if self._local_chat:
+            return
+        if not getattr(self, "api_key", None):
+            raise PageIndexAPIError(
+                "chat_model is empty — it configures nothing, and a local "
+                "client has no managed chat to fall back to. Set "
+                "chat_model=... to run the agent with your own model.")
+        raise PageIndexAPIError(
+            f"{lane} drives your own chat model — construct the client "
+            "with chat_model=... (or a chat= model); the managed cloud chat "
+            "serves the answer lane and chat_completions() only.")
+
     if not TYPE_CHECKING:
         # The protocol doors live behind chat(protocol=...); their old
         # names are the vendor SDKs' own, so an agent-written
@@ -875,6 +890,24 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        protocol: None = None,
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> Union[str, "ChatStream"]: ...
+
+    @overload
+    def chat(
+        self,
+        messages: Union[str, list[dict[str, Any]]],
+        doc_id: Optional[Union[str, list[str]]] = None,
+        stream: bool = False,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        show_process: Union[bool, Mapping[str, Any], None] = None,
+        *,
         protocol: Optional[str] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -1028,12 +1061,6 @@ class PageIndexClient:
                 "protocol selects the wire: \"responses\" (OpenAI Responses) "
                 "or \"messages\" (Anthropic Messages), or leave it unset for "
                 f"the answer lane — got {protocol!r}.")
-        if (show_process is not False and show_process is not None
-                and not stream):
-            raise PageIndexAPIError(
-                "show_process shows the run as it happens and requires "
-                "stream=True; only show_process=False (or None) means "
-                f"off — got {show_process!r}.")
         if (protocol is not None and show_process is not False
                 and show_process is not None):
             raise PageIndexAPIError(
@@ -1041,18 +1068,19 @@ class PageIndexClient:
                 f"protocol={protocol!r} the run comes back as the protocol's "
                 "own transcript and events — drop show_process, or drop "
                 "protocol for the woven text stream.")
+        if (show_process is not False and show_process is not None
+                and not stream):
+            raise PageIndexAPIError(
+                "show_process shows the run as it happens and requires "
+                "stream=True; only show_process=False (or None) means "
+                f"off — got {show_process!r}.")
         if isinstance(instructions, list) and protocol != "messages":
             raise PageIndexAPIError(
                 "instructions blocks are the Messages protocol's shape — "
                 "with protocol=\"messages\" they append after the managed "
                 "system blocks; the other lanes take a string.")
         if protocol is not None:
-            if not self._local_chat:
-                raise PageIndexAPIError(
-                    f"chat(protocol={protocol!r}) drives your own chat model "
-                    "— construct the client with chat_model=... (or a chat= "
-                    "model); the managed cloud chat serves the answer lane "
-                    "and chat_completions() only.")
+            self._require_own_chat(f"chat(protocol={protocol!r})")
             if protocol == "responses":
                 return self._responses(
                     messages, model=model, stream=stream, doc_id=doc_id,
@@ -1062,7 +1090,7 @@ class PageIndexClient:
                                if reasoning_effort is not None else None),
                     extra_body=extra_body, extra_headers=extra_headers,
                     backend=backend)
-            if model is None:
+            if not model:
                 raise PageIndexAPIError(
                     "protocol=\"messages\" drives Anthropic's Messages API "
                     "with the Anthropic SDK — name the Claude model with "
@@ -1079,14 +1107,8 @@ class PageIndexClient:
                 messages, model=model, stream=stream, doc_id=doc_id,
                 system=instructions, max_turns=max_turns, extra_body=body,
                 extra_headers=extra_headers, backend=backend)
-        if instructions is not None:
-            if not self._local_chat:
-                raise PageIndexAPIError(
-                    "instructions drives your own chat model, which this "
-                    "client does not configure — construct the client with "
-                    "chat_model=... (or a chat= model) to run the agent in "
-                    "your process, or drop it to use the managed chat "
-                    "endpoint.")
+        if instructions:
+            self._require_own_chat("instructions")
             if isinstance(messages, str):
                 if not messages.strip():
                     raise PageIndexAPIError(
@@ -1311,8 +1333,8 @@ class PageIndexClient:
         Responses API; backends that only speak chat.completions should use
         ``chat_completions()``. Provider-prefixed models (``anthropic/…``)
         route through LiteLLM's chat.completions adapter and are therefore
-        refused here — use ``chat_completions()`` or ``messages()`` for
-        those.
+        refused here — use ``chat_completions()`` or
+        ``chat(protocol="messages")`` for those.
 
         Args:
             input: A user message string, or a list of Responses input items
@@ -1355,13 +1377,7 @@ class PageIndexClient:
                 ``api_key``, ``base_url``, ``organization``, … — passed
                 verbatim; unknown keys raise.
         """
-        if not self._local_chat:
-            raise PageIndexAPIError(
-                "chat(protocol='responses') drives your own chat model — "
-                "construct the "
-                "client with chat_model=... (or a chat= model); the managed "
-                "cloud chat serves chat_completions() only."
-            )
+        self._require_own_chat("chat(protocol='responses')")
         from .local_chat import run_responses
         return run_responses(
             self, input, model=model, stream=stream, doc_id=doc_id,
@@ -1447,13 +1463,7 @@ class PageIndexClient:
                 ``api_key``, ``base_url``, ``auth_token``, … — passed
                 verbatim; unknown keys raise.
         """
-        if not self._local_chat:
-            raise PageIndexAPIError(
-                "chat(protocol='messages') drives your own chat model — "
-                "construct the "
-                "client with chat_model=... (or a chat= model); the managed "
-                "cloud chat serves chat_completions() only."
-            )
+        self._require_own_chat("chat(protocol='messages')")
         from .local_chat import run_messages
         return run_messages(
             self, messages, model=model, max_tokens=max_tokens,

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -530,6 +530,20 @@ class PageIndexClient:
             return bool(model.strip())
         return model is not None
 
+    if not TYPE_CHECKING:
+        # The protocol doors live behind chat(protocol=...); their old
+        # names are the vendor SDKs' own, so an agent-written
+        # client.messages(...) fails here with the way in. Runtime-only:
+        # a __getattr__ the type checker can see would silence every
+        # attribute typo on the client.
+        def __getattr__(self, name):
+            if name in ("responses", "messages"):
+                raise AttributeError(
+                    f"{name}() moved: call chat(protocol={name!r}, ...) "
+                    "— the same protocol, engine, and envelope.")
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute {name!r}")
+
     @property
     def retrieve_model(self):
         """Legacy name for ``chat_model``."""
@@ -758,88 +772,190 @@ class PageIndexClient:
 
     # ---------- CHAT ----------
 
-    # stream picks the return type: the docstring's `.events` usage must
-    # type-check for py.typed consumers
+    # stream and protocol pick the return type: the docstring's `.events`
+    # usage and the protocol envelopes must type-check for py.typed
+    # consumers
     @overload
     def chat(
         self,
-        messages: Union[str, list[dict[str, str]]],
+        messages: Union[str, list[dict[str, Any]]],
         doc_id: Optional[Union[str, list[str]]] = None,
         stream: Literal[False] = False,
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
+        *,
+        protocol: None = None,
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> str: ...
 
     @overload
     def chat(
         self,
-        messages: Union[str, list[dict[str, str]]],
+        messages: Union[str, list[dict[str, Any]]],
         doc_id: Optional[Union[str, list[str]]] = None,
         *,
         stream: Literal[True],
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
+        protocol: None = None,
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> "ChatStream": ...
 
     @overload
     def chat(
         self,
-        messages: Union[str, list[dict[str, str]]],
+        messages: Union[str, list[dict[str, Any]]],
+        doc_id: Optional[Union[str, list[str]]] = None,
+        stream: Literal[False] = False,
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        show_process: Union[bool, Mapping[str, Any], None] = None,
+        *,
+        protocol: Literal["responses", "messages"],
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]: ...
+
+    @overload
+    def chat(
+        self,
+        messages: Union[str, list[dict[str, Any]]],
+        doc_id: Optional[Union[str, list[str]]] = None,
+        *,
+        stream: Literal[True],
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        show_process: Union[bool, Mapping[str, Any], None] = None,
+        protocol: Literal["responses"],
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> Iterator[dict[str, Any]]: ...
+
+    @overload
+    def chat(
+        self,
+        messages: Union[str, list[dict[str, Any]]],
+        doc_id: Optional[Union[str, list[str]]] = None,
+        *,
+        stream: Literal[True],
+        model: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        show_process: Union[bool, Mapping[str, Any], None] = None,
+        protocol: Literal["messages"],
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> Iterator[Any]: ...
+
+    @overload
+    def chat(
+        self,
+        messages: Union[str, list[dict[str, Any]]],
         doc_id: Optional[Union[str, list[str]]] = None,
         stream: bool = False,
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
-    ) -> Union[str, "ChatStream"]: ...
+        *,
+        protocol: Optional[str] = None,
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> Union[str, "ChatStream", dict[str, Any], Iterator[Any]]: ...
 
     def chat(
         self,
-        messages: Union[str, list[dict[str, str]]],
+        messages: Union[str, list[dict[str, Any]]],
         doc_id: Optional[Union[str, list[str]]] = None,
         stream: bool = False,
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
-    ) -> Union[str, "ChatStream"]:
+        *,
+        protocol: Optional[str] = None,
+        instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        max_turns: Optional[int] = None,
+        backend: Optional[dict[str, Any]] = None,
+        extra_headers: Optional[dict[str, str]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
+    ) -> Union[str, "ChatStream", dict[str, Any], Iterator[Any]]:
         """
-        Ask a question about your documents, get the answer.
+        Ask a question about your documents.
 
-        Thin sugar over the same engine as ``chat_completions()`` in
-        every mode — same wire, minus the envelope. Multi-turn: keep your
-        own role/content list of the visible conversation (append each
-        answer as an assistant message; join a stream into one only with
-        ``show_process=False``) and pass it back. For usage
-        accounting, streaming metadata, or the full protocol transcripts,
-        use the protocol surfaces: ``chat_completions()``,
-        ``responses()``, ``messages()``.
+        The answer lane (no ``protocol``): thin sugar over the same engine
+        as ``chat_completions()`` in every mode — same wire, minus the
+        envelope. Returns the answer string (a ``ChatStream`` when
+        streaming). Multi-turn: keep your own role/content list of the
+        visible conversation (append each answer as an assistant message;
+        join a stream into one only with ``show_process=False``) and pass
+        it back.
+
+        The protocol lanes (``protocol="responses"`` / ``"messages"``):
+        own-model chat driven natively over the OpenAI Responses API or
+        Anthropic's Messages API. Input and output are that protocol's own
+        shapes — the history may carry its transcript (Responses items, or
+        Messages content blocks with prior tool_use/tool_result
+        round-trips), and the return is its response envelope, streaming
+        its native events. A round-tripped transcript continues the
+        agent's memory and the provider's cached prefix: follow-ups re-read
+        the run instead of redoing the tool work. The protocol is declared,
+        never inferred from the model name. Keep ``doc_id`` and
+        ``protocol`` constant across a conversation's calls.
 
         Args:
-            messages: A question string, or role/content conversation
-                history.
+            messages: A question string, or the conversation history —
+                role/content messages on every lane. A leading ``system``
+                row joins the managed prompt on the answer lane only; the
+                protocol lanes pass rows to the wire as they are (use
+                ``instructions`` for persona there). With a protocol, also
+                that protocol's transcript items or content blocks.
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls. Local
                 documents: also enforced at the tool layer, not just
                 prompted. Cloud documents: the managed chat scopes
                 server-side; own-model chat targets at the prompt level.
-            stream: Return a ``ChatStream``: iterate it for the answer
-                as text chunks as they are produced, or read its
-                ``.events`` property instead for the run as typed event
-                dicts — thinking/answer deltas, each tool call and its
-                full result (own-model chat only; never clipped). One
-                run serves one view.
+            stream: Answer lane: return a ``ChatStream`` — iterate it for
+                the answer as text chunks as they are produced, or read
+                its ``.events`` property instead for the run as typed
+                event dicts — thinking/answer deltas, each tool call and
+                its full result (own-model chat only; never clipped). One
+                run serves one view. Protocol lanes: the protocol's own
+                event stream.
             model: Own-model chat only — backend model name (defaults
-                to ``chat_model``).
+                to ``chat_model``). ``protocol="messages"`` needs it named
+                — a Claude model; there is no cross-vendor default.
             reasoning_effort: Own-model chat only — how hard the model
                 thinks (``"low"`` / ``"medium"`` / ``"high"``; what a
-                backend accepts is its own). Unset sends nothing — the
-                model's default behavior applies.
-            show_process: Streamed own-model chat — weave the run into
-                the text stream for display: thinking flows as
-                "[thinking] " sections, each tool call as a "[tool_call]
-                name arguments" line with its "[tool_result]" line, and
-                the answer unlabeled. **On by default**, weaving what the mode
+                backend accepts is its own). Each lane sends its native
+                spelling: LiteLLM's ``reasoning_effort``, Responses
+                ``reasoning.effort``, Messages ``output_config.effort``.
+                Unset sends nothing — the model's default applies.
+            show_process: Answer lane, streamed own-model chat — weave
+                the run into the text stream for display: thinking flows
+                as "[thinking] " sections, each tool call as a
+                "[tool_call] name arguments" line with its "[tool_result]"
+                line, and the answer unlabeled. **On by default**, weaving
+                what the mode
                 serves: the in-process agent's full run; on a managed
                 client, the tool calls the endpoint streams (its wire
                 carries no thinking and no tool results). Pass ``False``
@@ -857,24 +973,131 @@ class PageIndexClient:
                 models expose none on the chat protocol). The labels are
                 not a parse format, and a process stream must not be
                 appended back as conversation history — for the
-                machine-readable process use ``.events``, ``responses()``
-                or ``messages()``.
+                machine-readable process use ``.events``, or a protocol
+                lane's transcript. A protocol lane returns that
+                transcript itself, so ``show_process`` is an error there.
+            protocol: ``None`` for the answer lane, or ``"responses"`` /
+                ``"messages"`` — the wire protocol, engine, and
+                input/output shapes of this call. Own-model chat only.
+            instructions: Own-model chat only — persona or extra guidance
+                appended after the managed system prompt (which stays: it
+                carries the tool guidance and the document context). A
+                string on every lane; with ``protocol="messages"`` also
+                a list of Messages system blocks. On the answer lane it
+                precedes any ``system`` rows in the history.
+            max_turns: Own-model chat only — cap on agent turns per call.
+            backend: Own-model chat only — connection overrides for this
+                call's backend, merged over the client's ``chat_backend``
+                (per-call keys win): LiteLLM's connection params on the
+                answer lane, the openai / anthropic SDK's client params
+                on the protocol lanes. Passed through verbatim.
+            extra_headers: Own-model chat only — extra HTTP headers
+                merged into each backend request; caller headers win.
+                LiteLLM's anthropic adapter owns ``anthropic-beta`` on the
+                answer lane — Anthropic beta flags ride
+                ``protocol="messages"``.
+            extra_body: Own-model chat only — the provider's own request
+                fields beyond this method's parameters (``thinking``,
+                ``top_k``, ``max_output_tokens``, …), merged last so they
+                win — including over the fields the SDK writes
+                (``system``, ``input``): override those and the managed
+                prompt is yours to replace. Answer lane: LiteLLM's own
+                params, mapped or refused per provider (its named
+                sampling params are ``chat_completions()``'s); protocol
+                lanes: verbatim into the request body. Credentials belong
+                in ``backend``, never here.
 
         Returns:
-            - stream=False: the answer string
-            - stream=True: a ``ChatStream`` — iterating it yields text
-              chunks (with show_process, the run's process woven in as
-              labeled sections); ``.events`` yields typed event dicts:
-              ``{"type": "thinking"|"answer", "delta": ...}``,
+            - answer lane, stream=False: the answer string
+            - answer lane, stream=True: a ``ChatStream`` — iterating it
+              yields text chunks (with show_process, the run's process
+              woven in as labeled sections); ``.events`` yields typed
+              event dicts: ``{"type": "thinking"|"answer", "delta": ...}``,
               ``{"type": "tool_call", "call_id", "name", "arguments"}``,
               ``{"type": "tool_result", "call_id", "name", "output"}``
+            - protocol lane, stream=False: the protocol's response
+              envelope — Responses: ``output`` plus an ``items``
+              transcript and cross-turn ``usage``; Messages: the final
+              message with a ``messages`` turn sequence and aggregated
+              ``usage``
+            - protocol lane, stream=True: an iterator of the protocol's
+              own stream events
         """
+        if protocol not in (None, "responses", "messages"):
+            raise PageIndexAPIError(
+                "protocol selects the wire: \"responses\" (OpenAI Responses) "
+                "or \"messages\" (Anthropic Messages), or leave it unset for "
+                f"the answer lane — got {protocol!r}.")
         if (show_process is not False and show_process is not None
                 and not stream):
             raise PageIndexAPIError(
                 "show_process shows the run as it happens and requires "
                 "stream=True; only show_process=False (or None) means "
                 f"off — got {show_process!r}.")
+        if (protocol is not None and show_process is not False
+                and show_process is not None):
+            raise PageIndexAPIError(
+                "show_process weaves the answer lane's run; with "
+                f"protocol={protocol!r} the run comes back as the protocol's "
+                "own transcript and events — drop show_process, or drop "
+                "protocol for the woven text stream.")
+        if isinstance(instructions, list) and protocol != "messages":
+            raise PageIndexAPIError(
+                "instructions blocks are the Messages protocol's shape — "
+                "with protocol=\"messages\" they append after the managed "
+                "system blocks; the other lanes take a string.")
+        if protocol is not None:
+            if not self._local_chat:
+                raise PageIndexAPIError(
+                    f"chat(protocol={protocol!r}) drives your own chat model "
+                    "— construct the client with chat_model=... (or a chat= "
+                    "model); the managed cloud chat serves the answer lane "
+                    "and chat_completions() only.")
+            if protocol == "responses":
+                return self._responses(
+                    messages, model=model, stream=stream, doc_id=doc_id,
+                    instructions=cast(Optional[str], instructions),
+                    max_turns=max_turns,
+                    reasoning=({"effort": reasoning_effort}
+                               if reasoning_effort is not None else None),
+                    extra_body=extra_body, extra_headers=extra_headers,
+                    backend=backend)
+            if model is None:
+                raise PageIndexAPIError(
+                    "protocol=\"messages\" drives Anthropic's Messages API "
+                    "with the Anthropic SDK — name the Claude model with "
+                    "model=... (there is no cross-vendor default to guess).")
+            body = extra_body
+            if reasoning_effort is not None:
+                # Anthropic's own effort field, beside the caller's other
+                # output_config keys — theirs still win.
+                given = extra_body or {}
+                body = {**given, "output_config": {
+                    "effort": reasoning_effort,
+                    **given.get("output_config", {})}}
+            return self._messages(
+                messages, model=model, stream=stream, doc_id=doc_id,
+                system=instructions, max_turns=max_turns, extra_body=body,
+                extra_headers=extra_headers, backend=backend)
+        if instructions is not None:
+            if not self._local_chat:
+                raise PageIndexAPIError(
+                    "instructions drives your own chat model, which this "
+                    "client does not configure — construct the client with "
+                    "chat_model=... (or a chat= model) to run the agent in "
+                    "your process, or drop it to use the managed chat "
+                    "endpoint.")
+            if isinstance(messages, str):
+                if not messages.strip():
+                    raise PageIndexAPIError(
+                        "messages must be a non-empty string or a list of "
+                        "message dicts.")
+                messages = [{"role": "user", "content": messages}]
+            if isinstance(messages, list):
+                # The first system text: managed prompt, then instructions,
+                # then the history's own system rows.
+                messages = [{"role": "system", "content": instructions},
+                            *messages]
         if stream:
             # the default means "on where available"
             resolved = True if show_process is None else show_process
@@ -883,18 +1106,28 @@ class PageIndexClient:
                 return run_chat_stream(self, messages, doc_id=doc_id,
                                        model=model,
                                        reasoning_effort=reasoning_effort,
-                                       show_process=resolved)
+                                       show_process=resolved,
+                                       max_turns=max_turns, backend=backend,
+                                       extra_headers=extra_headers,
+                                       extra_body=extra_body)
             from .local_chat import _process_options, run_cloud_chat_stream
             if resolved is not False:
                 _process_options(resolved)  # choke before the request is sent
             chunks = self.chat_completions(messages, stream=True,
                                            stream_metadata=True,
                                            doc_id=doc_id, model=model,
-                                           reasoning_effort=reasoning_effort)
+                                           reasoning_effort=reasoning_effort,
+                                           max_turns=max_turns,
+                                           backend=backend,
+                                           extra_headers=extra_headers,
+                                           extra_body=extra_body)
             return run_cloud_chat_stream(
                 cast(Iterator[dict[str, Any]], chunks), resolved)
         result = self.chat_completions(messages, doc_id=doc_id, model=model,
-                                       reasoning_effort=reasoning_effort)
+                                       reasoning_effort=reasoning_effort,
+                                       max_turns=max_turns, backend=backend,
+                                       extra_headers=extra_headers,
+                                       extra_body=extra_body)
         envelope = cast(dict[str, Any], result)
         try:
             return envelope["choices"][0]["message"]["content"] or ""
@@ -943,7 +1176,7 @@ class PageIndexClient:
         finish reason — "stop", or the backend's "length" /
         "content_filter" when the last turn was cut short. For
         the tool-use process and prompt-cache round-trip use
-        ``responses()`` or ``messages()``.
+        ``chat(protocol="responses")`` or ``chat(protocol="messages")``.
 
         Args:
             messages: Conversation messages with 'role' and 'content' keys,
@@ -989,8 +1222,8 @@ class PageIndexClient:
             extra_headers: Own-model chat only — extra HTTP headers merged into
                 each backend request; caller headers win. One exception:
                 LiteLLM's anthropic adapter owns the ``anthropic-beta``
-                header (your value is dropped there) — use ``messages()``
-                for Anthropic beta flags.
+                header (your value is dropped there) — Anthropic beta
+                flags ride ``chat(protocol="messages")``.
             backend: Own-model chat only — connection overrides for this call's
                 backend, merged over the client's ``chat_backend``
                 (per-call keys win). Keys are LiteLLM's own connection
@@ -1043,7 +1276,7 @@ class PageIndexClient:
             enable_citations=enable_citations,
         )
 
-    def responses(
+    def _responses(
         self,
         input: Union[str, list[dict[str, Any]]],
         model: Optional[str] = None,
@@ -1060,7 +1293,8 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
         """
-        Document QA over the OpenAI Responses protocol — the agentic surface.
+        The engine behind ``chat(protocol="responses")``: document QA over
+        the OpenAI Responses protocol.
 
         Own-model chat only — local mode, or a cloud client constructed
         with ``chat_model=``/``chat=``. Drives your backend's /responses
@@ -1123,7 +1357,8 @@ class PageIndexClient:
         """
         if not self._local_chat:
             raise PageIndexAPIError(
-                "responses() drives your own chat model — construct the "
+                "chat(protocol='responses') drives your own chat model — "
+                "construct the "
                 "client with chat_model=... (or a chat= model); the managed "
                 "cloud chat serves chat_completions() only."
             )
@@ -1136,7 +1371,7 @@ class PageIndexClient:
             extra_headers=extra_headers, backend=backend,
         )
 
-    def messages(
+    def _messages(
         self,
         messages: Union[str, list[dict[str, Any]]],
         model: str,
@@ -1155,7 +1390,8 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
     ) -> Union[dict[str, Any], Iterator[Any]]:
         """
-        Document QA over the Anthropic Messages protocol — Claude-native.
+        The engine behind ``chat(protocol="messages")``: document QA over
+        the Anthropic Messages protocol, Claude-native.
 
         Own-model chat only — local mode, or a cloud client constructed
         with ``chat_model=``/``chat=``. Drives Anthropic's /v1/messages
@@ -1213,7 +1449,8 @@ class PageIndexClient:
         """
         if not self._local_chat:
             raise PageIndexAPIError(
-                "messages() drives your own chat model — construct the "
+                "chat(protocol='messages') drives your own chat model — "
+                "construct the "
                 "client with chat_model=... (or a chat= model); the managed "
                 "cloud chat serves chat_completions() only."
             )
@@ -1471,7 +1708,7 @@ class PageIndexClient:
         "authorization_token": <your PageIndex API key>}]`` (drop
         ``?tools=read`` for the full tool set) — with no client-side
         tools involved. Local: the in-process tools — the same set
-        ``messages()`` runs internally.
+        ``chat(protocol="messages")`` runs internally.
 
         Requires ``anthropic>=0.108.0``
         (``pip install 'pageindex[anthropic]'``), imported only when this
@@ -1517,10 +1754,11 @@ class PageIndexClient:
         Sugar over the explicit form — ``agent_instructions`` (with
         ``doc_id`` targeting) as the system prompt and
         ``as_anthropic_tools`` as the tools — plus the ``max_tokens``
-        default and 10-turn ``max_iterations`` bound ``messages()`` uses,
+        default and 10-turn ``max_iterations`` bound
+        ``chat(protocol="messages")`` uses,
         and a top-level ``cache_control`` so each loop turn re-reads the
         growing prompt from cache (pop the key if you place your own
-        breakpoints — the API allows four). Unlike ``messages()``,
+        breakpoints — the API allows four). Unlike the chat lane,
         ``system`` here is the bare instructions string, without the chat
         header or its block-level breakpoint. To customize further,
         switch to those methods directly.

--- a/pageindex/integrations/anthropic_sdk.py
+++ b/pageindex/integrations/anthropic_sdk.py
@@ -3,7 +3,8 @@
 Cloud clients get one runnable tool per live cloud MCP tool — the server's
 input schemas pass through verbatim (MCP inputSchema and Messages API
 input_schema are the same shape), calls proxied over MCP. Local clients get
-the in-process tools — the same set messages() runs internally. Failed
+the in-process tools — the same set chat(protocol="messages") runs
+internally. Failed
 calls raise ToolError so the runner emits the tool_result with
 ``is_error: true`` and the envelope as its content.
 """

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -60,7 +60,8 @@ def _system_text(content: Any) -> str:
 def _split_chat_messages(messages) -> "tuple[list[str], list[dict]]":
     """Validate the chat_completions surface's messages: system/developer
     content joins the managed instructions; user/assistant history passes
-    through. Tool-history round-trips belong to responses()/messages()."""
+    through. Tool-history round-trips belong to the protocol lanes,
+    chat(protocol=...)."""
     if not isinstance(messages, list) or not messages:
         raise PageIndexAPIError("messages must be a non-empty list.")
     system_texts: list[str] = []
@@ -77,13 +78,13 @@ def _split_chat_messages(messages) -> "tuple[list[str], list[dict]]":
             if not isinstance(content, str):
                 raise PageIndexAPIError(
                     "chat_completions content must be a string; for "
-                    "structured items use responses() or messages()."
+                    "structured items use chat(protocol=...)."
                 )
             history.append({"role": role, "content": content})
         else:
             raise PageIndexAPIError(
                 f"Unsupported role for chat_completions: {role!r}. Tool "
-                "history round-trips belong to responses() or messages()."
+                "history round-trips belong to chat(protocol=...)."
             )
     if not history:
         raise PageIndexAPIError("messages must contain a user or assistant "
@@ -175,7 +176,8 @@ def _require_openai_agents(method: str) -> None:
             f"{method} with your own chat model requires the OpenAI "
             "Agents SDK — "
             "pip install openai-agents. "
-            "messages() runs on the anthropic extra instead."
+            "chat(protocol='messages') runs on the anthropic extra "
+            "instead."
         ) from exc
 
 
@@ -192,10 +194,11 @@ def _openai_model(protocol: str, model_name: str, backend=None):
         model_name = model_name.removeprefix("litellm/")
         if "/" in model_name and not model_name.startswith("openai/"):
             raise PageIndexAPIError(
-                f"responses() cannot drive '{model_name}': provider-prefixed "
-                "models route through LiteLLM, which speaks chat.completions, "
-                "not the Responses API. Use chat_completions() (or messages() "
-                "for Anthropic models), or point OPENAI_BASE_URL at a "
+                f"protocol='responses' cannot drive '{model_name}': "
+                "provider-prefixed models route through LiteLLM, which speaks "
+                "chat.completions, not the Responses API. Use chat() without "
+                "protocol, or chat_completions() (or protocol='messages' for "
+                "Anthropic models), or point OPENAI_BASE_URL at a "
                 "Responses-capable backend and use a bare or "
                 "'openai/'-prefixed model name."
             )
@@ -390,7 +393,7 @@ def _model_backend_error(exc, lane: str, client=None) -> PageIndexAPIError:
     function tools while reasoning is on) gets its documented exits
     appended, since the fix is a different route, not a retry. The exits
     are per-lane: of the chat lane's three, two are dead ends for a
-    responses() caller — it IS the other lane, and its reasoning knob is
+    Responses-lane caller — it IS the other lane, and its reasoning knob is
     ``reasoning``, not ``reasoning_effort``. On a cloud client an
     auth-shaped failure gets the own-model architecture spelled out —
     the misreading it corrects ("the cloud runs my model") surfaces
@@ -403,7 +406,8 @@ def _model_backend_error(exc, lane: str, client=None) -> PageIndexAPIError:
         )
         message += (
             ", pass reasoning_effort (older litellm routes explicit "
-            "efforts), or call responses() instead." if lane == "chat"
+            "efforts), or use chat(protocol='responses') instead."
+            if lane == "chat"
             else "."
         )
     if (getattr(client, "api_key", None)
@@ -693,7 +697,8 @@ async def _chat_events_agen(client, agent, items, run_kwargs):
                            "output": event.item.output}
         completed = True
     except (MaxTurnsExceeded, AgentsException, openai.OpenAIError) as exc:
-        raise _translate_run_error(exc, None, "chat", client) from exc
+        raise _translate_run_error(exc, run_kwargs.get("max_turns"),
+                                   "chat", client) from exc
     finally:
         if not completed and hasattr(streamed, "cancel"):
             streamed.cancel()  # abandoned/failed: stop the agent task
@@ -895,6 +900,8 @@ def run_cloud_chat_stream(chunks,
 def run_chat_stream(client, messages, doc_id=None, model=None,
                     reasoning_effort=None,
                     show_process: Union[bool, Mapping[str, Any]] = False,
+                    max_turns=None, backend=None, extra_headers=None,
+                    extra_body=None,
                     ) -> ChatStream:
     """chat(stream=True): validation and the agent build run here, eagerly;
     the run itself starts when the returned stream's chosen view is first
@@ -902,6 +909,7 @@ def run_chat_stream(client, messages, doc_id=None, model=None,
     options = (None if show_process is False or show_process is None
                else _process_options(show_process))
     _require_openai_agents("chat")
+    _validate_max_turns(max_turns)
     if isinstance(messages, str):
         if not messages.strip():
             raise PageIndexAPIError(
@@ -909,8 +917,10 @@ def run_chat_stream(client, messages, doc_id=None, model=None,
                 "message dicts.")
         messages = [{"role": "user", "content": messages}]
     agent, items, _ = _chat_agent(client, messages, doc_id, model,
-                                  reasoning_effort=reasoning_effort)
-    run_kwargs = _run_kwargs(None)
+                                  reasoning_effort=reasoning_effort,
+                                  extra_body=extra_body, backend=backend,
+                                  extra_headers=extra_headers)
+    run_kwargs = _run_kwargs(max_turns)
 
     def events():
         return _stream_sync(
@@ -1033,7 +1043,7 @@ def run_responses(client, input, model: Optional[str] = None,
                   extra_headers: Optional[dict] = None,
                   backend: Optional[dict] = None,
                   ) -> Union[dict, Iterator[dict]]:
-    _require_openai_agents("responses")
+    _require_openai_agents("chat(protocol='responses')")
     _validate_max_turns(max_turns)
     if isinstance(input, str) and input.strip():
         items = [{"role": "user", "content": input}]
@@ -1198,8 +1208,8 @@ def _require_anthropic() -> None:
         import anthropic  # noqa: F401
     except ImportError as exc:
         raise PageIndexAPIError(
-            "messages drives your own chat model and requires the "
-            "Anthropic SDK — "
+            "chat(protocol='messages') drives your own chat model and "
+            "requires the Anthropic SDK — "
             "pip install anthropic (or pip install 'pageindex[anthropic]')."
         ) from exc
     try:
@@ -1207,8 +1217,8 @@ def _require_anthropic() -> None:
         from anthropic.lib.tools import ToolError  # noqa: F401
     except ImportError as exc:
         raise PageIndexAPIError(
-            "messages requires anthropic >= 0.108.0 (the tool "
-            "runner with ToolError) — pip install -U anthropic."
+            "chat(protocol='messages') requires anthropic >= 0.108.0 (the "
+            "tool runner with ToolError) — pip install -U anthropic."
         ) from exc
 
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -1051,7 +1051,7 @@ def run_responses(client, input, model: Optional[str] = None,
             and all(isinstance(item, dict) for item in input)):
         items = list(input)
     else:
-        raise PageIndexAPIError("input must be a non-empty string or list "
+        raise PageIndexAPIError("messages must be a non-empty string or list "
                                 "of item dicts.")
     scope = client._local_doc_scope(doc_id)
     block = _doc_block(client, doc_id, scoped=scope is not None)
@@ -1077,6 +1077,7 @@ def run_responses(client, input, model: Optional[str] = None,
 
     response_id = f"resp_{uuid.uuid4().hex}"
     created_at = int(time.time())
+    given = extra_body or {}
 
     def envelope(transcript: list, raw_responses) -> dict:
         return {
@@ -1098,10 +1099,11 @@ def run_responses(client, input, model: Optional[str] = None,
             # Backend echo when captured; the request sends neither param.
             "tool_choice": recorded.get("tool_choice", "auto"),
             "parallel_tool_calls": recorded.get("parallel_tool_calls", True),
-            "temperature": temperature,
-            "top_p": top_p,
-            "reasoning": reasoning,
-            "max_output_tokens": max_output_tokens,
+            "temperature": given.get("temperature", temperature),
+            "top_p": given.get("top_p", top_p),
+            "reasoning": given.get("reasoning", reasoning),
+            "max_output_tokens": given.get("max_output_tokens",
+                                           max_output_tokens),
             "error": recorded.get("error"),
             "incomplete_details": recorded.get("incomplete_details"),
             "metadata": None,
@@ -1392,7 +1394,8 @@ def run_messages(client, messages, model: str,
     owns_transport = ("http_client" not in (merged or {})
                       and backend_client not in _ANTHROPIC_CLIENTS.values())
     if max_tokens is None:
-        max_tokens = _default_max_tokens(model, thinking)
+        max_tokens = _default_max_tokens(
+            model, (extra_body or {}).get("thinking", thinking))
     runner = backend_client.beta.messages.tool_runner(
         max_tokens=max_tokens,
         messages=prepared,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1958,6 +1958,16 @@ def test_local_client_blank_chat_model_refuses_at_chat_door(local_client):
         local_client.chat_model = blank
         with pytest.raises(PageIndexAPIError, match="chat_model is empty"):
             local_client.chat_completions("hi")
+        # the protocol and instructions knobs must not point a local
+        # client at the managed chat it does not have
+        with pytest.raises(PageIndexAPIError, match="chat_model is empty"):
+            local_client.chat("hi", protocol="responses")
+        with pytest.raises(PageIndexAPIError, match="chat_model is empty"):
+            local_client.chat("hi", instructions="brief")
+        with pytest.raises(PageIndexAPIError, match="chat_model is empty"):
+            local_client._responses("hi")
+        with pytest.raises(PageIndexAPIError, match="chat_model is empty"):
+            local_client._messages("hi", model="claude-x")
 
 
 def test_blank_chat_model_carries_no_model_into_agent_config():

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -263,7 +263,7 @@ def test_chat_completions_validation(client, store_path, fake_model):
     with pytest.raises(PageIndexAPIError, match="managed chat endpoint"):
         client.chat_completions([{"role": "user", "content": "x"}],
                                 enable_citations=True)
-    with pytest.raises(PageIndexAPIError, match="responses\\(\\) or messages"):
+    with pytest.raises(PageIndexAPIError, match="chat\\(protocol="):
         client.chat_completions([{"role": "tool", "content": "x"}])
     with pytest.raises(PageIndexAPIError, match="must be a string"):
         client.chat_completions([{"role": "user", "content": [1]}])
@@ -324,10 +324,14 @@ def test_cloud_guards():
         cloud.chat_completions([{"role": "user", "content": "x"}],
                                extra_headers={"x-beta": "1"})
     with pytest.raises(PageIndexAPIError, match="own chat model"):
-        cloud.responses("x")
+        cloud.chat("x", protocol="responses")
     with pytest.raises(PageIndexAPIError, match="own chat model"):
-        cloud.messages([{"role": "user", "content": "x"}], model="m",
-                       max_tokens=10)
+        cloud.chat([{"role": "user", "content": "x"}],
+                   protocol="messages", model="m")
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
+        cloud.chat("x", instructions="be brief")
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
+        cloud.chat("x", max_turns=2)
 
 
 @needs_agents
@@ -897,7 +901,7 @@ def test_responses_end_to_end(client, store_path, fake_model):
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    result = client.responses("What status?")
+    result = client._responses("What status?")
     assert result["id"].startswith("resp_")
     assert result["object"] == "response"
     assert result["status"] == "completed"
@@ -925,13 +929,13 @@ def test_responses_round_trip_extends_prefix(client, store_path, fake_model):
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    result = client.responses("What status?")
+    result = client._responses("What status?")
 
     second = fake_model([[_msg_item("Done")]])
     follow_up = ([{"role": "user", "content": "What status?"}]
                  + result["items"]
                  + [{"role": "user", "content": "and now?"}])
-    client.responses(follow_up)
+    client._responses(follow_up)
     previous_final = first.inputs[-1]
     assert second.inputs[0][:len(previous_final)] == previous_final
 
@@ -945,13 +949,13 @@ def test_responses_round_trip_prefix_with_doc_id(client, store_path, fake_model)
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    result = client.responses("What status?", doc_id="pi-a")
+    result = client._responses("What status?", doc_id="pi-a")
 
     second = fake_model([[_msg_item("Done")]])
     follow_up = ([{"role": "user", "content": "What status?"}]
                  + result["items"]
                  + [{"role": "user", "content": "and now?"}])
-    client.responses(follow_up, doc_id="pi-a")
+    client._responses(follow_up, doc_id="pi-a")
     previous_final = first.inputs[-1]
     assert second.inputs[0][:len(previous_final)] == previous_final
 
@@ -975,16 +979,16 @@ def test_doc_id_conversations_get_distinct_cache_keys(client, store_path,
     monkeypatch.setattr(local_chat, "_conversation_cache_key", spy)
 
     fake_model([[_msg_item("a")]])
-    result = client.responses("What is the CAGR?", doc_id="pi-a")
+    result = client._responses("What is the CAGR?", doc_id="pi-a")
     fake_model([[_msg_item("b")]])
-    client.responses("Summarize section 3.", doc_id="pi-a")
+    client._responses("Summarize section 3.", doc_id="pi-a")
     assert keys[0] != keys[1]  # unrelated conversations never pool
 
     fake_model([[_msg_item("c")]])
     follow_up = ([{"role": "user", "content": "What is the CAGR?"}]
                  + result["items"]
                  + [{"role": "user", "content": "and now?"}])
-    client.responses(follow_up, doc_id="pi-a")
+    client._responses(follow_up, doc_id="pi-a")
     assert keys[2] == keys[0]  # a continuation keeps its conversation's key
 
     fake_model([[_msg_item("d")]])
@@ -995,7 +999,7 @@ def test_doc_id_conversations_get_distinct_cache_keys(client, store_path,
 
     seed_doc(store_path, "pi-b", "contract.pdf")
     fake_model([[_msg_item("f")]])
-    client.responses("What is the CAGR?", doc_id="pi-b")
+    client._responses("What is the CAGR?", doc_id="pi-b")
     assert keys[5] != keys[0]  # same opener, different doc: no pooling
 
 
@@ -1006,7 +1010,7 @@ def test_responses_stream_passthrough(client, store_path, fake_model):
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    events = list(client.responses("q", stream=True))
+    events = list(client._responses("q", stream=True))
     types = [event.get("type") for event in events]
     assert "response.output_text.delta" in types
     assert not [event for event in events
@@ -1039,7 +1043,7 @@ def test_responses_stream_opens_with_created(client, store_path, fake_model):
         [_msg_item("The answer")],
     ])
     fake.emit_created = True  # two turns emit two; one must pass through
-    events = list(client.responses("q", stream=True))
+    events = list(client._responses("q", stream=True))
     created = [e for e in events if e["type"] == "response.created"]
     assert len(created) == 1 and events[0] is created[0]
     assert events[0]["sequence_number"] == 1
@@ -1062,7 +1066,7 @@ def test_responses_envelope_validates_as_official_response(client, store_path,
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    result = client.responses("What status?")
+    result = client._responses("What status?")
     parsed = Response.model_validate(result)
     assert [item.type for item in parsed.output] == ["function_call",
                                                      "message"]
@@ -1082,7 +1086,7 @@ def test_responses_stream_events_validate_as_official_events(
         [_msg_item("The answer")],
     ])
     adapter = TypeAdapter(ResponseStreamEvent)
-    events = list(client.responses("q", stream=True))
+    events = list(client._responses("q", stream=True))
     assert events
     for event in events:
         adapter.validate_python(event)
@@ -1155,7 +1159,7 @@ def test_messages_end_to_end(client, store_path, fake_anthropic):
         _anthropic_message([{"type": "text", "text": "The answer"}],
                            "end_turn"),
     ])
-    result = client.messages([{"role": "user", "content": "What status?"}],
+    result = client._messages([{"role": "user", "content": "What status?"}],
                              model="claude-test", max_tokens=100)
     assert result["stop_reason"] == "end_turn"
     assert result["content"][0]["text"] == "The answer"
@@ -1184,7 +1188,7 @@ def test_messages_doc_block_and_system(client, store_path, fake_anthropic):
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn"),
     ])
-    client.messages([{"role": "user", "content": "hi"}], model="claude-test",
+    client._messages([{"role": "user", "content": "hi"}], model="claude-test",
                     max_tokens=100, doc_id=doc_id, system="Answer in French.")
     system = calls[0]["system"]
     assert "The user has specified document: report.pdf" in system[1]["text"]
@@ -1215,7 +1219,7 @@ def test_messages_stream_passthrough(client, store_path, fake_anthropic):
         "",
     ])
     fake_anthropic([sse])
-    events = list(client.messages([{"role": "user", "content": "q"}],
+    events = list(client._messages([{"role": "user", "content": "q"}],
                                   model="claude-test", max_tokens=100,
                                   stream=True))
     types = [event.type for event in events]
@@ -1227,24 +1231,24 @@ def test_messages_accepts_query_string(client, fake_anthropic):
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn"),
     ])
-    result = client.messages("What status?", model="claude-test")
+    result = client._messages("What status?", model="claude-test")
     assert result["content"][0]["text"] == "ok"
     assert calls[0]["messages"] == [{"role": "user",
                                      "content": "What status?"}]
     # The wire-required budget is table-setting, not a user obligation.
     assert calls[0]["max_tokens"] == 8192
     with pytest.raises(PageIndexAPIError, match="non-empty string"):
-        client.messages("   ", model="claude-test")
+        client._messages("   ", model="claude-test")
 
 
 @needs_anthropic
 def test_messages_validation(client, fake_anthropic):
     fake_anthropic([])
     with pytest.raises(PageIndexAPIError, match="non-empty"):
-        client.messages([], model="claude-test", max_tokens=100)
+        client._messages([], model="claude-test", max_tokens=100)
     with pytest.raises(PageIndexAPIError,
                        match="Documents not found or access denied"):
-        client.messages([{"role": "user", "content": "x"}],
+        client._messages([{"role": "user", "content": "x"}],
                         model="claude-test", max_tokens=100, doc_id="ghost")
 
 
@@ -1261,14 +1265,14 @@ def test_messages_raises_when_runner_params_unreadable(client, fake_anthropic,
     monkeypatch.setattr(BetaToolRunner, "set_messages_params",
                         lambda self, params: None)
     with pytest.raises(PageIndexAPIError, match="anthropic version"):
-        client.messages([{"role": "user", "content": "hi"}],
+        client._messages([{"role": "user", "content": "hi"}],
                         model="claude-test", max_tokens=100)
 
 
 def test_messages_missing_framework(client, monkeypatch):
     monkeypatch.setitem(sys.modules, "anthropic", None)
     with pytest.raises(PageIndexAPIError, match="pageindex\\[anthropic\\]"):
-        client.messages([{"role": "user", "content": "x"}],
+        client._messages([{"role": "user", "content": "x"}],
                         model="claude-test", max_tokens=100)
 
 
@@ -1280,7 +1284,7 @@ def _anthropic_tool_use(tool_use_id="tu_1"):
 
 
 @needs_agents
-@pytest.mark.parametrize("surface", ["chat_completions", "responses"])
+@pytest.mark.parametrize("surface", ["chat_completions", "_responses"])
 @pytest.mark.parametrize("streaming", [False, True])
 def test_max_turns_wrapped(client, store_path, fake_model, surface, streaming):
     """MaxTurnsExceeded is an engine-internal type; callers get the SDK's
@@ -1346,7 +1350,7 @@ def test_responses_stream_single_completed_monotonic_sequence(
         [_call_item("get_document", {"doc_name": "report.pdf"})],
         [_msg_item("The answer")],
     ])
-    events = list(client.responses("q", stream=True))
+    events = list(client._responses("q", stream=True))
     completed = [event for event in events
                  if event.get("type") == "response.completed"]
     assert len(completed) == 1 and events[-1] is completed[0]
@@ -1361,7 +1365,7 @@ def test_responses_envelope_fields_and_cache_group(client, store_path,
                                                    fake_model):
     seed_doc(store_path, "pi-a", "report.pdf")
     fake_model([[_msg_item("ok")]])
-    result = client.responses("q")
+    result = client._responses("q")
     names = {tool["name"] for tool in result["tools"]}
     assert names == {"browse_documents", "get_document",
                      "get_document_structure", "get_page_content"}
@@ -1375,20 +1379,21 @@ def test_responses_envelope_fields_and_cache_group(client, store_path,
 def test_sol_class_refusal_names_its_exits():
     """The chatcmpl+tools-while-reasoning 400 is a lane problem, not a
     retry problem — the wrapped error must name every exit that is real
-    for the caller's lane. Chat has three; a responses() caller gets only
+    for the caller's lane. Chat has three; a Responses-lane caller gets only
     the litellm upgrade (it IS the other lane, and its reasoning knob is
     ``reasoning``, not ``reasoning_effort``)."""
     refusal = Exception(
         "Error code: 400 - Function tools with reasoning_effort are not "
         "supported for gpt-5.6-sol in /v1/chat/completions.")
     chat = str(local_chat._model_backend_error(refusal, "chat"))
-    assert "responses()" in chat and "litellm" in chat
+    assert "chat(protocol='responses')" in chat and "litellm" in chat
     assert "pass reasoning_effort" in chat
     resp = str(local_chat._model_backend_error(refusal, "responses"))
     assert "upgrade litellm" in resp
-    assert "responses()" not in resp and "pass reasoning_effort" not in resp
+    assert "protocol='responses'" not in resp
+    assert "pass reasoning_effort" not in resp
     plain = local_chat._model_backend_error(Exception("rate limited"), "chat")
-    assert "responses()" not in str(plain)
+    assert "protocol='responses'" not in str(plain)
 
 
 def test_conversation_cache_key_stable_per_conversation():
@@ -1529,21 +1534,21 @@ def test_sampling_knobs_ride_model_settings(client, store_path, fake_model,
     assert seen["chat"].top_p == 0.9
     assert seen["chat"].max_tokens == 256
     fake_model([[_msg_item("ok")]])
-    result = client.responses("q", max_output_tokens=321)
+    result = client._responses("q", max_output_tokens=321)
     assert seen["responses"].max_tokens == 321
     assert result["max_output_tokens"] == 321
     fake_model([[_msg_item("ok")]])
-    assert client.responses("q")["max_output_tokens"] is None
+    assert client._responses("q")["max_output_tokens"] is None
 
 
 @needs_agents
 def test_responses_envelope_echoes_reasoning(client, store_path, fake_model):
     seed_doc(store_path, "pi-a", "report.pdf")
     fake_model([[_msg_item("ok")]])
-    result = client.responses("q", reasoning={"effort": "low"})
+    result = client._responses("q", reasoning={"effort": "low"})
     assert result["reasoning"] == {"effort": "low"}
     fake_model([[_msg_item("ok")]])
-    assert client.responses("q")["reasoning"] is None
+    assert client._responses("q")["reasoning"] is None
 
 
 @needs_agents
@@ -1551,7 +1556,7 @@ def test_responses_input_validation(client, fake_model):
     fake_model([])
     for bad in ("", "   ", [], [1], None):
         with pytest.raises(PageIndexAPIError, match="input must be"):
-            client.responses(bad)
+            client._responses(bad)
 
 
 @needs_agents
@@ -1645,7 +1650,7 @@ def test_responses_refuses_litellm_routed_models(store_path):
     client = PageIndexLocalClient(storage_path=store_path,
                                   retrieve_model="anthropic/claude-x")
     with pytest.raises(PageIndexAPIError, match="chat_completions"):
-        client.responses("q")
+        client._responses("q")
 
 
 @needs_agents
@@ -1676,7 +1681,7 @@ def test_envelope_model_strips_openai_routing_prefix(store_path, fake_model):
     result = client.chat_completions("q")
     assert result["model"] == "gpt-5.2"
     fake_model([[_msg_item("ok")]])
-    result = client.responses("q")
+    result = client._responses("q")
     assert result["model"] == "gpt-5.2"
 
 
@@ -1734,7 +1739,7 @@ def test_responses_envelope_reports_backend_truncation(client, store_path,
 
     fake._client = types.SimpleNamespace(
         responses=types.SimpleNamespace(create=create))
-    result = client.responses("q")
+    result = client._responses("q")
     assert result["status"] == "incomplete"
     assert result["incomplete_details"] == {"reason": "max_output_tokens"}
     assert result["error"] is None
@@ -1754,7 +1759,7 @@ def test_responses_envelope_reports_backend_tool_params(client, store_path,
 
     fake._client = types.SimpleNamespace(
         responses=types.SimpleNamespace(create=create))
-    result = client.responses("q")
+    result = client._responses("q")
     assert result["tool_choice"] == "none"
     assert result["parallel_tool_calls"] is False
 
@@ -1763,7 +1768,7 @@ def test_responses_envelope_reports_backend_tool_params(client, store_path,
 def test_chat_completions_wraps_framework_errors(client, store_path,
                                                  fake_model, monkeypatch):
     """Both chat_completions paths surface engine failures as the SDK's
-    own error type, like responses()."""
+    own error type, like the protocol lanes."""
     from agents.exceptions import ModelBehaviorError
     seed_doc(store_path, "pi-a", "report.pdf")
     fake = fake_model([[_msg_item("never terminal")]])
@@ -1790,7 +1795,7 @@ def test_responses_stream_wraps_framework_errors(client, store_path,
     fake = fake_model([[_msg_item("never terminal")]])
     fake.no_terminal = True
     with pytest.raises(PageIndexAPIError, match="agent backend failed"):
-        list(client.responses("q", stream=True))
+        list(client._responses("q", stream=True))
 
 
 class _TerminalModel(FakeModel):
@@ -1839,7 +1844,7 @@ def test_responses_stream_backend_terminal_states_are_events(
     fake.terminal = terminal
     monkeypatch.setattr(local_chat, "_openai_model",
                         lambda protocol, model_name, backend=None: fake)
-    events = list(client.responses("q", stream=True))
+    events = list(client._responses("q", stream=True))
     assert events[0]["type"] == "response.output_text.delta"
     last = events[-1]
     assert last["type"] == f"response.{terminal}"
@@ -1874,12 +1879,12 @@ def test_provider_errors_wrap_as_sdk_errors(client, store_path, fake_model,
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
         client.chat_completions("q")
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
-        client.responses("q")
+        client._responses("q")
     monkeypatch.setattr(fake, "stream_response", conn_err_stream)
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
         list(client.chat_completions("q", stream=True))
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
-        list(client.responses("q", stream=True))
+        list(client._responses("q", stream=True))
 
 
 @needs_anthropic
@@ -1901,9 +1906,9 @@ def test_messages_provider_errors_wrap_as_sdk_errors(client, store_path,
     monkeypatch.setattr(local_chat, "_anthropic_client",
                         lambda backend=None: fake)
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
-        client.messages("q", model="claude-test")
+        client._messages("q", model="claude-test")
     with pytest.raises(PageIndexAPIError, match="model backend failed"):
-        list(client.messages("q", model="claude-test", stream=True))
+        list(client._messages("q", model="claude-test", stream=True))
 
 
 @needs_agents
@@ -2029,15 +2034,15 @@ def test_messages_max_tokens_default_resolves_per_model(client, fake_anthropic):
     claude-3 generation caps output at 4096."""
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-3-opus-20240229")
+    client._messages("q", model="claude-3-opus-20240229")
     assert calls[0]["max_tokens"] == 4096
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-sonnet-4-5")
+    client._messages("q", model="claude-sonnet-4-5")
     assert calls[0]["max_tokens"] == 8192
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-3-opus-20240229", max_tokens=1234)
+    client._messages("q", model="claude-3-opus-20240229", max_tokens=1234)
     assert calls[0]["max_tokens"] == 1234
 
 
@@ -2047,12 +2052,12 @@ def test_messages_thinking_passes_through(client, fake_anthropic):
     nothing so the backend default applies."""
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-sonnet-4-5",
+    client._messages("q", model="claude-sonnet-4-5",
                     thinking={"type": "adaptive"})
     assert calls[0]["thinking"] == {"type": "adaptive"}
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-sonnet-4-5")
+    client._messages("q", model="claude-sonnet-4-5")
     assert "thinking" not in calls[0]
 
 
@@ -2062,12 +2067,12 @@ def test_messages_extra_body_merges_into_the_wire_body(client, fake_anthropic):
     asserted on the captured wire body, not the SDK call."""
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-sonnet-4-5",
+    client._messages("q", model="claude-sonnet-4-5",
                     extra_body={"service_tier": "auto"})
     assert calls[0]["service_tier"] == "auto"
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-sonnet-4-5")
+    client._messages("q", model="claude-sonnet-4-5")
     assert "service_tier" not in calls[0]
 
 
@@ -2086,7 +2091,7 @@ def test_messages_tool_error_flagged_and_scoped(client, store_path,
                            "tool_use"),
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn"),
     ])
-    client.messages("q", model="claude-test", doc_id="pi-a")
+    client._messages("q", model="claude-test", doc_id="pi-a")
     tool_result = calls[1]["messages"][-1]["content"][0]
     assert tool_result["type"] == "tool_result"
     assert tool_result.get("is_error") is True
@@ -2102,7 +2107,7 @@ def test_messages_envelope_json_and_no_internal_fields(client, store_path,
         _anthropic_message([{"type": "text", "text": "The answer"}],
                            "end_turn"),
     ])
-    result = client.messages([{"role": "user", "content": "q"}],
+    result = client._messages([{"role": "user", "content": "q"}],
                              model="claude-test", max_tokens=100)
     dumped = json.dumps(result)  # the whole envelope must serialize
     assert "parsed_output" not in dumped
@@ -2118,7 +2123,7 @@ def test_messages_max_turns_truncation_round_trippable(client, store_path,
         _anthropic_message([_anthropic_tool_use()], "tool_use"),
         _anthropic_message([_anthropic_tool_use("tu_2")], "tool_use"),
     ])
-    result = client.messages([{"role": "user", "content": "q"}],
+    result = client._messages([{"role": "user", "content": "q"}],
                              model="claude-test", max_tokens=100, max_turns=1)
     assert len(calls) == 1
     assert result["stop_reason"] == "tool_use"
@@ -2146,7 +2151,7 @@ def test_messages_tool_use_cut_by_max_tokens_not_duplicated(client,
         _anthropic_message([_anthropic_tool_use()], "max_tokens"),
         _anthropic_message([_anthropic_tool_use("tu_2")], "tool_use"),
     ])
-    result = client.messages([{"role": "user", "content": "q"}],
+    result = client._messages([{"role": "user", "content": "q"}],
                              model="claude-test", max_tokens=100, max_turns=1)
     assert len(calls) == 1
     assert result["stop_reason"] == "max_tokens"
@@ -2172,7 +2177,7 @@ def test_messages_refusal_with_tool_use_stays_appendable(client, store_path,
         _anthropic_message([{"type": "text", "text": "I can't help."},
                             _anthropic_tool_use()], "refusal"),
     ])
-    result = client.messages([{"role": "user", "content": "q"}],
+    result = client._messages([{"role": "user", "content": "q"}],
                              model="claude-test", max_tokens=100)
     assert result["stop_reason"] == "refusal"
     message, = result["messages"]
@@ -2191,7 +2196,7 @@ def test_messages_default_cap(client, store_path, fake_anthropic):
         _anthropic_message([_anthropic_tool_use(f"tu_{index}")], "tool_use")
         for index in range(30)
     ])
-    result = client.messages([{"role": "user", "content": "q"}],
+    result = client._messages([{"role": "user", "content": "q"}],
                              model="claude-test", max_tokens=100)
     assert len(calls) == 10  # bounded like the OpenAI surfaces
     assert result["stop_reason"] == "tool_use"
@@ -2203,13 +2208,13 @@ def test_messages_edge_validation(client, store_path, fake_anthropic):
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn"),
     ])
-    client.messages([{"role": "user", "content": "q"}], model="claude-test",
+    client._messages([{"role": "user", "content": "q"}], model="claude-test",
                     max_tokens=100, system="   ")
     assert all(block["text"].strip() for block in calls[0]["system"])
     with pytest.raises(PageIndexAPIError, match="message dicts"):
-        client.messages(["not a dict"], model="claude-test", max_tokens=100)
+        client._messages(["not a dict"], model="claude-test", max_tokens=100)
     with pytest.raises(PageIndexAPIError, match="doc_id"):
-        client.messages([{"role": "user", "content": "q"}],
+        client._messages([{"role": "user", "content": "q"}],
                         model="claude-test", max_tokens=100, doc_id=123)
 
 
@@ -2260,13 +2265,13 @@ def test_messages_top_level_cache_control(client, store_path, fake_anthropic):
     seed_doc(store_path, "pi-a", "report.pdf")
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-test", max_tokens=50)
+    client._messages("q", model="claude-test", max_tokens=50)
     assert calls[0]["cache_control"] == {"type": "ephemeral"}
     marked = [{"type": "text", "text": f"b{i}",
                "cache_control": {"type": "ephemeral"}} for i in range(3)]
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
-    client.messages("q", model="claude-test", max_tokens=50, system=marked)
+    client._messages("q", model="claude-test", max_tokens=50, system=marked)
     assert "cache_control" not in calls[0]
 
 
@@ -2298,7 +2303,7 @@ def test_messages_backend_merges_and_reaches_the_client(client, fake_anthropic,
         lambda backend=None: (seen.setdefault("backend", backend),
                               fixture_client())[1])
     client.chat_backend = {"base_url": "http://cb"}
-    client.messages("q", model="claude-sonnet-4-5", backend={"api_key": "z"})
+    client._messages("q", model="claude-sonnet-4-5", backend={"api_key": "z"})
     assert seen["backend"] == {"base_url": "http://cb", "api_key": "z"}
 
 
@@ -2345,7 +2350,7 @@ def test_messages_extra_headers_reach_the_wire(client, monkeypatch):
             transport=anthropic_httpx.MockTransport(handler)))
     monkeypatch.setattr(local_chat, "_anthropic_client",
                         lambda backend=None: fake)
-    client.messages("q", model="claude-sonnet-4-5",
+    client._messages("q", model="claude-sonnet-4-5",
                     extra_headers={"anthropic-beta": "context-1m-2025"})
     assert seen["beta"] == "context-1m-2025"
 
@@ -2366,7 +2371,7 @@ def test_messages_default_max_tokens_clears_thinking_budget(client, fake_anthrop
     calls = fake_anthropic([
         _anthropic_message([{"type": "text", "text": "a"}], "end_turn"),
     ])
-    client.messages("q", model="claude-test",
+    client._messages("q", model="claude-test",
                     thinking={"type": "enabled", "budget_tokens": 10000})
     assert calls[0]["max_tokens"] == 10000 + 8192
     assert calls[0]["thinking"] == {"type": "enabled",
@@ -2374,7 +2379,7 @@ def test_messages_default_max_tokens_clears_thinking_budget(client, fake_anthrop
     calls = fake_anthropic([  # fresh fake: each run closes its client
         _anthropic_message([{"type": "text", "text": "b"}], "end_turn"),
     ])
-    client.messages("q", model="claude-test", max_tokens=11000,
+    client._messages("q", model="claude-test", max_tokens=11000,
                     thinking={"type": "enabled", "budget_tokens": 10000})
     assert calls[0]["max_tokens"] == 11000  # explicit value passes through
 
@@ -2424,7 +2429,7 @@ def test_messages_reuses_cached_client_across_runs(client, monkeypatch):
         raise AssertionError("cache hit expected — no new construction")
     monkeypatch.setattr(anthropic, "Anthropic", boom)
     for _ in range(2):
-        result = client.messages("q", model="claude-test", max_tokens=64,
+        result = client._messages("q", model="claude-test", max_tokens=64,
                                  backend={"api_key": "test"})
         assert result["stop_reason"] == "end_turn"
 
@@ -2632,11 +2637,11 @@ def test_messages_keeps_caller_owned_http_client_open(client):
     body = _anthropic_message([{"type": "text", "text": "a"}], "end_turn")
     shared = anthropic_httpx.Client(transport=anthropic_httpx.MockTransport(
         lambda request: anthropic_httpx.Response(200, json=body)))
-    out = client.messages("q", model="claude-test",
+    out = client._messages("q", model="claude-test",
                           backend={"api_key": "t", "http_client": shared})
     assert out["content"][0]["text"] == "a"
     assert not shared.is_closed
-    client.messages("q", model="claude-test",
+    client._messages("q", model="claude-test",
                     backend={"api_key": "t", "http_client": shared})
     shared.close()
 
@@ -2656,7 +2661,7 @@ def test_messages_without_credentials_raises_contract_error(client,
     for backend in (None, {"timeout": 30}, {"api_key": None}):
         with pytest.raises(PageIndexAPIError,
                            match="Anthropic backend is not configured"):
-            client.messages("q", model="claude-test", backend=backend)
+            client._messages("q", model="claude-test", backend=backend)
 
 
 def test_cache_extra_args_follow_wire_normalization():
@@ -2839,8 +2844,8 @@ def test_bridge_gate_and_citations(monkeypatch):
 
     monkeypatch.setattr(local_chat, "run_responses", fake_responses)
     monkeypatch.setattr(local_chat, "run_messages", fake_messages)
-    client.responses("q")
-    client.messages("q", model="mm")
+    client._responses("q")
+    client._messages("q", model="mm")
     assert called["responses"] is client and called["messages"] is client
 
 
@@ -2868,7 +2873,7 @@ def test_bridge_auth_failure_error_teaches_architecture():
 
 def test_bridge_auth_note_managed_exit_is_chat_lane_only():
     """The managed-chat exit ("drop the chat model") is real only for
-    chat_completions(); responses() and messages() refuse a client
+    chat_completions(); the protocol lanes refuse a client
     without an own model, so on those lanes the note keeps the
     credentials advice and drops the exit that would send the caller in
     a circle."""
@@ -2906,9 +2911,9 @@ def test_messages_auth_failure_teaches_architecture(bridge_client,
 
     monkeypatch.setattr(local_chat, "_anthropic_client", fresh_fake)
     with pytest.raises(PageIndexAPIError, match="provider credentials"):
-        client.messages("q", model="claude-test", max_tokens=100)
+        client._messages("q", model="claude-test", max_tokens=100)
     with pytest.raises(PageIndexAPIError, match="provider credentials"):
-        list(client.messages("q", model="claude-test", max_tokens=100,
+        list(client._messages("q", model="claude-test", max_tokens=100,
                              stream=True))
 
 
@@ -2939,7 +2944,7 @@ def test_messages_no_backend_leak_when_tool_build_fails(bridge_client,
     monkeypatch.setattr(
         "pageindex.integrations.anthropic_sdk.build_anthropic_tools", boom)
     with pytest.raises(PageIndexAPIError, match="MCP server"):
-        client.messages("q", model="claude-test", max_tokens=100)
+        client._messages("q", model="claude-test", max_tokens=100)
     assert all(fake.closed for fake in made)
 
 
@@ -2952,7 +2957,7 @@ def test_bridge_responses_lane_runs_cloud_tools(bridge_client, fake_model):
         [_call_item("get_document", {"doc_name": "r.pdf"})],
         [_msg_item("Done")],
     ])
-    result = client.responses("What?")
+    result = client._responses("What?")
     assert result["object"] == "response" and result["status"] == "completed"
     assert "Done" in json.dumps(result["output"])
     assert bridge.calls == [("get_document", {"doc_name": "r.pdf"})]
@@ -2969,7 +2974,7 @@ def test_bridge_messages_lane_runs_cloud_tools(bridge_client, fake_anthropic):
         _anthropic_message([{"type": "text", "text": "The answer"}],
                            "end_turn"),
     ])
-    result = client.messages("What?", model="claude-test", max_tokens=64)
+    result = client._messages("What?", model="claude-test", max_tokens=64)
     assert result["content"][0]["text"] == "The answer"
     wire = calls[0]
     assert wire["tools"][0]["name"] == "get_document"
@@ -2986,3 +2991,115 @@ def test_bridge_openai_agent_config_carries_configured_model(bridge_client):
     config = client.openai_agent_config()
     assert config["model"] == "fake-model"
     assert "CLOUD LIVE INSTRUCTIONS" in config["instructions"]
+
+
+# ── chat(protocol=): the protocol doors behind the front door ──
+
+def test_old_door_names_point_at_chat_protocol(client):
+    for name in ("responses", "messages"):
+        with pytest.raises(AttributeError, match=f"chat\\(protocol={name!r}"):
+            getattr(client, name)
+        assert not hasattr(client, name)
+    with pytest.raises(AttributeError, match="no attribute 'no_such_thing'"):
+        client.no_such_thing
+
+
+def test_chat_protocol_responses_is_the_door(client, monkeypatch):
+    seen = []
+    monkeypatch.setattr(local_chat, "run_responses",
+                        lambda c, input, **kw: seen.append((input, kw)) or "door")
+    knobs = dict(doc_id="pi-a", model="gpt-x", max_turns=3,
+                 backend={"api_key": "k"}, extra_headers={"x": "1"},
+                 extra_body={"seed": 1}, instructions="be brief")
+    assert client.chat("q", protocol="responses", reasoning_effort="low",
+                       **knobs) == "door"
+    assert client._responses("q", reasoning={"effort": "low"}, **knobs) == "door"
+    assert seen[0] == seen[1]
+    assert seen[0][1]["reasoning"] == {"effort": "low"}
+    # the default for the stream view is silently off on a protocol lane
+    assert client.chat("q", protocol="responses", stream=True) == "door"
+    assert seen[-1][1]["stream"] is True
+
+
+def test_chat_protocol_messages_is_the_door(client, monkeypatch):
+    seen = []
+    monkeypatch.setattr(local_chat, "run_messages",
+                        lambda c, messages, **kw: seen.append((messages, kw)) or "door")
+    blocks = [{"type": "text", "text": "persona",
+               "cache_control": {"type": "ephemeral"}}]
+    knobs = dict(doc_id="pi-a", model="claude-x", max_turns=3,
+                 backend={"api_key": "k"}, extra_headers={"anthropic-beta": "b"})
+    history = [{"role": "user", "content": [{"type": "text", "text": "q"}]}]
+    assert client.chat(history, protocol="messages", reasoning_effort="low",
+                       instructions=blocks, extra_body={"top_k": 5},
+                       **knobs) == "door"
+    assert client._messages(history, system=blocks,
+                            extra_body={"output_config": {"effort": "low"},
+                                        "top_k": 5},
+                            **knobs) == "door"
+    assert seen[0] == seen[1]
+    # Anthropic's own effort field; the caller's extra_body still wins
+    client.chat("q", protocol="messages", model="claude-x",
+                reasoning_effort="low",
+                extra_body={"output_config": {"effort": "max"}})
+    assert seen[-1][1]["extra_body"] == {"output_config": {"effort": "max"}}
+    assert seen[-1][0] == "q"
+    # a caller's other output_config keys survive; only effort is ours
+    client.chat("q", protocol="messages", model="claude-x",
+                reasoning_effort="low",
+                extra_body={"output_config": {"format": {"type": "json"}}})
+    assert seen[-1][1]["extra_body"] == {
+        "output_config": {"format": {"type": "json"}, "effort": "low"}}
+
+
+def test_chat_protocol_chokes(client, monkeypatch):
+    monkeypatch.setattr(local_chat, "run_responses",
+                        lambda c, input, **kw: "door")
+    with pytest.raises(PageIndexAPIError, match="protocol"):
+        client.chat("q", protocol="grpc")
+    with pytest.raises(PageIndexAPIError, match="show_process"):
+        client.chat("q", protocol="responses", stream=True, show_process=True)
+    with pytest.raises(PageIndexAPIError, match="instructions blocks"):
+        client.chat("q", protocol="responses",
+                    instructions=[{"type": "text", "text": "x"}])
+    with pytest.raises(PageIndexAPIError, match="instructions blocks"):
+        client.chat("q", instructions=[{"type": "text", "text": "x"}])
+    with pytest.raises(PageIndexAPIError, match="model="):
+        client.chat("q", protocol="messages")
+
+
+@needs_agents
+def test_chat_instructions_precede_history_system_rows(client, store_path,
+                                                        fake_model, monkeypatch):
+    fake_model([[_msg_item("ok")], [_msg_item("ok")]])
+    seen = {}
+    real = local_chat._managed_instructions
+
+    def spy(c, extra):
+        seen["extra"] = list(extra)
+        return real(c, extra)
+
+    monkeypatch.setattr(local_chat, "_managed_instructions", spy)
+    answer = client.chat([{"role": "system", "content": "short"},
+                          {"role": "user", "content": "q"}],
+                         instructions="analyst")
+    assert answer == "ok"
+    assert seen["extra"] == ["analyst", "short"]
+    client.chat("q", instructions="analyst")  # a bare question works too
+    assert seen["extra"] == ["analyst"]
+
+
+def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):
+    seen = {}
+    monkeypatch.setattr(local_chat, "run_chat_completions",
+                        lambda c, messages, **kw: seen.update(kw) or {
+                            "choices": [{"message": {"content": "a"}}]})
+    knobs = dict(max_turns=2, backend={"api_key": "k"},
+                 extra_headers={"x": "1"}, extra_body={"seed": 1})
+    assert client.chat("q", **knobs) == "a"
+    assert {k: seen[k] for k in knobs} == knobs
+    streamed = {}
+    monkeypatch.setattr(local_chat, "run_chat_stream",
+                        lambda c, messages, **kw: streamed.update(kw) or "s")
+    assert client.chat("q", stream=True, **knobs) == "s"
+    assert {k: streamed[k] for k in knobs} == knobs

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -328,6 +328,11 @@ def test_cloud_guards():
     with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat([{"role": "user", "content": "x"}],
                    protocol="messages", model="m")
+    # the hidden doors refuse the same way: door X is chat(protocol=X)
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
+        cloud._responses("x")
+    with pytest.raises(PageIndexAPIError, match="own chat model"):
+        cloud._messages("x", model="m")
     with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat("x", instructions="be brief")
     with pytest.raises(PageIndexAPIError, match="own chat model"):
@@ -1284,7 +1289,7 @@ def _anthropic_tool_use(tool_use_id="tu_1"):
 
 
 @needs_agents
-@pytest.mark.parametrize("surface", ["chat_completions", "_responses"])
+@pytest.mark.parametrize("surface", ["chat_completions", "_responses", "chat"])
 @pytest.mark.parametrize("streaming", [False, True])
 def test_max_turns_wrapped(client, store_path, fake_model, surface, streaming):
     """MaxTurnsExceeded is an engine-internal type; callers get the SDK's
@@ -1310,6 +1315,8 @@ def test_max_turns_rejects_non_positive(client, store_path, fake_model):
         client.chat_completions([{"role": "user", "content": "q"}],
                                 max_turns=0)
     # every door that takes max_turns validates it, the runner config too
+    with pytest.raises(PageIndexAPIError, match="positive integer"):
+        client.chat("q", max_turns=0, stream=True)
     with pytest.raises(PageIndexAPIError, match="positive integer"):
         client.anthropic_runner_config(model="claude-sonnet-4-5",
                                        max_turns=-1)
@@ -1539,6 +1546,15 @@ def test_sampling_knobs_ride_model_settings(client, store_path, fake_model,
     assert result["max_output_tokens"] == 321
     fake_model([[_msg_item("ok")]])
     assert client._responses("q")["max_output_tokens"] is None
+    # the public door has no knob for these; extra_body carries them to the
+    # wire, and the envelope must report what was sent, not the unset locals
+    fake_model([[_msg_item("ok")]])
+    result = client.chat("q", protocol="responses",
+                         extra_body={"max_output_tokens": 321, "top_p": 0.9,
+                                     "temperature": 0.2})
+    assert result["max_output_tokens"] == 321
+    assert result["top_p"] == 0.9
+    assert result["temperature"] == 0.2
 
 
 @needs_agents
@@ -1549,14 +1565,20 @@ def test_responses_envelope_echoes_reasoning(client, store_path, fake_model):
     assert result["reasoning"] == {"effort": "low"}
     fake_model([[_msg_item("ok")]])
     assert client._responses("q")["reasoning"] is None
+    fake_model([[_msg_item("ok")]])
+    result = client.chat("q", protocol="responses",
+                         extra_body={"reasoning": {"effort": "high"}})
+    assert result["reasoning"] == {"effort": "high"}
 
 
 @needs_agents
 def test_responses_input_validation(client, fake_model):
     fake_model([])
     for bad in ("", "   ", [], [1], None):
-        with pytest.raises(PageIndexAPIError, match="input must be"):
+        with pytest.raises(PageIndexAPIError, match="messages must be"):
             client._responses(bad)
+        with pytest.raises(PageIndexAPIError, match="messages must be"):
+            client.chat(bad, protocol="responses")
 
 
 @needs_agents
@@ -2382,6 +2404,16 @@ def test_messages_default_max_tokens_clears_thinking_budget(client, fake_anthrop
     client._messages("q", model="claude-test", max_tokens=11000,
                     thinking={"type": "enabled", "budget_tokens": 10000})
     assert calls[0]["max_tokens"] == 11000  # explicit value passes through
+    # the public door's spelling: thinking rides extra_body, same lift
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "c"}], "end_turn"),
+    ])
+    client.chat("q", protocol="messages", model="claude-test",
+                extra_body={"thinking": {"type": "enabled",
+                                         "budget_tokens": 10000}})
+    assert calls[0]["max_tokens"] == 10000 + 8192
+    assert calls[0]["thinking"] == {"type": "enabled",
+                                    "budget_tokens": 10000}
 
 
 @needs_anthropic
@@ -3055,10 +3087,13 @@ def test_chat_protocol_messages_is_the_door(client, monkeypatch):
 def test_chat_protocol_chokes(client, monkeypatch):
     monkeypatch.setattr(local_chat, "run_responses",
                         lambda c, input, **kw: "door")
-    with pytest.raises(PageIndexAPIError, match="protocol"):
+    with pytest.raises(PageIndexAPIError, match="protocol selects"):
         client.chat("q", protocol="grpc")
-    with pytest.raises(PageIndexAPIError, match="show_process"):
+    with pytest.raises(PageIndexAPIError, match="drop show_process"):
         client.chat("q", protocol="responses", stream=True, show_process=True)
+    # the protocol refusal first: "add stream=True" is no remedy here
+    with pytest.raises(PageIndexAPIError, match="drop show_process"):
+        client.chat("q", protocol="responses", show_process=True)
     with pytest.raises(PageIndexAPIError, match="instructions blocks"):
         client.chat("q", protocol="responses",
                     instructions=[{"type": "text", "text": "x"}])
@@ -3066,12 +3101,14 @@ def test_chat_protocol_chokes(client, monkeypatch):
         client.chat("q", instructions=[{"type": "text", "text": "x"}])
     with pytest.raises(PageIndexAPIError, match="model="):
         client.chat("q", protocol="messages")
+    with pytest.raises(PageIndexAPIError, match="model="):
+        client.chat("q", protocol="messages", model="")
 
 
 @needs_agents
 def test_chat_instructions_precede_history_system_rows(client, store_path,
                                                         fake_model, monkeypatch):
-    fake_model([[_msg_item("ok")], [_msg_item("ok")]])
+    fake_model([[_msg_item("ok")], [_msg_item("ok")], [_msg_item("ok")]])
     seen = {}
     real = local_chat._managed_instructions
 
@@ -3087,6 +3124,8 @@ def test_chat_instructions_precede_history_system_rows(client, store_path,
     assert seen["extra"] == ["analyst", "short"]
     client.chat("q", instructions="analyst")  # a bare question works too
     assert seen["extra"] == ["analyst"]
+    client.chat("q", instructions="")  # blank configures nothing, no row
+    assert seen["extra"] == []
 
 
 def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):


### PR DESCRIPTION
`responses()` and `messages()` move behind the front door: they are now `chat(protocol="responses")` and `chat(protocol="messages")`, with the protocol's own input and output shapes — transcript items / content blocks in, the response envelope or native stream out. The same engines run underneath (`_responses()` / `_messages()`); the old public names raise an `AttributeError` that names the new spelling. `chat_completions()` is unchanged.

Why: the old names are the vendor SDKs' own, and an AI coding agent handed a `PageIndexClient` reaches for `client.messages(...)` on prior alone, then builds an Anthropic-shaped integration where `chat()` was the one-liner. Behind an explicit `protocol=` the capability is reachable only after reading `chat()`'s docs — the right context — and a mis-reach fails fast with the way in. The `__getattr__` that does this is runtime-only (under `if not TYPE_CHECKING`) so pyright keeps flagging attribute typos on the client. The shape matches the current generation of unified-entry SDKs (one entry, explicit protocol variants, a provider-fields escape hatch).

## `chat()` changes

- `protocol=None | "responses" | "messages"` — declared, never inferred from the model name; own-model chat only (the managed cloud chat rejects it). `"messages"` needs `model=` naming a Claude model.
- New knobs that lost their public home with the doors: `instructions` (appended after the managed prompt — a string on every lane, Messages system blocks with `protocol="messages"`; on the answer lane it precedes any `system` rows in the history), `max_turns`, `backend`, `extra_headers`, `extra_body`.
- `reasoning_effort` lands natively on each lane: LiteLLM's `reasoning_effort`, Responses `reasoning.effort`, Anthropic `output_config.effort` (a caller's own `output_config` keys survive; theirs win).
- Provider-specific fields (`thinking`, `top_k`, `max_output_tokens`, …) ride `extra_body`, merged last — including over the fields the SDK writes; override `system` and the managed prompt is yours to replace.
- `show_process` stays the answer lane's view; passing it with a protocol is an error (the protocol's transcript is the process).
- Six overloads keep the return types narrow for py.typed consumers: `str` / `ChatStream` / `dict` / `Iterator[dict]` / `Iterator[Any]`.
- The streamed answer lane now honors `max_turns` / `backend` / `extra_headers` / `extra_body` and reports the real `max_turns` in its error.

## Compatibility

Breaking for callers of `responses()` / `messages()` (public since 0.2.10); the raised message points at `chat(protocol=...)`. Everything else is additive. Version bump deferred.

## Tests

471 green (+6): the old names point at the new spelling and `hasattr` is false; `chat(protocol=X, …)` forwards exactly what `_X(…)` receives (both lanes); effort mapping and the `output_config` merge; the four loud boundaries; instructions ordering on the answer lane; the promoted knobs reach both answer-lane runners. Without-frameworks leg simulated (skips, no failures); pyright unchanged.

https://claude.ai/code/session_017uvMD9eatgdaupLGFUjuKM


## Review round 1 (56de632)

Through the public door the Messages lane's `thinking` rides `extra_body`, so the default `max_tokens` lift now reads it there (the documented `extra_body={"thinking": ...}` no longer 400s). The Responses envelope echoes the `extra_body`-carried `temperature` / `top_p` / `reasoning` / `max_output_tokens` instead of the never-set locals. One `_require_own_chat` refusal serves `chat(protocol=...)`, the doors behind it, and `instructions`, so the texts cannot drift and a local client with `chat_model` blank gets the local remedy on every lane and both doors. `model=""` on the Messages lane is unset; the protocol refusal for `show_process` comes before the `stream=True` hint; `instructions=""` configures nothing; Responses validation says `messages`. A seventh overload (`protocol=None`, `stream: bool`) keeps `str | ChatStream` for a runtime-variable `stream`. 473 green, 9 red-verified assertions, pyright unchanged.

https://claude.ai/code/session_01M9GdjnuDHHwDKqMzvPWCcj
