### PR TITLE
Ignore the default results/ output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 logs/
 .pageindex/
 dist/
+/results/


### PR DESCRIPTION
`run_pageindex.py` writes its trees to `./results`:

```python
output_dir = './results'   # lines 142 and 198
```

but `results/` is not in `.gitignore`, so running the CLI leaves untracked JSON at the repo root — and it keeps getting swept into commits. History has it **ten times**: 51 files, 3.2 MB, from `first commit` through `improve tree optimization`, `fix doc locations`, `fix physical index` and others. Nothing is tracked there right now, so this is purely preventing the next one.

Scoped with a leading slash, so the curated `examples/documents/results/` samples are untouched — verified:

```
$ git check-ignore -v results/probe_structure.json
.gitignore:9:/results/	results/probe_structure.json

$ git check-ignore examples/documents/results/earthmover_structure.json
(no match — still tracked, 8 files)
```

https://claude.ai/code/session_01KXmNuHrkQEkefNS12V7apV