### PR TITLE
fix: Responses effort rides extra_body; envelope reports metadata; "" is unset on every lane

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -296,7 +296,7 @@ class PageIndexClient:
             documents (structure and summaries). Defaults to the SDK
             default (fast and cheap).
         chat_model (str, optional): Your own model for the chat surfaces
-            (``chat``, ``chat_completions``, ``responses``), exposed as
+            (``chat``, ``chat_completions``), exposed as
             ``client.chat_model`` — on a cloud client, setting it runs
             the document-QA agent in your process over the cloud
             documents (page content then flows through your process to
@@ -555,7 +555,9 @@ class PageIndexClient:
             if name in ("responses", "messages"):
                 raise AttributeError(
                     f"{name}() moved: call chat(protocol={name!r}, ...) "
-                    "— the same protocol, engine, and envelope.")
+                    "— the same protocol, engine, and envelope. Pass the "
+                    "rest by keyword; its sampling and thinking fields "
+                    "ride extra_body under their wire names.")
             raise AttributeError(
                 f"{type(self).__name__!r} object has no attribute {name!r}")
 
@@ -957,11 +959,11 @@ class PageIndexClient:
 
         Args:
             messages: A question string, or the conversation history —
-                role/content messages on every lane. A leading ``system``
-                row joins the managed prompt on the answer lane only; the
-                protocol lanes pass rows to the wire as they are (use
-                ``instructions`` for persona there). With a protocol, also
-                that protocol's transcript items or content blocks.
+                role/content messages on every lane. ``system`` rows join
+                the managed prompt on the answer lane only, wherever they
+                sit; the protocol lanes pass rows to the wire as they are
+                (use ``instructions`` for persona there). With a protocol,
+                also that protocol's transcript items or content blocks.
             doc_id: Document ID or list of IDs to scope the conversation.
                 Keep it identical across a conversation's calls. Local
                 documents: also enforced at the tool layer, not just
@@ -1018,7 +1020,11 @@ class PageIndexClient:
                 string on every lane; with ``protocol="messages"`` also
                 a list of Messages system blocks. On the answer lane it
                 precedes any ``system`` rows in the history.
-            max_turns: Own-model chat only — cap on agent turns per call.
+            max_turns: Own-model chat only — cap on agent turns per call
+                (default 10). The OpenAI lanes raise at the cap;
+                ``protocol="messages"`` returns the truncated run
+                (``stop_reason: "tool_use"``, its ``messages`` valid for
+                continuation).
             backend: Own-model chat only — connection overrides for this
                 call's backend, merged over the client's ``chat_backend``
                 (per-call keys win): LiteLLM's connection params on the
@@ -1030,15 +1036,14 @@ class PageIndexClient:
                 answer lane — Anthropic beta flags ride
                 ``protocol="messages"``.
             extra_body: Own-model chat only — the provider's own request
-                fields beyond this method's parameters (``thinking``,
-                ``top_k``, ``max_output_tokens``, …), merged last so they
-                win — including over the fields the SDK writes
-                (``system``, ``input``): override those and the managed
-                prompt is yours to replace. Answer lane: LiteLLM's own
-                params, mapped or refused per provider (its named
-                sampling params are ``chat_completions()``'s); protocol
-                lanes: verbatim into the request body. Credentials belong
-                in ``backend``, never here.
+                fields beyond this method's parameters, in the lane's
+                wire names (Responses ``max_output_tokens``, Messages
+                ``thinking`` / ``top_k``), merged last so they win.
+                Answer lane: LiteLLM's own params, mapped or refused per
+                provider (its named sampling params are
+                ``chat_completions()``'s); protocol lanes: verbatim into
+                the request body. Credentials belong in ``backend``,
+                never here.
 
         Returns:
             - answer lane, stream=False: the answer string
@@ -1082,21 +1087,26 @@ class PageIndexClient:
         if protocol is not None:
             self._require_own_chat(f"chat(protocol={protocol!r})")
             if protocol == "responses":
+                body = extra_body
+                if reasoning_effort:
+                    # OpenAI's own effort field, beside the caller's other
+                    # reasoning keys — theirs still win.
+                    given = extra_body or {}
+                    body = {**given, "reasoning": {
+                        "effort": reasoning_effort,
+                        **given.get("reasoning", {})}}
                 return self._responses(
                     messages, model=model, stream=stream, doc_id=doc_id,
                     instructions=cast(Optional[str], instructions),
-                    max_turns=max_turns,
-                    reasoning=({"effort": reasoning_effort}
-                               if reasoning_effort is not None else None),
-                    extra_body=extra_body, extra_headers=extra_headers,
-                    backend=backend)
+                    max_turns=max_turns, extra_body=body,
+                    extra_headers=extra_headers, backend=backend)
             if not model:
                 raise PageIndexAPIError(
                     "protocol=\"messages\" drives Anthropic's Messages API "
                     "with the Anthropic SDK — name the Claude model with "
                     "model=... (there is no cross-vendor default to guess).")
             body = extra_body
-            if reasoning_effort is not None:
+            if reasoning_effort:
                 # Anthropic's own effort field, beside the caller's other
                 # output_config keys — theirs still win.
                 given = extra_body or {}

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1289,10 +1289,9 @@ class PageIndexClient:
                 "chat_model is empty — it configures nothing, and a local "
                 "client has no managed chat to fall back to. Set "
                 "chat_model=... to run the agent with your own model.")
-        if (model is not None or max_turns is not None or top_p is not None
-                or max_tokens is not None or reasoning_effort is not None
-                or extra_body is not None or extra_headers is not None
-                or backend is not None):
+        if (model or max_turns is not None or top_p is not None
+                or max_tokens is not None or reasoning_effort
+                or extra_body or extra_headers or backend):
             raise PageIndexAPIError(
                 "model, max_turns, top_p, max_tokens, reasoning_effort, "
                 "extra_body, extra_headers and backend drive your own chat "

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -1106,7 +1106,7 @@ def run_responses(client, input, model: Optional[str] = None,
                                            max_output_tokens),
             "error": recorded.get("error"),
             "incomplete_details": recorded.get("incomplete_details"),
-            "metadata": None,
+            "metadata": given.get("metadata"),
         }
 
     if not stream:

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -318,7 +318,7 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
     # top-level kwarg on every supported openai-agents version, and the
     # channel admits values outside the OpenAI enum ("none").
     extra_args = _cache_extra_args(model_name)
-    if reasoning_effort is not None:
+    if reasoning_effort:
         extra_args = {**(extra_args or {}),
                       "reasoning_effort": reasoning_effort}
     conn = _sdk_backend(backend) if backend else {}

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -77,13 +77,13 @@ def _split_chat_messages(messages) -> "tuple[list[str], list[dict]]":
             content = message.get("content")
             if not isinstance(content, str):
                 raise PageIndexAPIError(
-                    "chat_completions content must be a string; for "
+                    "content must be a string on this lane; for "
                     "structured items use chat(protocol=...)."
                 )
             history.append({"role": role, "content": content})
         else:
             raise PageIndexAPIError(
-                f"Unsupported role for chat_completions: {role!r}. Tool "
+                f"Unsupported role {role!r} on this lane. Tool "
                 "history round-trips belong to chat(protocol=...)."
             )
     if not history:

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -300,8 +300,13 @@ def test_chat_completions_missing_framework(client, monkeypatch):
         client.chat_completions([{"role": "user", "content": "x"}])
 
 
-def test_cloud_guards():
+def test_cloud_guards(monkeypatch):
     cloud = PageIndexCloudClient(api_key="pi-test-key")
+    # empty is unset, as on the local lane — the managed chat serves it
+    monkeypatch.setattr(cloud._api, "chat_completions",
+                        lambda **kw: {"choices": [{"message": {"content": "ok"}}]})
+    assert cloud.chat("x", model="", reasoning_effort="", extra_body={},
+                      extra_headers={}, backend={}) == "ok"
     with pytest.raises(PageIndexAPIError, match="own chat model"):
         cloud.chat_completions([{"role": "user", "content": "x"}], model="m")
     with pytest.raises(PageIndexAPIError, match="own chat model"):
@@ -1486,6 +1491,10 @@ def test_reasoning_passthrough_reaches_each_engine(monkeypatch):
     agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
                                      None, None)
     assert agent.model_settings.reasoning is None
+    assert agent.model_settings.extra_args is None
+    # "" is unset on this lane too, like the protocol lanes
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None, reasoning_effort="")
     assert agent.model_settings.extra_args is None
 
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -1555,20 +1555,43 @@ def test_sampling_knobs_ride_model_settings(client, store_path, fake_model,
     assert result["max_output_tokens"] == 321
     assert result["top_p"] == 0.9
     assert result["temperature"] == 0.2
+    sent = seen["responses"].extra_body
+    assert {"max_output_tokens": 321, "top_p": 0.9,
+            "temperature": 0.2}.items() <= sent.items()
 
 
 @needs_agents
-def test_responses_envelope_echoes_reasoning(client, store_path, fake_model):
+def test_responses_envelope_echoes_reasoning(client, store_path, fake_model,
+                                             monkeypatch):
     seed_doc(store_path, "pi-a", "report.pdf")
     fake_model([[_msg_item("ok")]])
     result = client._responses("q", reasoning={"effort": "low"})
     assert result["reasoning"] == {"effort": "low"}
     fake_model([[_msg_item("ok")]])
     assert client._responses("q")["reasoning"] is None
+    seen = {}
+    real = local_chat._openai_agent
+
+    def spy(*args, **kwargs):
+        agent = real(*args, **kwargs)
+        seen[args[1]] = agent.model_settings
+        return agent
+
+    monkeypatch.setattr(local_chat, "_openai_agent", spy)
     fake_model([[_msg_item("ok")]])
     result = client.chat("q", protocol="responses",
                          extra_body={"reasoning": {"effort": "high"}})
     assert result["reasoning"] == {"effort": "high"}
+    assert seen["responses"].extra_body["reasoning"] == {"effort": "high"}
+    # effort joins the caller's reasoning object on the one channel to the
+    # wire; a separate reasoning= would be replaced whole by extra_body's
+    fake_model([[_msg_item("ok")]])
+    result = client.chat("q", protocol="responses", reasoning_effort="high",
+                         extra_body={"reasoning": {"summary": "auto"}})
+    assert seen["responses"].reasoning is None
+    assert seen["responses"].extra_body["reasoning"] == {
+        "summary": "auto", "effort": "high"}
+    assert result["reasoning"] == {"summary": "auto", "effort": "high"}
 
 
 @needs_agents
@@ -3042,12 +3065,28 @@ def test_chat_protocol_responses_is_the_door(client, monkeypatch):
                         lambda c, input, **kw: seen.append((input, kw)) or "door")
     knobs = dict(doc_id="pi-a", model="gpt-x", max_turns=3,
                  backend={"api_key": "k"}, extra_headers={"x": "1"},
-                 extra_body={"seed": 1}, instructions="be brief")
+                 instructions="be brief")
     assert client.chat("q", protocol="responses", reasoning_effort="low",
-                       **knobs) == "door"
-    assert client._responses("q", reasoning={"effort": "low"}, **knobs) == "door"
+                       extra_body={"seed": 1}, **knobs) == "door"
+    assert client._responses("q", extra_body={"seed": 1,
+                                              "reasoning": {"effort": "low"}},
+                             **knobs) == "door"
     assert seen[0] == seen[1]
-    assert seen[0][1]["reasoning"] == {"effort": "low"}
+    assert seen[0][1]["reasoning"] is None
+    # OpenAI's own effort field; the caller's extra_body still wins
+    client.chat("q", protocol="responses", reasoning_effort="low",
+                extra_body={"reasoning": {"effort": "high"}})
+    assert seen[-1][1]["extra_body"] == {"reasoning": {"effort": "high"}}
+    # a caller's other reasoning keys survive; only effort is ours
+    client.chat("q", protocol="responses", reasoning_effort="low",
+                extra_body={"reasoning": {"summary": "auto"}})
+    assert seen[-1][1]["extra_body"] == {
+        "reasoning": {"summary": "auto", "effort": "low"}}
+    # "" is unset, like model="" and instructions=""
+    client.chat("q", protocol="responses", reasoning_effort="",
+                extra_body={"seed": 1})
+    assert seen[-1][1]["extra_body"] == {"seed": 1}
+    assert seen[-1][1]["reasoning"] is None
     # the default for the stream view is silently off on a protocol lane
     assert client.chat("q", protocol="responses", stream=True) == "door"
     assert seen[-1][1]["stream"] is True
@@ -3082,6 +3121,10 @@ def test_chat_protocol_messages_is_the_door(client, monkeypatch):
                 extra_body={"output_config": {"format": {"type": "json"}}})
     assert seen[-1][1]["extra_body"] == {
         "output_config": {"format": {"type": "json"}, "effort": "low"}}
+    # "" is unset, like model="" and instructions=""
+    client.chat("q", protocol="messages", model="claude-x",
+                reasoning_effort="")
+    assert seen[-1][1]["extra_body"] is None
 
 
 def test_chat_protocol_chokes(client, monkeypatch):

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -1551,13 +1551,15 @@ def test_sampling_knobs_ride_model_settings(client, store_path, fake_model,
     fake_model([[_msg_item("ok")]])
     result = client.chat("q", protocol="responses",
                          extra_body={"max_output_tokens": 321, "top_p": 0.9,
-                                     "temperature": 0.2})
+                                     "temperature": 0.2,
+                                     "metadata": {"tag": "abc"}})
     assert result["max_output_tokens"] == 321
     assert result["top_p"] == 0.9
     assert result["temperature"] == 0.2
+    assert result["metadata"] == {"tag": "abc"}
     sent = seen["responses"].extra_body
-    assert {"max_output_tokens": 321, "top_p": 0.9,
-            "temperature": 0.2}.items() <= sent.items()
+    assert {"max_output_tokens": 321, "top_p": 0.9, "temperature": 0.2,
+            "metadata": {"tag": "abc"}}.items() <= sent.items()
 
 
 @needs_agents


### PR DESCRIPTION
Three follow-ups to #460 (`chat(protocol=)`), from the review rounds on #461. Same commits as feat/chat-protocol df16c18 / fbd6b4d / b15858b, cherry-picked onto main.

**Responses effort rides extra_body; chat() docs say what the wire does** (8ca938c)
`reasoning_effort` on the Responses lane joins the caller's `extra_body["reasoning"]` object (their keys win) instead of a separate `reasoning=` that a caller's object replaced whole on the wire. Mirrors the Messages lane's `output_config`. `reasoning_effort=""` is unset on both protocol lanes. Docstrings name the wire fields per lane, drop the invitation to override the SDK's system/input, say every system row joins the managed prompt on the answer lane, and document the max_turns raise-vs-truncate divergence. The migration message points at keywords + extra_body.

**Responses envelope reports the metadata sent** (51909cd)
`metadata` is a request field the caller sets through extra_body; the envelope hard-coded None. Now `given.get()`, like the other caller-set fields.

**"" is unset on the answer lane; managed-cloud gate reads falsy as unset** (e3cd7d4)
`reasoning_effort=""` reached LiteLLM as a literal empty effort on the answer lane while the protocol lanes treated it as unset. And `chat_completions`' managed-cloud own-model gate, which `chat()` routes through, refused `model=""` / `reasoning_effort=""` / `{}` as knobs the caller never set. Non-numeric knobs now read falsy as unset, as the local lane always has; numeric ones keep `is not None`.

Each fix carries a red-verified test. 470 passed on this base; the same commits are CI-green on feat/chat-protocol (#461).

https://claude.ai/code/session_01BAmVWYKoSnFEydbMjuZjHc
