### PR TITLE
ChatStream moves to a light module so chat()'s type hints resolve at runtime

### DIFF
--- a/pageindex/__init__.py
+++ b/pageindex/__init__.py
@@ -1,6 +1,7 @@
 """PageIndex SDK."""
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
+from .chat_stream import ChatStream
 from .client import PageIndexClient, PageIndexCloudClient, PageIndexLocalClient
 from .errors import PageIndexAPIError
 from .types import (ChatConfig, ChatProcessOptions, CloudIndexConfig,
@@ -8,7 +9,6 @@ from .types import (ChatConfig, ChatProcessOptions, CloudIndexConfig,
 
 if _TYPE_CHECKING:
     from .flash import page_index_flash
-    from .local_chat import ChatStream
     from .page_index_classic import page_index, page_index_main
     from .page_index_md import md_to_tree
     from .tree_optimize import optimize_tree
@@ -23,15 +23,14 @@ __all__ = [
 ]
 
 _LAZY = {
-    "ChatStream": ".local_chat",
     "page_index_flash": ".flash",
     "optimize_tree": ".tree_optimize",
     "md_to_tree": ".page_index_md",
 }
-_SUBMODULES = {"agent_tools", "client", "cloud_api", "errors", "flash",
-               "integrations", "local_api", "local_chat", "local_store",
-               "mcp_bridge", "page_index_classic", "page_index_md",
-               "tree_optimize", "types", "utils"}
+_SUBMODULES = {"agent_tools", "chat_stream", "client", "cloud_api", "errors",
+               "flash", "integrations", "local_api", "local_chat",
+               "local_store", "mcp_bridge", "page_index_classic",
+               "page_index_md", "tree_optimize", "types", "utils"}
 
 
 def __getattr__(name):

--- a/pageindex/chat_stream.py
+++ b/pageindex/chat_stream.py
@@ -1,4 +1,6 @@
-"""chat(stream=True)'s stream type — light, so client.py imports it."""
+"""chat(stream=True)'s return type: one run, one view — text or events."""
+from __future__ import annotations
+
 from typing import Any, Iterator, Optional
 
 from .errors import PageIndexAPIError

--- a/pageindex/chat_stream.py
+++ b/pageindex/chat_stream.py
@@ -1,0 +1,66 @@
+"""chat(stream=True)'s stream type — light, so client.py imports it."""
+from typing import Any, Iterator, Optional
+
+from .errors import PageIndexAPIError
+
+
+class ChatStream:
+    """chat(stream=True)'s stream: iterate it for the answer text pieces
+    (with show_process, the woven display); read ``.events`` instead for
+    the typed process event dicts. One underlying run — consume exactly
+    one view; call chat() again for the other."""
+
+    def __init__(self, text, events):
+        self._text = text      # () -> Iterator[str]
+        self._events = events  # () -> Iterator[dict], or the refusal text
+        self._view: Optional[str] = None
+        self._it: Any = None
+        self._closed = False
+
+    def _claim(self, view: str) -> None:
+        if self._view is not None and self._view != view:
+            raise PageIndexAPIError(
+                f"This chat stream is being consumed as {self._view}; one "
+                "run serves one view — call chat() again for the other.")
+        self._view = view
+
+    def __iter__(self) -> "ChatStream":
+        return self
+
+    def __next__(self) -> str:
+        self._claim("text")
+        if self._it is None:
+            if self._closed:
+                raise StopIteration
+            self._it = self._text()
+        return next(self._it)
+
+    @property
+    def events(self) -> Iterator[dict]:
+        """The run as typed event dicts: {"type": "thinking"|"answer",
+        "delta": ...}, {"type": "tool_call", "call_id", "name",
+        "arguments"}, {"type": "tool_result", "call_id", "name",
+        "output"} — full data, never clipped. Consuming — not merely
+        reading the attribute — claims the view, so debugger panes and
+        getattr probing stay side-effect free."""
+        def consume():
+            if isinstance(self._events, str):
+                raise PageIndexAPIError(self._events)
+            self._claim("events")
+            if self._it is None:
+                if self._closed:
+                    return
+                self._it = self._events()
+            # no `yield from`: a dropped handle must not close the run
+            for ev in self._it:
+                yield ev
+        return consume()
+
+    def close(self) -> None:
+        """Stop the run: closes the open view, and the stream is dead
+        afterwards, like a closed generator (own-model chat: a run never
+        consumed never starts)."""
+        self._closed = True
+        close = getattr(self._it, "close", None)
+        if close is not None:
+            close()

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -9,7 +9,6 @@ import warnings
 from typing import (TYPE_CHECKING, Any, Callable, Iterator, Literal, Mapping,
                     Optional, Union, cast, overload)
 
-# real, not TYPE_CHECKING: chat()'s hints must resolve at runtime
 from .chat_stream import ChatStream
 from .errors import PageIndexAPIError
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -9,6 +9,7 @@ import warnings
 from typing import (TYPE_CHECKING, Any, Callable, Iterator, Literal, Mapping,
                     Optional, Union, cast, overload)
 
+# real, not TYPE_CHECKING: chat()'s hints must resolve at runtime
 from .chat_stream import ChatStream
 from .errors import PageIndexAPIError
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -9,10 +9,8 @@ import warnings
 from typing import (TYPE_CHECKING, Any, Callable, Iterator, Literal, Mapping,
                     Optional, Union, cast, overload)
 
+from .chat_stream import ChatStream
 from .errors import PageIndexAPIError
-
-if TYPE_CHECKING:
-    from .local_chat import ChatStream
 
 
 _litellm_preload_started = False
@@ -826,7 +824,7 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         extra_body: Optional[dict[str, Any]] = None,
-    ) -> "ChatStream": ...
+    ) -> ChatStream: ...
 
     @overload
     def chat(
@@ -898,7 +896,7 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         extra_body: Optional[dict[str, Any]] = None,
-    ) -> Union[str, "ChatStream"]: ...
+    ) -> Union[str, ChatStream]: ...
 
     @overload
     def chat(
@@ -916,7 +914,7 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         extra_body: Optional[dict[str, Any]] = None,
-    ) -> Union[str, "ChatStream", dict[str, Any], Iterator[Any]]: ...
+    ) -> Union[str, ChatStream, dict[str, Any], Iterator[Any]]: ...
 
     def chat(
         self,
@@ -933,7 +931,7 @@ class PageIndexClient:
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         extra_body: Optional[dict[str, Any]] = None,
-    ) -> Union[str, "ChatStream", dict[str, Any], Iterator[Any]]:
+    ) -> Union[str, ChatStream, dict[str, Any], Iterator[Any]]:
         """
         Ask a question about your documents.
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -13,6 +13,7 @@ import uuid
 from typing import Any, Iterator, Mapping, Optional, Union
 
 from .agent_tools import _base_instructions, doc_targeting_block
+from .chat_stream import ChatStream
 from .errors import PageIndexAPIError
 
 CHAT_HEADER = (
@@ -772,68 +773,6 @@ def _weave(events, options) -> Iterator[str]:
         close = getattr(events, "close", None)
         if close is not None:
             close()  # cancel the underlying run on abandonment
-
-
-class ChatStream:
-    """chat(stream=True)'s stream: iterate it for the answer text pieces
-    (with show_process, the woven display); read ``.events`` instead for
-    the typed process event dicts. One underlying run — consume exactly
-    one view; call chat() again for the other."""
-
-    def __init__(self, text, events):
-        self._text = text      # () -> Iterator[str]
-        self._events = events  # () -> Iterator[dict], or the refusal text
-        self._view: Optional[str] = None
-        self._it: Any = None
-        self._closed = False
-
-    def _claim(self, view: str) -> None:
-        if self._view is not None and self._view != view:
-            raise PageIndexAPIError(
-                f"This chat stream is being consumed as {self._view}; one "
-                "run serves one view — call chat() again for the other.")
-        self._view = view
-
-    def __iter__(self) -> "ChatStream":
-        return self
-
-    def __next__(self) -> str:
-        self._claim("text")
-        if self._it is None:
-            if self._closed:
-                raise StopIteration
-            self._it = self._text()
-        return next(self._it)
-
-    @property
-    def events(self) -> Iterator[dict]:
-        """The run as typed event dicts: {"type": "thinking"|"answer",
-        "delta": ...}, {"type": "tool_call", "call_id", "name",
-        "arguments"}, {"type": "tool_result", "call_id", "name",
-        "output"} — full data, never clipped. Consuming — not merely
-        reading the attribute — claims the view, so debugger panes and
-        getattr probing stay side-effect free."""
-        def consume():
-            if isinstance(self._events, str):
-                raise PageIndexAPIError(self._events)
-            self._claim("events")
-            if self._it is None:
-                if self._closed:
-                    return
-                self._it = self._events()
-            # no `yield from`: a dropped handle must not close the run
-            for ev in self._it:
-                yield ev
-        return consume()
-
-    def close(self) -> None:
-        """Stop the run: closes the open view, and the stream is dead
-        afterwards, like a closed generator (own-model chat: a run never
-        consumed never starts)."""
-        self._closed = True
-        close = getattr(self._it, "close", None)
-        if close is not None:
-            close()
 
 
 def _cloud_chunk_events(chunks) -> Iterator[dict]:

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -1,6 +1,6 @@
 """Own-model chat: document-QA agents over the local or cloud agent
-tools, plus the ChatStream views, which also weave the managed
-endpoint's chunk stream."""
+tools, and the runs behind both ChatStream views, which also weave the
+managed endpoint's chunk stream."""
 from __future__ import annotations
 
 import asyncio

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -77,8 +77,8 @@ def test_public_method_type_hints_resolve_at_runtime():
              if not name.startswith("_")}
     assert len(hints) > 10, f"public-method walk collapsed: {sorted(hints)}"
     assert ChatStream in typing.get_args(hints["chat"]["return"])
-    # the import path the class shipped under in 0.2.11-0.2.14
-    assert pageindex.local_chat.ChatStream is ChatStream
+    assert pageindex.local_chat.ChatStream is ChatStream, (
+        "the import path the class shipped under in 0.2.11-0.2.14")
 
 
 def test_sdk_submodules_reachable_and_dunder_probes_stay_lazy():

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -75,7 +75,7 @@ def test_public_method_type_hints_resolve_at_runtime():
     hints = {name: typing.get_type_hints(fn) for name, fn
              in inspect.getmembers(PageIndexClient, inspect.isfunction)
              if not name.startswith("_")}
-    assert len(hints) > 10, f"the public-method walk collapsed: {sorted(hints)}"
+    assert len(hints) > 10, f"public-method walk collapsed: {sorted(hints)}"
     assert ChatStream in typing.get_args(hints["chat"]["return"])
     # the import path the class shipped under in 0.2.11-0.2.14
     assert pageindex.local_chat.ChatStream is ChatStream

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -53,14 +53,28 @@ def test_import_pageindex_is_lazy():
     probe = (
         "import sys; import pageindex; "
         "heavy = [m for m in ('pageindex.page_index_classic', 'pageindex.flash', "
-        "'pageindex.utils', 'pageindex.tree_optimize', 'numpy', 'PyPDF2') "
-        "if m in sys.modules]; "
+        "'pageindex.utils', 'pageindex.tree_optimize', "
+        "'pageindex.local_chat', 'numpy', 'PyPDF2') if m in sys.modules]; "
         "print(','.join(heavy) or 'clean'); "
         "print(type(pageindex.page_index_main).__name__)"
     )
     out = subprocess.run([sys.executable, "-c", probe],
                          capture_output=True, text=True, check=True)
     assert out.stdout.split() == ["clean", "function"]
+
+
+def test_public_method_type_hints_resolve_at_runtime():
+    """Tools that introspect signatures at runtime (agents' function_tool,
+    pydantic, doc generators) evaluate the annotations: every public
+    method's hints must resolve, ChatStream included."""
+    import inspect
+    import typing
+    from pageindex import ChatStream, PageIndexClient
+    for name, fn in inspect.getmembers(PageIndexClient, inspect.isfunction):
+        if not name.startswith("_"):
+            typing.get_type_hints(fn)
+    hints = typing.get_type_hints(PageIndexClient.chat)
+    assert ChatStream in typing.get_args(hints["return"])
 
 
 def test_sdk_submodules_reachable_and_dunder_probes_stay_lazy():

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -54,7 +54,8 @@ def test_import_pageindex_is_lazy():
         "import sys; import pageindex; "
         "heavy = [m for m in ('pageindex.page_index_classic', 'pageindex.flash', "
         "'pageindex.utils', 'pageindex.tree_optimize', "
-        "'pageindex.local_chat', 'numpy', 'PyPDF2') if m in sys.modules]; "
+        "'pageindex.local_chat', 'numpy', 'PyPDF2', "
+        "'agents', 'litellm', 'openai', 'anthropic') if m in sys.modules]; "
         "print(','.join(heavy) or 'clean'); "
         "print(type(pageindex.page_index_main).__name__)"
     )
@@ -69,12 +70,15 @@ def test_public_method_type_hints_resolve_at_runtime():
     method's hints must resolve, ChatStream included."""
     import inspect
     import typing
+    import pageindex
     from pageindex import ChatStream, PageIndexClient
-    for name, fn in inspect.getmembers(PageIndexClient, inspect.isfunction):
-        if not name.startswith("_"):
-            typing.get_type_hints(fn)
-    hints = typing.get_type_hints(PageIndexClient.chat)
-    assert ChatStream in typing.get_args(hints["return"])
+    hints = {name: typing.get_type_hints(fn) for name, fn
+             in inspect.getmembers(PageIndexClient, inspect.isfunction)
+             if not name.startswith("_")}
+    assert len(hints) > 10, f"the public-method walk collapsed: {sorted(hints)}"
+    assert ChatStream in typing.get_args(hints["chat"]["return"])
+    # the import path the class shipped under in 0.2.11-0.2.14
+    assert pageindex.local_chat.ChatStream is ChatStream
 
 
 def test_sdk_submodules_reachable_and_dunder_probes_stay_lazy():


### PR DESCRIPTION
`ChatStream` was importable in `client.py` only under `TYPE_CHECKING` (a real import would have dragged `local_chat`'s asyncio stack into `import pageindex`), which left `chat()`'s return annotation a dangling string: `typing.get_type_hints(PageIndexClient.chat)` raised `NameError`, and so did anything that introspects signatures. `agents.function_tool(client.chat)` died on it before looking at a single parameter.

The class touches neither asyncio nor the agent frameworks, so it moves to `pageindex/chat_stream.py`; `client.py` imports it for real, and the package exports it directly instead of lazily. `import pageindex` still leaves `local_chat` unloaded, and import cost is unchanged.

A review of the first commit found the move's own guards thinner than they looked, fixed in the second:

- `chat_stream.py` had no `from __future__ import annotations`, unlike every sibling module, so its `-> "ChatStream"` quotes were load-bearing: unquoting them — the very edit this move makes in `client.py` — broke `import pageindex` outright.
- The import in `client.py` is the whole fix and reads like a typing-only one, so a comment says why it must stay real.
- The lazy-import test's denylist named no framework, so `agents`, `litellm`, `openai` or `anthropic` could join the eager path with a green suite — the cost this module was split out to avoid.
- The type-hints walk had no floor, so it could silently stop covering anything, and nothing pinned `pageindex.local_chat.ChatStream`, the path the class shipped under in 0.2.11-0.2.14.
- `local_chat`'s module docstring still claimed the class.

Sits on the review view #457. The `client.py` hunk was merged by hand onto main's `chat()` signatures (#460), keeping main's `TYPE_CHECKING` import, which its runtime-only `__getattr__` still uses.

Verification: 476 passed; whole suite with `openai-agents` blocked 370 passed / 106 skipped; pyright 0 on the touched files, package unchanged (236). The type-hints test is red on base (`NameError`), and all four new guards were mutation-checked red. Note `function_tool(client.chat)` also needs `strict_mode=False`: `chat()`'s object-typed parameters are what `pageindex/integrations/openai_agents.py` exists to work around, and that is unchanged here.
