### PR TITLE
fix: extra_body refuses the skeleton keys; sampling fields ride ModelSettings on LiteLLM-routed models

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1043,8 +1043,11 @@ class PageIndexClient:
                 Answer lane: LiteLLM's own params, mapped or refused per
                 provider (its named sampling params are
                 ``chat_completions()``'s); protocol lanes: verbatim into
-                the request body. Credentials belong in ``backend``,
-                never here.
+                the request body. The managed prompt, conversation and
+                tools are not fields here (``system`` / ``instructions``
+                / ``input`` / ``messages`` / ``tools`` are refused);
+                extend the prompt with ``instructions=``. Credentials
+                belong in ``backend``, never here.
 
         Returns:
             - answer lane, stream=False: the answer string

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1255,7 +1255,10 @@ class PageIndexClient:
                 OpenAI-compatible backends take them verbatim in the
                 request body; LiteLLM-routed providers take them as
                 LiteLLM's own params (mapped or refused per provider).
-                Credentials belong in ``backend``, never here.
+                The managed prompt, conversation and tools are not
+                fields here (``system`` / ``instructions`` / ``input`` /
+                ``messages`` / ``tools`` are refused). Credentials belong
+                in ``backend``, never here.
             extra_headers: Own-model chat only — extra HTTP headers merged into
                 each backend request; caller headers win. One exception:
                 LiteLLM's anthropic adapter owns the ``anthropic-beta``

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1041,8 +1041,8 @@ class PageIndexClient:
                 wire names (Responses ``max_output_tokens``, Messages
                 ``thinking`` / ``top_k``), merged last so they win.
                 Answer lane: LiteLLM's own params, mapped or refused per
-                provider (its named sampling params are
-                ``chat_completions()``'s); protocol lanes: verbatim into
+                provider (``response_format`` has no door on
+                LiteLLM-routed models); protocol lanes: verbatim into
                 the request body. The managed prompt, conversation and
                 tools are not fields here (``system`` / ``instructions``
                 / ``input`` / ``messages`` / ``tools`` are refused);

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -302,10 +302,26 @@ def _merged_backend(client, backend):
     return merged or None
 
 
+_SKELETON_KEYS = frozenset({"system", "instructions", "input", "messages",
+                            "tools"})
+
+
+def _refuse_skeleton(extra_body) -> None:
+    """The managed prompt, conversation and tools are the SDK's on every
+    lane; extra_body merges last, so a caller's copy would replace them."""
+    hit = sorted(_SKELETON_KEYS.intersection(extra_body or ()))
+    if hit:
+        raise PageIndexAPIError(
+            f"extra_body cannot carry {', '.join(hit)}: the managed prompt, "
+            "conversation and tools are the SDK's. Extend the prompt with "
+            "instructions=; the conversation is the first argument.")
+
+
 def _openai_agent(client, protocol: str, model_name: str, instructions: str,
                   temperature, top_p, doc_ids=None, cache_key=None,
                   reasoning=None, reasoning_effort=None, extra_body=None,
                   max_tokens=None, backend=None, extra_headers=None):
+    _refuse_skeleton(extra_body)
     from agents import Agent, ModelSettings
     from .integrations.openai_agents import build_openai_tools
     # ModelSettings.extra_body is the one channel all three engines put on
@@ -1365,6 +1381,7 @@ def run_messages(client, messages, model: str,
     _require_anthropic()
     import anthropic
     _validate_max_turns(max_turns)
+    _refuse_skeleton(extra_body)
     if isinstance(messages, str) and messages.strip():
         messages = [{"role": "user", "content": messages}]
     if (not isinstance(messages, list) or not messages

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -4,6 +4,7 @@ endpoint's chunk stream."""
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
 import json
 import queue
@@ -351,22 +352,30 @@ def _openai_agent(client, protocol: str, model_name: str, instructions: str,
             if cache_key and openai_backend else None)
     # Caller extras merge last, so they win over ours; non-OpenAI
     # destinations take them as LiteLLM kwargs instead (see note above).
+    routed: dict[str, Any] = {}
     if extra_body:
         if openai_backend:
             body = {**(body or {}), **extra_body}
         else:
-            extra_args = {**(extra_args or {}), **extra_body}
+            # openai-agents passes ModelSettings' own fields to litellm by
+            # name beside **extra_args, so those ride their field.
+            own = {field.name for field in dataclasses.fields(ModelSettings)}
+            routed = {k: v for k, v in extra_body.items() if k in own}
+            rest = {k: v for k, v in extra_body.items() if k not in own}
+            if rest:
+                extra_args = {**(extra_args or {}), **rest}
     from pydantic import ValidationError
     try:
-        settings = ModelSettings(
-            temperature=temperature, top_p=top_p, max_tokens=max_tokens,
-            reasoning=reasoning,
+        settings = ModelSettings(**{
+            "temperature": temperature, "top_p": top_p,
+            "max_tokens": max_tokens, "reasoning": reasoning,
             # Streamed runs otherwise carry no usage at all (agents forwards
             # this as stream_options only on streaming calls).
-            include_usage=True,
-            extra_body=body,
-            extra_headers=extra_headers,
-            extra_args=extra_args)
+            "include_usage": True,
+            "extra_body": body,
+            "extra_headers": extra_headers,
+            "extra_args": extra_args,
+            **routed})
     except ValidationError as exc:
         raise PageIndexAPIError(f"Invalid model settings: {exc}") from exc
     return Agent(

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -1523,6 +1523,36 @@ def test_reasoning_passthrough_reaches_each_engine(monkeypatch):
 
 
 @needs_agents
+def test_extra_body_model_settings_fields_ride_their_field(monkeypatch):
+    """LiteLLM-routed answer lane: openai-agents passes ModelSettings'
+    own fields to litellm by name beside **extra_args, so a caller's copy
+    in extra_args collided with them. Those ride their field, the
+    caller's value winning; the rest stay LiteLLM kwargs. OpenAI
+    destinations keep the request-body path."""
+    pytest.importorskip("litellm")
+    monkeypatch.setattr(local_chat, "_openai_model", lambda *a: None)
+    monkeypatch.setattr("pageindex.integrations.openai_agents.build_openai_tools",
+                        lambda *a, **k: [])
+    agent = local_chat._openai_agent(None, "chat", "anthropic/claude-x",
+                                     "sys", 0.7, None,
+                                     extra_body={"temperature": 0.2,
+                                                 "top_k": 5})
+    settings = agent.model_settings
+    assert settings.temperature == 0.2
+    assert settings.extra_args["top_k"] == 5
+    assert "temperature" not in settings.extra_args
+    agent = local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None,
+                                     extra_body={"temperature": 0.2})
+    assert agent.model_settings.temperature is None
+    assert agent.model_settings.extra_body == {"temperature": 0.2}
+    with pytest.raises(PageIndexAPIError, match="Invalid model settings"):
+        local_chat._openai_agent(None, "chat", "anthropic/claude-x", "sys",
+                                 None, None,
+                                 extra_body={"temperature": "hot"})
+
+
+@needs_agents
 def test_extra_body_passthrough_reaches_each_engine(monkeypatch):
     """Caller extras merge last — over the cache key on OpenAI
     destinations — and ride LiteLLM's own kwargs elsewhere, where

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3162,6 +3162,31 @@ def test_chat_protocol_messages_is_the_door(client, monkeypatch):
     assert seen[-1][1]["extra_body"] is None
 
 
+def test_extra_body_refuses_skeleton_keys():
+    """The managed prompt, conversation and tools are the SDK's on every
+    lane; extra_body merges last, so a caller's copy would silently
+    replace them. Refused at the seam both openai-agents lanes share."""
+    for key in ("system", "instructions", "input", "messages", "tools"):
+        with pytest.raises(PageIndexAPIError, match="instructions="):
+            local_chat._openai_agent(None, "chat", "gpt-test", "sys",
+                                     None, None, extra_body={key: "x"})
+    with pytest.raises(PageIndexAPIError, match="instructions="):
+        local_chat._openai_agent(None, "responses", "gpt-test", "sys",
+                                 None, None, extra_body={"input": "x"})
+
+
+@needs_anthropic
+def test_messages_extra_body_refuses_skeleton_before_transport(client,
+                                                                monkeypatch):
+    made = []
+    monkeypatch.setattr(local_chat, "_anthropic_client",
+                        lambda backend=None: made.append(1))
+    with pytest.raises(PageIndexAPIError, match="instructions="):
+        local_chat.run_messages(client, "q", model="claude-x",
+                                extra_body={"system": "x"})
+    assert made == []
+
+
 def test_chat_protocol_chokes(client, monkeypatch):
     monkeypatch.setattr(local_chat, "run_responses",
                         lambda c, input, **kw: "door")


### PR DESCRIPTION
Two follow-ups to #460 (`chat(protocol=)`), from the second review round on #461. Same commits as feat/chat-protocol 4d18854 / c1ad980, cherry-picked onto main.

**extra_body refuses the skeleton keys** (4d18854)
extra_body merges last on every lane, so a caller's `system` / `instructions` / `input` / `messages` / `tools` replaced the managed prompt, the conversation or the doc tools wholesale. The run succeeded and answered without tool guidance or document scoping, silently. Those are the SDK's on every lane; the door for the prompt is `instructions=`. Refused at the two seams where extra_body meets the wire, before the Anthropic transport exists on the Messages lane.

**extra_body sampling fields ride their ModelSettings field on LiteLLM-routed models** (c1ad980)
On the answer lane, extra_body for a non-OpenAI destination becomes `ModelSettings.extra_args`, the LiteLLM kwargs channel. openai-agents passes ModelSettings' own fields to `litellm.acompletion` by name beside `**extra_args`, so a caller's `temperature` / `top_p` / `max_tokens` / penalties / `tool_choice` collided with the explicit keyword and died as a raw TypeError inside the framework. Split by the framework's own contract: keys that are ModelSettings fields ride their field (the caller's value winning over ours), the rest stay LiteLLM kwargs. The field list is the public dataclass, not a hand-kept name list; bad values now fail ModelSettings validation and surface as PageIndexAPIError. `response_format` is not a ModelSettings field and still has no door on this lane; documented.

Each fix carries red-verified tests. 476 green on feat/chat-protocol; the same commits are verified green on this base before the PR was opened.

https://claude.ai/code/session_01BAmVWYKoSnFEydbMjuZjHc
