### PR TITLE
litellm terminal noise: quiet as a default, and the no-fetch stamp on every lane

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -35,8 +35,6 @@ def _preload_litellm() -> None:
     def _import() -> None:
         try:
             import litellm  # noqa: F401
-            from .utils import _quiet_litellm
-            _quiet_litellm()
         except Exception:
             pass
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -19,14 +19,6 @@ _litellm_preload_started = False
 def _preload_litellm() -> None:
     """Start litellm's multi-second import in the background, once per
     process — a per-client thread would churn under per-request clients."""
-    # LiteLLM's import otherwise fetches its model map over the network —
-    # seconds of blocking (or a hang offline). Stamped here, not at package
-    # import, so merely importing pageindex leaves the host process's own
-    # litellm untouched; setdefault, so an explicit user choice wins.
-    os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    # Its logger initializes from LITELLM_LOG at import; ERROR keeps
-    # WARNING chatter off the caller's stderr from the first record.
-    os.environ.setdefault("LITELLM_LOG", "ERROR")
     global _litellm_preload_started
     if _litellm_preload_started:
         return

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -1281,6 +1281,7 @@ def _default_max_tokens(model: str, thinking=None) -> int:
     if isinstance(budget, int) and not isinstance(budget, bool):
         want = budget + 8192
         try:
+            from . import utils  # noqa: F401  — must precede litellm's import
             import litellm
             ceiling = (litellm.model_cost.get(model)
                        or {}).get("max_output_tokens")

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -252,6 +252,8 @@ def _litellm_claude_marks(wire: str) -> Optional[dict]:
     hands bare names to LiteLLM's own resolution)."""
     try:
         from litellm import get_llm_provider
+        from .utils import _quiet_litellm
+        _quiet_litellm()
         model, provider, _, _ = get_llm_provider(model=wire)
     except Exception:
         return None
@@ -287,6 +289,8 @@ def _openai_protocol(model_name: str) -> bool:
         return True
     try:
         import litellm
+        from .utils import _quiet_litellm
+        _quiet_litellm()
         _, provider, _, _ = litellm.get_llm_provider(model=wire)
     except Exception:
         return False

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -12,6 +12,11 @@ import asyncio
 from io import BytesIO
 from dotenv import find_dotenv, load_dotenv
 load_dotenv(find_dotenv(usecwd=True))
+# LiteLLM's import otherwise fetches its model map over the network — seconds
+# of blocking, a WARNING offline. Every litellm lane imports this module
+# first (the CLI never runs the client's preload); setdefault, so an explicit
+# user choice wins.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 import logging
 import yaml
 from pathlib import Path
@@ -68,17 +73,18 @@ def _quiet_litellm() -> None:
     embedder switch, as its Router does; it gates only this banner and the
     "Give Feedback / Get Help" one. Its logger quiets the same way — WARNING
     chatter (remote-map fetch fallbacks, cost hiccups) is not actionable for
-    SDK callers — unless the caller picked a level via LITELLM_LOG, which
-    litellm honors at import and this respects. The dotted litellm name
-    covers the module-level loggers its adapters create; errors still raise
-    and log with their full text."""
+    SDK callers — as a default only: LITELLM_LOG picks the default, and a
+    level anyone set explicitly (the host, litellm's own _turn_on_debug())
+    stays theirs. The dotted litellm name covers the module-level loggers
+    its adapters create; errors still raise and log with their full text."""
     import litellm
     litellm.suppress_debug_info = True
     level = getattr(logging, os.environ.get("LITELLM_LOG", "ERROR").upper(),
                     logging.ERROR)
-    if level >= logging.ERROR:
-        for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy", "litellm"):
-            logging.getLogger(name).setLevel(level)
+    for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy", "litellm"):
+        logger = logging.getLogger(name)
+        if logger.level == logging.NOTSET:
+            logger.setLevel(level)
 
 # Backward compatibility: support CHATGPT_API_KEY as alias for OPENAI_API_KEY
 if not os.getenv("OPENAI_API_KEY") and os.getenv("CHATGPT_API_KEY"):

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -74,9 +74,11 @@ def _quiet_litellm() -> None:
     and log with their full text."""
     import litellm
     litellm.suppress_debug_info = True
-    if os.environ.get("LITELLM_LOG", "ERROR").upper() == "ERROR":
+    level = getattr(logging, os.environ.get("LITELLM_LOG", "ERROR").upper(),
+                    logging.ERROR)
+    if level >= logging.ERROR:
         for name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy", "litellm"):
-            logging.getLogger(name).setLevel(logging.ERROR)
+            logging.getLogger(name).setLevel(level)
 
 # Backward compatibility: support CHATGPT_API_KEY as alias for OPENAI_API_KEY
 if not os.getenv("OPENAI_API_KEY") and os.getenv("CHATGPT_API_KEY"):
@@ -189,9 +191,9 @@ def llm_completion(model, prompt, chat_history=None, return_finish_reason=False)
         except Exception as e:
             if getattr(e, "status_code", None) in _NO_RETRY_STATUS:
                 raise
-            logging.warning("Retrying LLM completion")
             logging.error(f"Error: {e}")
             if i < max_retries - 1:
+                logging.warning("Retrying LLM completion")
                 time.sleep(1)
             else:
                 raise LLMRetriesExhausted(
@@ -221,9 +223,9 @@ async def llm_acompletion(model, prompt):
         except Exception as e:
             if getattr(e, "status_code", None) in _NO_RETRY_STATUS:
                 raise
-            logging.warning("Retrying LLM completion")
             logging.error(f"Error: {e}")
             if i < max_retries - 1:
+                logging.warning("Retrying LLM completion")
                 await asyncio.sleep(1)
             else:
                 raise LLMRetriesExhausted(

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -12,10 +12,7 @@ import asyncio
 from io import BytesIO
 from dotenv import find_dotenv, load_dotenv
 load_dotenv(find_dotenv(usecwd=True))
-# LiteLLM's import otherwise fetches its model map over the network — seconds
-# of blocking, a WARNING offline. Every litellm lane imports this module
-# first (the CLI never runs the client's preload); setdefault, so an explicit
-# user choice wins.
+# litellm's import fetches its model map over the network unless told not to.
 os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
 import logging
 import yaml
@@ -65,18 +62,8 @@ def _mute_litellm_bridge_usage_warning() -> None:
 
 
 def _quiet_litellm() -> None:
-    """litellm print()s a red "Provider List:" banner into stdout when a
-    provider lookup fails — its OpenRouter adapter probes supports_reasoning()
-    with the provider-stripped model name on every completion, so any model
-    missing from litellm's static map stamps the banner into the middle of a
-    streamed answer (get_llm_provider_logic, seen on 1.97). Flip litellm's own
-    embedder switch, as its Router does; it gates only this banner and the
-    "Give Feedback / Get Help" one. Its logger quiets the same way — WARNING
-    chatter (remote-map fetch fallbacks, cost hiccups) is not actionable for
-    SDK callers — as a default only: LITELLM_LOG picks the default, and a
-    level anyone set explicitly (the host, litellm's own _turn_on_debug())
-    stays theirs. The dotted litellm name covers the module-level loggers
-    its adapters create; errors still raise and log with their full text."""
+    """Mute litellm's stdout "Provider List:" banner and default its loggers
+    to LITELLM_LOG (ERROR unset); a level set elsewhere stays."""
     import litellm
     litellm.suppress_debug_info = True
     level = getattr(logging, os.environ.get("LITELLM_LOG", "ERROR").upper(),

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -5,10 +5,6 @@ from pageindex import *
 from pageindex.page_index_md import md_to_tree
 from pageindex.utils import ConfigLoader
 
-# Keep LiteLLM's import off the network (frozen bundled model-cost map);
-# an explicit user setting wins.
-os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-
 if __name__ == "__main__":
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Process PDF or Markdown document and generate structure')

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -881,10 +881,7 @@ def test_openai_agent_config_repairs_litellm_types(tmp_path, monkeypatch,
     process, outside our completion helpers — the LiteLLM repairs must
     run at config time, and only for LiteLLM-routed models."""
     pytest.importorskip("agents")
-    import pageindex.client
     import pageindex.utils
-    # The preload thread runs _quiet_litellm too; keep it out of the count.
-    monkeypatch.setattr(pageindex.client, "_litellm_preload_started", True)
     calls = []
     monkeypatch.setattr(pageindex.utils, repair,
                         lambda: calls.append(True))

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -873,14 +873,18 @@ def test_non_string_doc_name_stays_not_found(client, store_path):
 
 
 @pytest.mark.parametrize("repair", ["_repair_litellm_types",
-                                    "_mute_litellm_bridge_usage_warning"])
+                                    "_mute_litellm_bridge_usage_warning",
+                                    "_quiet_litellm"])
 def test_openai_agent_config_repairs_litellm_types(tmp_path, monkeypatch,
                                                    repair):
     """The BYO path resolves its model through LiteLLM in the caller's
     process, outside our completion helpers — the LiteLLM repairs must
     run at config time, and only for LiteLLM-routed models."""
     pytest.importorskip("agents")
+    import pageindex.client
     import pageindex.utils
+    # The preload thread runs _quiet_litellm too; keep it out of the count.
+    monkeypatch.setattr(pageindex.client, "_litellm_preload_started", True)
     calls = []
     monkeypatch.setattr(pageindex.utils, repair,
                         lambda: calls.append(True))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2009,7 +2009,9 @@ def test_preload_stamps_litellm_log_level(monkeypatch):
     stderr; setdefault, so a caller's explicit choice wins."""
     import pageindex.client as client_mod
     monkeypatch.setattr(client_mod, "_litellm_preload_started", True)
-    monkeypatch.delenv("LITELLM_LOG", raising=False)
+    # delenv on an absent name records no undo; setenv first so it does.
+    monkeypatch.setenv("LITELLM_LOG", "x")
+    monkeypatch.delenv("LITELLM_LOG")
     client_mod._preload_litellm()
     assert os.environ["LITELLM_LOG"] == "ERROR"
     monkeypatch.setenv("LITELLM_LOG", "DEBUG")
@@ -2038,3 +2040,18 @@ def test_retry_notice_logs_instead_of_stdout(monkeypatch, capsys, caplog):
     assert utils.llm_completion("openai/gpt-x", "hi") == "ok"
     assert capsys.readouterr().out == ""
     assert any("Retrying" in r.getMessage() for r in caplog.records)
+
+
+def test_retry_notice_only_when_a_retry_follows(monkeypatch, caplog):
+    """The notice announces a retry; the terminal attempt raises instead."""
+    litellm = pytest.importorskip("litellm")
+    from pageindex import utils
+
+    def broken(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(litellm, "completion", broken)
+    monkeypatch.setattr(utils.time, "sleep", lambda s: None)
+    with pytest.raises(utils.LLMRetriesExhausted):
+        utils.llm_completion("openai/gpt-x", "hi")
+    assert sum("Retrying" in r.getMessage() for r in caplog.records) == 9

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2004,9 +2004,7 @@ def test_blank_chat_model_carries_no_model_into_agent_config():
 
 
 def test_utils_import_keeps_litellm_off_the_network():
-    """Every litellm lane imports utils first — the CLI pipeline never runs
-    the client's preload — so the no-fetch default is stamped there, ahead
-    of litellm's import; setdefault, so a caller's explicit choice wins."""
+    """utils' import sets litellm's no-fetch default; an explicit choice wins."""
     probe = ("import os, pageindex.utils; "
              "print(os.environ['LITELLM_LOCAL_MODEL_COST_MAP'])")
     env = {k: v for k, v in os.environ.items()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2003,21 +2003,6 @@ def test_blank_chat_model_carries_no_model_into_agent_config():
     assert "model" not in client.openai_agent_config()
 
 
-def test_utils_import_keeps_litellm_off_the_network():
-    """utils' import sets litellm's no-fetch default; an explicit choice wins."""
-    probe = ("import os, pageindex.utils; "
-             "print(os.environ['LITELLM_LOCAL_MODEL_COST_MAP'])")
-    env = {k: v for k, v in os.environ.items()
-           if k != "LITELLM_LOCAL_MODEL_COST_MAP"}
-    fresh = subprocess.run([sys.executable, "-c", probe], env=env,
-                           capture_output=True, text=True, check=True)
-    assert fresh.stdout.strip() == "True"
-    env["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
-    chosen = subprocess.run([sys.executable, "-c", probe], env=env,
-                            capture_output=True, text=True, check=True)
-    assert chosen.stdout.strip() == "False"
-
-
 def test_retry_notice_logs_instead_of_stdout(monkeypatch, capsys, caplog):
     """A retried completion must not write into the caller's stdout — that
     channel belongs to answers and CLI output; the notice rides logging

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2003,20 +2003,21 @@ def test_blank_chat_model_carries_no_model_into_agent_config():
     assert "model" not in client.openai_agent_config()
 
 
-def test_preload_stamps_litellm_log_level(monkeypatch):
-    """The background preload stamps LITELLM_LOG before litellm's import
-    initializes its logger, so import-time WARNING chatter never reaches
-    stderr; setdefault, so a caller's explicit choice wins."""
-    import pageindex.client as client_mod
-    monkeypatch.setattr(client_mod, "_litellm_preload_started", True)
-    # delenv on an absent name records no undo; setenv first so it does.
-    monkeypatch.setenv("LITELLM_LOG", "x")
-    monkeypatch.delenv("LITELLM_LOG")
-    client_mod._preload_litellm()
-    assert os.environ["LITELLM_LOG"] == "ERROR"
-    monkeypatch.setenv("LITELLM_LOG", "DEBUG")
-    client_mod._preload_litellm()
-    assert os.environ["LITELLM_LOG"] == "DEBUG"
+def test_utils_import_keeps_litellm_off_the_network():
+    """Every litellm lane imports utils first — the CLI pipeline never runs
+    the client's preload — so the no-fetch default is stamped there, ahead
+    of litellm's import; setdefault, so a caller's explicit choice wins."""
+    probe = ("import os, pageindex.utils; "
+             "print(os.environ['LITELLM_LOCAL_MODEL_COST_MAP'])")
+    env = {k: v for k, v in os.environ.items()
+           if k != "LITELLM_LOCAL_MODEL_COST_MAP"}
+    fresh = subprocess.run([sys.executable, "-c", probe], env=env,
+                           capture_output=True, text=True, check=True)
+    assert fresh.stdout.strip() == "True"
+    env["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+    chosen = subprocess.run([sys.executable, "-c", probe], env=env,
+                            capture_output=True, text=True, check=True)
+    assert chosen.stdout.strip() == "False"
 
 
 def test_retry_notice_logs_instead_of_stdout(monkeypatch, capsys, caplog):

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2671,23 +2671,22 @@ def test_litellm_lane_mutes_the_provider_list_banner(monkeypatch, capsys):
 
 
 @needs_agents
-def test_litellm_lane_gates_litellm_logging(monkeypatch):
+def test_litellm_lane_gates_litellm_logging(monkeypatch, caplog):
     """litellm's own logger sprays WARNING chatter (remote-map fetch
     fallbacks, cost hiccups) onto stderr from inside requests; building
-    the lane's model gates it to ERROR — unless the caller picked a
-    level via LITELLM_LOG, which stays theirs."""
+    the lane's model gates it to ERROR — as a default only: a level the
+    host set itself stays the host's."""
     pytest.importorskip("litellm")
     import logging
     monkeypatch.delenv("LITELLM_LOG", raising=False)
+    caplog.set_level(logging.NOTSET, logger="LiteLLM")  # untouched; restored
     gated = logging.getLogger("LiteLLM")
-    gated.setLevel(logging.WARNING)
     local_chat._openai_model("chat", "openrouter/z-ai/not-in-the-map")
-    assert gated.getEffectiveLevel() == logging.ERROR
+    assert gated.level == logging.ERROR
     assert not gated.isEnabledFor(logging.WARNING)
-    monkeypatch.setenv("LITELLM_LOG", "DEBUG")
-    gated.setLevel(logging.WARNING)
+    gated.setLevel(logging.WARNING)  # the host's own choice
     local_chat._openai_model("chat", "openrouter/z-ai/not-in-the-map")
-    assert gated.getEffectiveLevel() == logging.WARNING
+    assert gated.level == logging.WARNING
 
 
 def test_provider_lookups_flip_the_switch_before_asking(monkeypatch, capsys):
@@ -2703,21 +2702,18 @@ def test_provider_lookups_flip_the_switch_before_asking(monkeypatch, capsys):
     assert "Provider List" not in capsys.readouterr().out
 
 
-def test_quiet_litellm_honors_a_quieter_level(monkeypatch):
-    """A caller asking for less than ERROR via LITELLM_LOG gets that level,
-    not the WARNING chatter the gate exists to remove."""
+def test_quiet_litellm_honors_the_chosen_default(monkeypatch, caplog):
+    """LITELLM_LOG picks the default in both directions: CRITICAL quiets
+    further than the gate, DEBUG opens litellm up."""
     pytest.importorskip("litellm")
     import logging
     from pageindex.utils import _quiet_litellm
-    monkeypatch.setenv("LITELLM_LOG", "CRITICAL")
     gated = logging.getLogger("LiteLLM")
-    prior = gated.level
-    gated.setLevel(logging.WARNING)
-    try:
+    for chosen in (logging.CRITICAL, logging.DEBUG):
+        monkeypatch.setenv("LITELLM_LOG", logging.getLevelName(chosen))
+        caplog.set_level(logging.NOTSET, logger="LiteLLM")
         _quiet_litellm()
-        assert gated.getEffectiveLevel() == logging.CRITICAL
-    finally:
-        gated.setLevel(prior)
+        assert gated.level == chosen
 
 
 def test_openai_protocol_predicate_follows_litellm_routing():

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2690,6 +2690,36 @@ def test_litellm_lane_gates_litellm_logging(monkeypatch):
     assert gated.getEffectiveLevel() == logging.WARNING
 
 
+def test_provider_lookups_flip_the_switch_before_asking(monkeypatch, capsys):
+    """The lane asks litellm which provider serves a model before the
+    model is built, and openai_agent_config asks with no model built at
+    all; a failed ask print()s the banner, so the switch flips at the ask."""
+    litellm = pytest.importorskip("litellm")
+    for lookup in (local_chat._openai_protocol,
+                   local_chat._litellm_claude_marks):
+        monkeypatch.setattr(litellm, "suppress_debug_info", False)
+        assert not lookup("z-ai/not-in-the-map")
+        assert litellm.suppress_debug_info is True
+    assert "Provider List" not in capsys.readouterr().out
+
+
+def test_quiet_litellm_honors_a_quieter_level(monkeypatch):
+    """A caller asking for less than ERROR via LITELLM_LOG gets that level,
+    not the WARNING chatter the gate exists to remove."""
+    pytest.importorskip("litellm")
+    import logging
+    from pageindex.utils import _quiet_litellm
+    monkeypatch.setenv("LITELLM_LOG", "CRITICAL")
+    gated = logging.getLogger("LiteLLM")
+    prior = gated.level
+    gated.setLevel(logging.WARNING)
+    try:
+        _quiet_litellm()
+        assert gated.getEffectiveLevel() == logging.CRITICAL
+    finally:
+        gated.setLevel(prior)
+
+
 def test_openai_protocol_predicate_follows_litellm_routing():
     pytest.importorskip("litellm")
     for name in ("gpt-5", "openai/gpt-4o", "litellm/gpt-4o",

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2672,19 +2672,16 @@ def test_litellm_lane_mutes_the_provider_list_banner(monkeypatch, capsys):
 
 @needs_agents
 def test_litellm_lane_gates_litellm_logging(monkeypatch, caplog):
-    """litellm's own logger sprays WARNING chatter (remote-map fetch
-    fallbacks, cost hiccups) onto stderr from inside requests; building
-    the lane's model gates it to ERROR — as a default only: a level the
-    host set itself stays the host's."""
+    """The lane defaults litellm's logger to ERROR; a level the host set stays."""
     pytest.importorskip("litellm")
     import logging
     monkeypatch.delenv("LITELLM_LOG", raising=False)
-    caplog.set_level(logging.NOTSET, logger="LiteLLM")  # untouched; restored
+    caplog.set_level(logging.NOTSET, logger="LiteLLM")  # untouched
     gated = logging.getLogger("LiteLLM")
     local_chat._openai_model("chat", "openrouter/z-ai/not-in-the-map")
     assert gated.level == logging.ERROR
     assert not gated.isEnabledFor(logging.WARNING)
-    gated.setLevel(logging.WARNING)  # the host's own choice
+    gated.setLevel(logging.WARNING)
     local_chat._openai_model("chat", "openrouter/z-ai/not-in-the-map")
     assert gated.level == logging.WARNING
 
@@ -2703,8 +2700,7 @@ def test_provider_lookups_flip_the_switch_before_asking(monkeypatch, capsys):
 
 
 def test_quiet_litellm_honors_the_chosen_default(monkeypatch, caplog):
-    """LITELLM_LOG picks the default in both directions: CRITICAL quiets
-    further than the gate, DEBUG opens litellm up."""
+    """LITELLM_LOG picks the default, in both directions."""
     pytest.importorskip("litellm")
     import logging
     from pageindex.utils import _quiet_litellm

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -138,3 +138,18 @@ def test_import_leaves_litellm_env_untouched(tmp_path):
     out = subprocess.run([sys.executable, "-c", probe], env=env,
                          capture_output=True, text=True, check=True)
     assert out.stdout.strip() == "ok"
+
+
+def test_utils_import_keeps_litellm_off_the_network():
+    """utils' import sets litellm's no-fetch default; an explicit choice wins."""
+    probe = ("import os, pageindex.utils; "
+             "print(os.environ['LITELLM_LOCAL_MODEL_COST_MAP'])")
+    env = {k: v for k, v in os.environ.items()
+           if k != "LITELLM_LOCAL_MODEL_COST_MAP"}
+    fresh = subprocess.run([sys.executable, "-c", probe], env=env,
+                           capture_output=True, text=True, check=True)
+    assert fresh.stdout.strip() == "True"
+    env["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+    chosen = subprocess.run([sys.executable, "-c", probe], env=env,
+                            capture_output=True, text=True, check=True)
+    assert chosen.stdout.strip() == "False"

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -140,6 +140,21 @@ def test_import_leaves_litellm_env_untouched(tmp_path):
     assert out.stdout.strip() == "ok"
 
 
+def test_chat_module_stamps_before_it_imports_litellm():
+    """local_chat imports litellm without utils on its import path; the
+    stamp has to be in place by then anyway."""
+    probe = ("import os\n"
+             "from pageindex import local_chat\n"
+             "local_chat._default_max_tokens('claude-sonnet-4-5',"
+             " {'budget_tokens': 4096})\n"
+             "print(os.environ.get('LITELLM_LOCAL_MODEL_COST_MAP'))\n")
+    env = {k: v for k, v in os.environ.items()
+           if k != "LITELLM_LOCAL_MODEL_COST_MAP"}
+    out = subprocess.run([sys.executable, "-c", probe], env=env,
+                         capture_output=True, text=True, check=True)
+    assert out.stdout.strip() == "True"
+
+
 def test_utils_import_keeps_litellm_off_the_network():
     """utils' import sets litellm's no-fetch default; an explicit choice wins."""
     probe = ("import os, pageindex.utils; "


### PR DESCRIPTION
Lands the litellm terminal-noise follow-ups reviewed on `fix/litellm-warning` (review view: #458). Seven commits, cherry-picked onto current `main`.

### What changes

**The banner switch flips where the lookup happens.** `_openai_agent` asks LiteLLM which provider serves a model twice before building the model, and `openai_agent_config` asks with no model built at all. A failed lookup `print()`s the red "Provider List:" banner into stdout, mid-answer. `_quiet_litellm()` now runs at both `get_llm_provider` call sites, so every lane is covered.

**Quieting litellm's loggers is a default, not a clamp.** `_quiet_litellm()` used to set the four litellm loggers to ERROR on every call, overriding whatever the host application, `litellm._turn_on_debug()`, or `LITELLM_LOG=DEBUG` had set. It now sets a level only while a logger is still `NOTSET`. Unset stays ERROR as before; anything set explicitly wins, and there is no per-call `setLevel` churn.

**The no-fetch default covers every lane.** `LITELLM_LOCAL_MODEL_COST_MAP` moved from the client's preload to `utils`' module scope. The CLI pipeline and `openai_agent_config`/`anthropic_runner_config` on a managed cloud client never run that preload, so they fetched litellm's model cost map over the network on first import, and printed a warning when offline. `run_pageindex.py` no longer needs its own copy of the stamp.

**The thinking-budget ceiling stopped outrunning the stamp.** `_default_max_tokens`, reached from `anthropic_runner_config` and `messages()`, imported litellm with no `utils` on its import path. On a managed cloud client that meant a remote cost-map fetch, measured at 3517 entries against the bundled 2982.

**`LITELLM_LOG=ERROR` is no longer stamped into the environment.** It pinned litellm's stderr handler at ERROR for the whole process, disabling `litellm._turn_on_debug()` for good, while the logger level was what actually gated the chatter. Output verified identical with and without it across plain, logging-configured, and debug hosts.

**The retry notice only fires when a retry follows** (an off-by-one inherited from the old `print`).

### Verification

- 481 tests pass; the without-frameworks leg passes.
- Every public surface that can reach litellm was checked in a fresh process for whether `pageindex.utils` was loaded before litellm's first import: managed-cloud and own-model `openai_agent_config` and `anthropic_runner_config`, the chat lane's model and protocol lookups, the thinking-budget ceiling, CLI token counting, and `run_pageindex.py` offline. All report the local cost map. The remaining managed-cloud surfaces never import litellm at all.
- New assertions were red-verified against the pre-change code.
- An explicit `LITELLM_LOCAL_MODEL_COST_MAP` wins from both the shell and `.env`.
- Malformed `LITELLM_LOG` values raise exactly as they did before.

https://claude.ai/code/session_01CrSg9uRBvzVujNyU25Wmgk
