### PR TITLE
docs: the chart images load by absolute URL so PyPI renders them

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Building a tree locally runs **about $0.001 per page** with `gpt-5.6-luna` as th
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-cost-dark.png">
-  <img src="assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-cost-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-cost-light.png" width="75%" alt="Indexing cost against document length, log-log, for nine PDFs from 9 to 1,098 pages. Points track a $0.0011-per-page reference line; the spread around it is text density, not length.">
 </picture>
 </div>
 
@@ -128,8 +128,8 @@ Indexing time also scales predictably with document length. In the same local se
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/index-time-dark.png">
-  <img src="assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-time-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/index-time-light.png" width="75%" alt="Indexing time against document length, log-log, for nine PDFs from 9 to 1,098 pages. The measured indexing times range from about 13 seconds to 4.5 minutes and increase predictably with document length.">
 </picture>
 </div>
 
@@ -141,8 +141,8 @@ Indexing time also scales predictably with document length. In the same local se
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/results-dark.png">
-  <img src="assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/results-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/results-light.png" width="75%" alt="Accuracy against average cost per question. Each model forms a near-vertical reasoning-effort ladder; moving between models costs an order of magnitude a step.">
 </picture>
 </div>
 
@@ -155,8 +155,8 @@ The alternative to retrieval is handing the model the whole PDF on every questio
 
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/query-cost-dark.png">
-  <img src="assets/query-cost-light.png" width="75%" alt="Cost per query relative to PageIndex retrieval, for five PDFs from 52 to 805 pages. Passing the PDF natively costs 2.1x, 3.4x, 7.8x, and 16.6x more at 52, 85, 198, and 420 pages; at 805 pages it exceeds the model's context window.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/query-cost-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/query-cost-light.png" width="75%" alt="Cost per query relative to PageIndex retrieval, for five PDFs from 52 to 805 pages. Passing the PDF natively costs 2.1x, 3.4x, 7.8x, and 16.6x more at 52, 85, 198, and 420 pages; at 805 pages it exceeds the model's context window.">
 </picture>
 </div>
 
@@ -167,8 +167,8 @@ PageIndex reached a state-of-the-art [**98.7% accuracy**](https://vectify.ai/blo
 <div align="center">
 <a href="https://github.com/VectifyAI/Mafin2.5-FinanceBench">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/financebench-dark.png">
-  <img src="assets/financebench-light.png" width="70%" alt="FinanceBench accuracy: PageIndex 98.7%, vector RAG 50%.">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/financebench-dark.png">
+  <img src="https://raw.githubusercontent.com/VectifyAI/PageIndex/main/assets/financebench-light.png" width="70%" alt="FinanceBench accuracy: PageIndex 98.7%, vector RAG 50%.">
 </picture>
 </a>
 </div>


### PR DESCRIPTION
`pyproject.toml` publishes `README.md` as the PyPI description, and PyPI does not resolve a relative path against the GitHub repo. The five charts reference `assets/*.png` relatively, so they render as broken images on the project page — verified against the live 0.2.14 description, which carries all ten relative references.

Every chart now loads from `raw.githubusercontent.com`. The ten other images in the file were already absolute, so this makes the last five consistent rather than adding an exception.

Two things worth knowing:

- PyPI's sanitizer drops `<source>` entirely (verified with `readme_renderer`, the library PyPI itself uses), so only the `<img>` fallbacks decide what shows there — PyPI gets the light chart either way, and dark mode is not recoverable through link changes. The `srcset` URLs change too, so GitHub's dark variants stay spelled the same way as their light siblings.
- The URLs name the `main` branch, so the charts track `main`: replacing an image later also changes it on already-published PyPI pages. Pinning a tag would avoid that at the cost of an edit every release.

Verification: all ten URLs return 200; rendering the new README through `readme_renderer` leaves zero relative `<img src>` (was five); the file is byte-identical to `main` apart from those ten addresses, and the `<picture>` / `<source>` / `<img>` counts are unchanged, so GitHub rendering is untouched.

Supersedes #444, which did this before the query-cost chart was added and was closed with a note about indexing behaviour that does not apply to a README image change.
