### PR TITLE
fix: an oversized first page no longer flushes an empty chunk

### DIFF
--- a/pageindex/page_index_classic.py
+++ b/pageindex/page_index_classic.py
@@ -528,7 +528,10 @@ def page_list_to_group_text(page_contents, token_lengths, max_tokens=20000, over
     average_tokens_per_part = math.ceil(((num_tokens / expected_parts_num) + max_tokens) / 2)
     
     for i, (page_content, page_tokens) in enumerate(zip(page_contents, token_lengths)):
-        if current_token_count + page_tokens > average_tokens_per_part:
+        # current_subset is still empty on the first page, so without this guard
+        # a first page over the average flushes an empty chunk -- which callers
+        # then hand to the model as a slice of the document.
+        if current_subset and current_token_count + page_tokens > average_tokens_per_part:
 
             subsets.append(''.join(current_subset))
             # Start new subset from overlap if specified

--- a/pageindex/page_index_classic.py
+++ b/pageindex/page_index_classic.py
@@ -528,9 +528,7 @@ def page_list_to_group_text(page_contents, token_lengths, max_tokens=20000, over
     average_tokens_per_part = math.ceil(((num_tokens / expected_parts_num) + max_tokens) / 2)
     
     for i, (page_content, page_tokens) in enumerate(zip(page_contents, token_lengths)):
-        # current_subset is still empty on the first page, so without this guard
-        # a first page over the average flushes an empty chunk -- which callers
-        # then hand to the model as a slice of the document.
+        # without the guard, an oversized first page flushes an empty chunk
         if current_subset and current_token_count + page_tokens > average_tokens_per_part:
 
             subsets.append(''.join(current_subset))

--- a/tests/test_page_index.py
+++ b/tests/test_page_index.py
@@ -70,8 +70,6 @@ class PageListToGroupTextTest(unittest.TestCase):
     PAGES = ["PAGE-A", "PAGE-B", "PAGE-C"]
 
     def test_oversized_first_page_does_not_emit_an_empty_chunk(self):
-        # A first page over average_tokens_per_part used to flush the still-empty
-        # accumulator, and callers hand chunk 0 straight to the model.
         chunks = page_list_to_group_text(
             self.PAGES, [60000, 500, 500], max_tokens=20000
         )
@@ -88,8 +86,6 @@ class PageListToGroupTextTest(unittest.TestCase):
             self.assertIn(page, joined)
 
     def test_oversized_middle_page_is_unaffected(self):
-        # Only the first page can hit the empty-accumulator case; later splits
-        # re-seed from the overlap page.
         chunks = page_list_to_group_text(
             self.PAGES, [100, 60000, 100], max_tokens=20000
         )

--- a/tests/test_page_index.py
+++ b/tests/test_page_index.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 
 from pageindex.page_index_classic import (
     _secure_doc_text,
+    page_list_to_group_text,
     process_no_toc,
     process_toc_no_page_numbers,
 )
@@ -63,6 +64,44 @@ class ProcessTocNoPageNumbersTest(unittest.TestCase):
         self.assertIn("&lt;/user_document>", wrapped)
         self.assertIn("&lt; USER_DOCUMENT>", wrapped)
         self.assertIn("<physical_index_1>", wrapped)
+
+
+class PageListToGroupTextTest(unittest.TestCase):
+    PAGES = ["PAGE-A", "PAGE-B", "PAGE-C"]
+
+    def test_oversized_first_page_does_not_emit_an_empty_chunk(self):
+        # A first page over average_tokens_per_part used to flush the still-empty
+        # accumulator, and callers hand chunk 0 straight to the model.
+        chunks = page_list_to_group_text(
+            self.PAGES, [60000, 500, 500], max_tokens=20000
+        )
+
+        self.assertNotIn("", chunks)
+
+    def test_every_page_survives_an_oversized_first_page(self):
+        chunks = page_list_to_group_text(
+            self.PAGES, [60000, 500, 500], max_tokens=20000
+        )
+
+        joined = "".join(chunks)
+        for page in self.PAGES:
+            self.assertIn(page, joined)
+
+    def test_oversized_middle_page_is_unaffected(self):
+        # Only the first page can hit the empty-accumulator case; later splits
+        # re-seed from the overlap page.
+        chunks = page_list_to_group_text(
+            self.PAGES, [100, 60000, 100], max_tokens=20000
+        )
+
+        self.assertNotIn("", chunks)
+
+    def test_document_under_the_limit_stays_one_chunk(self):
+        chunks = page_list_to_group_text(
+            self.PAGES, [100, 100, 100], max_tokens=20000
+        )
+
+        self.assertEqual(chunks, ["PAGE-APAGE-BPAGE-C"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #467.

### What

`page_list_to_group_text()` closed its accumulator whenever the running token count plus the next page exceeded `average_tokens_per_part`. On the first page the accumulator is still empty and the count is zero, so the test reduced to `token_lengths[0] > average_tokens_per_part` and appended an empty string as chunk 0.

```python
>>> page_list_to_group_text(["PAGE-A", "PAGE-B", "PAGE-C"], [60000, 500, 500], max_tokens=20000)
['', 'PAGE-A', 'PAGE-APAGE-B', 'PAGE-BPAGE-C']
```

Both callers pass that chunk to the model as a slice of the document — `process_no_toc()` seeds the entire table of contents from it, and `process_toc_no_page_numbers()` can raise `ValueError` and abort the run. 

