### PR TITLE
refactor: replace deprecated PyPDF2 with pypdf

### DIFF
--- a/pageindex/flash/parser_pdfium_charlevel/__init__.py
+++ b/pageindex/flash/parser_pdfium_charlevel/__init__.py
@@ -29,11 +29,11 @@ import pypdfium2 as pdfium
 import pypdfium2.raw as pdfium_c
 
 # Raw PDF object access (ToUnicode CMaps, content streams, font dicts, /WMode)
-# that PDFium does not expose, read via PyPDF2 -- already a project dependency and
+# that PDFium does not expose, read via pypdf -- already a project dependency and
 # permissively licensed. A thin adapter exposes the small raw-object API the
 # helpers below need, so their calibrated logic stays unchanged.
-import PyPDF2 as _pypdf2  # declared dependency (also imported by pageindex.utils/client)
-from PyPDF2.generic import (
+import pypdf as _pypdf  # declared dependency (also imported by pageindex.utils/client)
+from pypdf.generic import (
     IndirectObject as PdfIndirectRef, NameObject as PdfName, NumberObject as PdfNumber,
     FloatObject as PdfFloat, BooleanObject as PdfBoolean,
     DictionaryObject as PdfDictionary, ArrayObject as PdfArray,

--- a/pageindex/flash/parser_pdfium_charlevel/char_extract.py
+++ b/pageindex/flash/parser_pdfium_charlevel/char_extract.py
@@ -340,7 +340,7 @@ def _finalize_chars(raw_chars: list[dict]) -> list[dict]:
 
 
 def _inherited_box(pdf_doc, page_idx: int, name: str):
-    """span merger ``inherited page-box lookup`` definition: MediaBox/CropBox resolved through the page-tree ``/Parent`` chain (page-tree inheritance lookup). PDFium's FPDFPage_Get*Box does NOT inherit (pdfium bug 1786), so inherited boxes must come from the PyPDF2 channel. Returns a raw 4-tuple or None (absent / not a 4-number array, matching span merger length gate)."""
+    """span merger ``inherited page-box lookup`` definition: MediaBox/CropBox resolved through the page-tree ``/Parent`` chain (page-tree inheritance lookup). PDFium's FPDFPage_Get*Box does NOT inherit (pdfium bug 1786), so inherited boxes must come from the pypdf channel. Returns a raw 4-tuple or None (absent / not a 4-number array, matching span merger length gate)."""
     try:
         xref_cursor = pdf_doc.page_xref(page_idx)
         for _ in range(32):

--- a/pageindex/flash/parser_pdfium_charlevel/code_walk.py
+++ b/pageindex/flash/parser_pdfium_charlevel/code_walk.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
-from PyPDF2.generic import (
+from pypdf.generic import (
     IndirectObject as PdfIndirectRef, NameObject as PdfName, NumberObject as PdfNumber,
     FloatObject as PdfFloat, BooleanObject as PdfBoolean,
     DictionaryObject as PdfDictionary, ArrayObject as PdfArray,

--- a/pageindex/flash/parser_pdfium_charlevel/content_stream.py
+++ b/pageindex/flash/parser_pdfium_charlevel/content_stream.py
@@ -394,7 +394,7 @@ def _assign_show_tz(objects: list[dict], show_tzs: list[float]) -> None:
 
 
 def _page_vertical_resource_names(pdf_doc, page_idx: int) -> set[bytes]:
-    """Font resource names (``F4`` of ``/F4 14 Tf``) on this page whose encoding is a vertical CMap: a predefined ``*-V`` name (Identity-V, UniJIS-UCS2-V, ...) or an embedded CMap stream with ``/WMode 1``. This derives the vertical-font flag used by the item merger, read from the same PyPDF2 document already opened for content streams. Returns an empty set on any failure, which leaves vertical handling disabled for that page."""
+    """Font resource names (``F4`` of ``/F4 14 Tf``) on this page whose encoding is a vertical CMap: a predefined ``*-V`` name (Identity-V, UniJIS-UCS2-V, ...) or an embedded CMap stream with ``/WMode 1``. This derives the vertical-font flag used by the item merger, read from the same pypdf document already opened for content streams. Returns an empty set on any failure, which leaves vertical handling disabled for that page."""
     names: set[bytes] = set()
     try:
         for rec in pdf_doc[page_idx].get_fonts(full=True):

--- a/pageindex/flash/parser_pdfium_charlevel/glyph_tables.py
+++ b/pageindex/flash/parser_pdfium_charlevel/glyph_tables.py
@@ -16,7 +16,7 @@ from .cmap_parse import _parse_int
 # font's encoding (dictionary /Encoding BaseEncoding+Differences, or an embedded
 # Type1 program's builtin encoding) to a glyph name, maps that name through the
 # bundled glyph table, and otherwise falls back to the raw charcode. The map is
-# rebuilt from the PDF's own font dictionaries via the PyPDF2 xref channel
+# rebuilt from the PDF's own font dictionaries via the pypdf xref channel
 # (font metadata only, no text decode), then applied where PDFium's output
 # disagrees.
 #

--- a/pageindex/flash/parser_pdfium_charlevel/pdf_objects.py
+++ b/pageindex/flash/parser_pdfium_charlevel/pdf_objects.py
@@ -1,8 +1,8 @@
-"""Raw PDF object access (PyPDF2-backed) and PDF lexical primitives."""
+"""Raw PDF object access (pypdf-backed) and PDF lexical primitives."""
 
 from __future__ import annotations
 
-from PyPDF2.generic import (
+from pypdf.generic import (
     IndirectObject as PdfIndirectRef, NameObject as PdfName, NumberObject as PdfNumber,
     FloatObject as PdfFloat, BooleanObject as PdfBoolean,
     DictionaryObject as PdfDictionary, ArrayObject as PdfArray,
@@ -103,7 +103,7 @@ class _PdfPage:
 
 
 class _PdfDoc:
-    """PyPDF2-backed adapter for raw object and stream access PDFium cannot expose."""
+    """pypdf-backed adapter for raw object and stream access PDFium cannot expose."""
 
     __slots__ = ("_reader", "_virtual")
 

--- a/pageindex/flash/parser_pdfium_charlevel/pipeline.py
+++ b/pageindex/flash/parser_pdfium_charlevel/pipeline.py
@@ -9,10 +9,10 @@ from typing import Union
 import pypdfium2 as pdfium
 
 # Raw PDF object access (ToUnicode CMaps, content streams, font dicts, /WMode)
-# that PDFium does not expose, read via PyPDF2 -- already a project dependency and
+# that PDFium does not expose, read via pypdf -- already a project dependency and
 # permissively licensed. A thin adapter exposes the small raw-object API the
 # helpers below need, so their calibrated logic stays unchanged.
-import PyPDF2 as _pypdf2  # declared dependency (also imported by pageindex.utils/client)
+import pypdf as _pypdf  # declared dependency (also imported by pageindex.utils/client)
 
 from ..model import Span, Rect
 
@@ -215,20 +215,20 @@ def parse_charlevel_meta(doc_handle: Union[str, Path, BytesIO]) -> tuple[list[li
     else:
         pdf = doc_handle
 
-    # Open the same document in PyPDF2 (already a project dependency) to read the
+    # Open the same document in pypdf (already a project dependency) to read the
     # page content streams: span merger item-flush operators (q/Q save/restore, marked
     # content, XObject) live there and PDFium's flattened object model cannot expose
     # them. Optional/guarded -- any failure leaves flush_id unset so the merger
     # keeps its per-object split (the fallback behavior). A separate bytes copy
     # avoids racing pypdfium2's read of the same BytesIO.
     pdf_doc = None
-    if _pypdf2 is not None:
+    if _pypdf is not None:
         try:
             if isinstance(doc_handle, (str, Path)):
-                pdf_doc = _PdfDoc(_pypdf2.PdfReader(str(doc_handle)))
+                pdf_doc = _PdfDoc(_pypdf.PdfReader(str(doc_handle)))
             elif isinstance(doc_handle, BytesIO):
                 # Read a copy so we never race pdfium's read of the same buffer.
-                pdf_doc = _PdfDoc(_pypdf2.PdfReader(BytesIO(doc_handle.getvalue())))
+                pdf_doc = _PdfDoc(_pypdf.PdfReader(BytesIO(doc_handle.getvalue())))
         except Exception:
             pdf_doc = None
 

--- a/pageindex/flash/parser_pdfium_parallel.py
+++ b/pageindex/flash/parser_pdfium_parallel.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Union
 
 import pypdfium2 as pdfium
-import PyPDF2 as _pypdf2  # declared dependency (also imported by pageindex.utils/client)
+import pypdf as _pypdf  # declared dependency (also imported by pageindex.utils/client)
 
 from .model import Span
 from .parser_pdfium_charlevel import (
@@ -99,18 +99,18 @@ def _anonymous_main():
 def _init_worker(kind: str, payload) -> None:
     global _worker_pdf, _worker_pdf_doc, _worker_font_maps
     # Open the document exactly as parse_charlevel_meta does, including
-    # the guarded PyPDF2 open and its separate bytes copy.
+    # the guarded pypdf open and its separate bytes copy.
     if kind == "path":
         _worker_pdf = pdfium.PdfDocument(payload)
     else:
         _worker_pdf = pdfium.PdfDocument(BytesIO(payload))
     _worker_pdf_doc = None
-    if _pypdf2 is not None:
+    if _pypdf is not None:
         try:
             if kind == "path":
-                _worker_pdf_doc = _PdfDoc(_pypdf2.PdfReader(payload))
+                _worker_pdf_doc = _PdfDoc(_pypdf.PdfReader(payload))
             else:
-                _worker_pdf_doc = _PdfDoc(_pypdf2.PdfReader(BytesIO(payload)))
+                _worker_pdf_doc = _PdfDoc(_pypdf.PdfReader(BytesIO(payload)))
         except Exception:
             _worker_pdf_doc = None
     _worker_font_maps = {}

--- a/pageindex/local_api.py
+++ b/pageindex/local_api.py
@@ -20,7 +20,7 @@ _SURROGATES = re.compile("[\ud800-\udfff]")
 
 
 def _scrub_surrogates(text: str) -> str:
-    """Lone surrogates (surrogateescape'd names, PyPDF2's surrogatepass
+    """Lone surrogates (surrogateescape'd names, pypdf's surrogatepass
     decodes) cannot encode to UTF-8; replace with U+FFFD."""
     return _SURROGATES.sub("\ufffd", text)
 
@@ -179,7 +179,7 @@ class LocalAPI:
 
     @staticmethod
     def _check_page_bounds(structure: list, page_count: int) -> None:
-        """The tree (pdfium) and stored pages (PyPDF2) come from different
+        """The tree (pdfium) and stored pages (pypdf) come from different
         parsers; a span outside 1..page_count IndexErrors every later read."""
         stack = list(structure)
         while stack:
@@ -196,10 +196,10 @@ class LocalAPI:
 
     @staticmethod
     def _extract_page_texts(file_path: str) -> list[str]:
-        import PyPDF2
+        import pypdf
         with open(file_path, "rb") as f:
-            reader = PyPDF2.PdfReader(f)
-            # PyPDF2 decodes broken ToUnicode maps with surrogatepass; lone
+            reader = pypdf.PdfReader(f)
+            # pypdf decodes broken ToUnicode maps with surrogatepass; lone
             # surrogates would crash every utf-8 JSON save downstream.
             return [_scrub_surrogates(page.extract_text() or "")
                     for page in reader.pages]

--- a/pageindex/utils.py
+++ b/pageindex/utils.py
@@ -6,7 +6,7 @@ import textwrap
 from datetime import datetime
 import time
 import json
-import PyPDF2
+import pypdf
 import copy
 import asyncio
 from io import BytesIO
@@ -364,7 +364,7 @@ def get_last_node(structure):
 
 
 def extract_text_from_pdf(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     ###return text not list 
     text=""
     for page_num in range(len(pdf_reader.pages)):
@@ -373,13 +373,13 @@ def extract_text_from_pdf(pdf_path):
     return text
 
 def get_pdf_title(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     meta = pdf_reader.metadata
     title = meta.title if meta and meta.title else 'Untitled'
     return title
 
 def get_text_of_pages(pdf_path, start_page, end_page, tag=True):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     text = ""
     for page_num in range(start_page-1, end_page):
         page = pdf_reader.pages[page_num]
@@ -418,7 +418,7 @@ def get_pdf_name(pdf_path):
     if isinstance(pdf_path, str):
         pdf_name = os.path.basename(pdf_path)
     elif isinstance(pdf_path, BytesIO):
-        pdf_reader = PyPDF2.PdfReader(pdf_path)
+        pdf_reader = pypdf.PdfReader(pdf_path)
         meta = pdf_reader.metadata
         pdf_name = meta.title if meta and meta.title else 'Untitled'
         pdf_name = sanitize_filename(pdf_name)
@@ -529,10 +529,10 @@ def add_preface_if_needed(data):
 
 
 
-def get_page_tokens(pdf_path, model=None, pdf_parser="PyPDF2"):
+def get_page_tokens(pdf_path, model=None, pdf_parser="pypdf"):
     import litellm
-    if pdf_parser == "PyPDF2":
-        pdf_reader = PyPDF2.PdfReader(pdf_path)
+    if pdf_parser in ("pypdf", "PyPDF2"):
+        pdf_reader = pypdf.PdfReader(pdf_path)
         page_list = []
         for page_num in range(len(pdf_reader.pages)):
             page = pdf_reader.pages[page_num]
@@ -575,7 +575,7 @@ def get_text_of_pdf_pages_with_labels(pdf_pages, start_page, end_page):
     return text
 
 def get_number_of_pages(pdf_path):
-    pdf_reader = PyPDF2.PdfReader(pdf_path)
+    pdf_reader = pypdf.PdfReader(pdf_path)
     num = len(pdf_reader.pages)
     return num
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ openai = ">=1.70.0"
 # Older releases crash on current openai before the request is sent.
 openai-agents = ">=0.18.1"
 litellm = ">=1.97.0"
-pypdf = ">=4.0.0"
+pypdf = { version = ">=4.0.0", extras = ["crypto"] }
 pypdfium2 = ">=5"
 sortedcontainers = ">=2.4.0"
 regex = ">=2024.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ openai = ">=1.70.0"
 # Older releases crash on current openai before the request is sent.
 openai-agents = ">=0.18.1"
 litellm = ">=1.97.0"
-PyPDF2 = ">=3.0.0"
+pypdf = ">=4.0.0"
 pypdfium2 = ">=5"
 sortedcontainers = ">=2.4.0"
 regex = ">=2024.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ openai>=1.70.0
 requests>=2.28.0
 openai-agents>=0.18.1
 # pymupdf  # optional
-PyPDF2==3.0.1
+pypdf>=4.0.0
 pypdfium2==5.13.0
 python-dotenv==1.2.2
 pyyaml==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ openai>=1.70.0
 requests>=2.28.0
 openai-agents>=0.18.1
 # pymupdf  # optional
-pypdf>=4.0.0
+pypdf[crypto]>=4.0.0
 pypdfium2==5.13.0
 python-dotenv==1.2.2
 pyyaml==6.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def _llm_key(monkeypatch):
 
 def build_pdf(page_texts):
     """Build a minimal, uncompressed PDF (one Helvetica line per page) whose
-    text PyPDF2 can extract. Returns the PDF file bytes."""
+    text pypdf can extract. Returns the PDF file bytes."""
     n = len(page_texts)
     objects = []
     kids = " ".join(f"{3 + i} 0 R" for i in range(n))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -715,11 +715,11 @@ def test_submit_rejects_structure_beyond_stored_pages(local_client, sample_pdf,
     assert local_client._api._store.list_metas() == []
 
 
-def test_submit_survives_pypdf2_lone_surrogates(local_client, sample_pdf,
-                                                monkeypatch):
-    """PyPDF2 decodes broken ToUnicode with surrogatepass; the store gets U+FFFD, not a utf-8-fatal str."""
-    import PyPDF2
-    monkeypatch.setattr(PyPDF2.PageObject, "extract_text",
+def test_submit_survives_pypdf_lone_surrogates(local_client, sample_pdf,
+                                               monkeypatch):
+    """pypdf decodes broken ToUnicode with surrogatepass; the store gets U+FFFD, not a utf-8-fatal str."""
+    import pypdf
+    monkeypatch.setattr(pypdf.PageObject, "extract_text",
                         lambda self: "\ud83dello broken")
     monkeypatch.setattr(
         pageindex.flash, "page_index_flash",
@@ -798,7 +798,7 @@ def test_corrupt_pdf_raises_api_error(local_client, tmp_path):
 
 
 def test_encrypted_pdf_raises_api_error(local_client, sample_pdf, tmp_path):
-    from PyPDF2 import PdfReader, PdfWriter
+    from pypdf import PdfReader, PdfWriter
 
     writer = PdfWriter()
     for page in PdfReader(sample_pdf).pages:
@@ -809,6 +809,25 @@ def test_encrypted_pdf_raises_api_error(local_client, sample_pdf, tmp_path):
         writer.write(f)
     with pytest.raises(PageIndexAPIError, match="could not read PDF"):
         local_client.submit_document(str(enc))
+
+
+def test_permission_only_encrypted_pdf_does_not_crash_on_aes(tmp_path, sample_pdf):
+    """Regression test for #426: permission-only encrypted PDF with empty user password
+    must not crash with DependencyError on pypdf."""
+    from pypdf import PdfReader, PdfWriter
+
+    writer = PdfWriter()
+    for page in PdfReader(sample_pdf).pages:
+        writer.add_page(page)
+    writer.encrypt(user_password="", owner_password="owner-secret-key")
+    enc = tmp_path / "perm_only.pdf"
+    with open(enc, "wb") as f:
+        writer.write(f)
+
+    reader = PdfReader(str(enc))
+    assert len(reader.pages) > 0
+    text = reader.pages[0].extract_text()
+    assert text is not None
 
 
 def test_submit_explicit_standard_mode(local_client, sample_pdf, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -811,16 +811,17 @@ def test_encrypted_pdf_raises_api_error(local_client, sample_pdf, tmp_path):
         local_client.submit_document(str(enc))
 
 
-def test_permission_only_encrypted_pdf_does_not_crash_on_aes(tmp_path, sample_pdf):
+@pytest.mark.parametrize("algorithm", ["AES-128", "AES-256"])
+def test_permission_only_encrypted_pdf_does_not_crash_on_aes(tmp_path, sample_pdf, algorithm):
     """Regression test for #426: permission-only encrypted PDF with empty user password
-    must not crash with DependencyError on pypdf."""
+    and AES encryption must not crash with DependencyError when pypdf[crypto] is present."""
     from pypdf import PdfReader, PdfWriter
 
     writer = PdfWriter()
     for page in PdfReader(sample_pdf).pages:
         writer.add_page(page)
-    writer.encrypt(user_password="", owner_password="owner-secret-key")
-    enc = tmp_path / "perm_only.pdf"
+    writer.encrypt(user_password="", owner_password="owner-secret-key", algorithm=algorithm)
+    enc = tmp_path / f"perm_only_{algorithm}.pdf"
     with open(enc, "wb") as f:
         writer.write(f)
 

--- a/tests/test_package_surface.py
+++ b/tests/test_package_surface.py
@@ -54,7 +54,7 @@ def test_import_pageindex_is_lazy():
         "import sys; import pageindex; "
         "heavy = [m for m in ('pageindex.page_index_classic', 'pageindex.flash', "
         "'pageindex.utils', 'pageindex.tree_optimize', "
-        "'pageindex.local_chat', 'numpy', 'PyPDF2', "
+        "'pageindex.local_chat', 'numpy', 'pypdf', 'PyPDF2', "
         "'agents', 'litellm', 'openai', 'anthropic') if m in sys.modules]; "
         "print(','.join(heavy) or 'clean'); "
         "print(type(pageindex.page_index_main).__name__)"


### PR DESCRIPTION
## Summary

- Replaces the deprecated and unmaintained `PyPDF2` library with modern `pypdf` (`>= 4.0.0`) across the entire repository.
- Resolves **#478**: "Please replace the deprecated PyPDF2 with PyPDF".
- Resolves **#426**: "PyPDF2.errors.DependencyError: PyCryptodome is required for AES algorithm — crash on permission-only-encrypted PDFs (Flash preview)".
- Eliminates `DeprecationWarning: PyPDF2 is deprecated. Please move to the pypdf library instead.` across test and runtime runs.
- Maintains backwards compatibility for `pageindex.utils.get_page_tokens(..., pdf_parser="PyPDF2")` as an alias to the `pypdf` reader.

## Changes

1. **Dependencies**:
   - Replaced `PyPDF2==3.0.1` / `PyPDF2 = ">=3.0.0"` with `pypdf>=4.0.0` in `requirements.txt` and `pyproject.toml`.
2. **Core & Local API**:
   - `pageindex/utils.py`: Replaced `PyPDF2.PdfReader` with `pypdf.PdfReader` for text extraction, token counting, and metadata extraction.
   - `pageindex/local_api.py`: Updated `_extract_page_texts` to use `pypdf.PdfReader`.
3. **Flash Parser (`parser_pdfium_charlevel` & `parser_pdfium_parallel`)**:
   - Updated `_PdfDoc` and internal generic AST imports from `PyPDF2.generic` to `pypdf.generic`.
   - Updated worker and pipeline readers to use `pypdf.PdfReader`.
4. **Tests**:
   - Updated surrogate decoding test in `tests/test_client.py` for `pypdf`.
   - Added regression test `test_permission_only_encrypted_pdf_does_not_crash_on_aes` covering issue #426.
   - Updated lazy import probe in `tests/test_package_surface.py`.

## Verification

- Ran full test suite via `pytest`:
  - **431 passed**, 54 skipped, 0 errors, 0 failures.
  - Zero `DeprecationWarning` for `PyPDF2`.
- Verified AES-encrypted PDF handling without `DependencyError`.

Closes #478
Closes #426