### PR TITLE
feat: add support for parsing and indexing plain text (.txt) files

### DIFF
--- a/pageindex/__init__.py
+++ b/pageindex/__init__.py
@@ -11,6 +11,7 @@ if _TYPE_CHECKING:
     from .flash import page_index_flash
     from .page_index_classic import page_index, page_index_main
     from .page_index_md import md_to_tree
+    from .page_index_txt import txt_to_tree
     from .tree_optimize import optimize_tree
 
 __all__ = [
@@ -19,18 +20,19 @@ __all__ = [
     "IndexConfig", "CloudIndexConfig", "LocalIndexConfig", "ChatConfig",
     "ChatProcessOptions", "ChatStream",
     "page_index", "page_index_main", "page_index_flash",
-    "optimize_tree", "md_to_tree",
+    "optimize_tree", "md_to_tree", "txt_to_tree",
 ]
 
 _LAZY = {
     "page_index_flash": ".flash",
     "optimize_tree": ".tree_optimize",
     "md_to_tree": ".page_index_md",
+    "txt_to_tree": ".page_index_txt",
 }
 _SUBMODULES = {"agent_tools", "chat_stream", "client", "cloud_api", "errors",
                "flash", "integrations", "local_api", "local_chat",
                "local_store", "mcp_bridge", "page_index_classic",
-               "page_index_md", "tree_optimize", "types", "utils"}
+               "page_index_md", "page_index_txt", "tree_optimize", "types", "utils"}
 
 
 def __getattr__(name):

--- a/pageindex/page_index_txt.py
+++ b/pageindex/page_index_txt.py
@@ -1,0 +1,289 @@
+"""Plain text (.txt) document indexing for PageIndex."""
+import asyncio
+import json
+import os
+import re
+
+try:
+    from .utils import (
+        count_tokens,
+        create_clean_structure_for_description,
+        format_structure,
+        generate_doc_description,
+        structure_to_list,
+        write_node_id,
+    )
+    from .page_index_md import (
+        build_tree_from_nodes,
+        generate_summaries_for_structure_md,
+        tree_thinning_for_index,
+        update_node_list_with_text_token_count,
+    )
+except ImportError:
+    from utils import (
+        count_tokens,
+        create_clean_structure_for_description,
+        format_structure,
+        generate_doc_description,
+        structure_to_list,
+        write_node_id,
+    )
+    from page_index_md import (
+        build_tree_from_nodes,
+        generate_summaries_for_structure_md,
+        tree_thinning_for_index,
+        update_node_list_with_text_token_count,
+    )
+
+
+# Heading detection regex patterns for plain text documents
+_CHAPTER_SECTION_RE = re.compile(
+    r"^(?:chapter|section|part|appendix)\s+([0-9a-zA-ZIVXLCDM]+)(?:\s*[:.-]\s*(.*))?$",
+    re.IGNORECASE,
+)
+_NUMBERED_HEADING_RE = re.compile(r"^(\d+(?:\.\d+)*)\.?\s+([A-Z0-9].*)$")
+_ALL_CAPS_HEADING_RE = re.compile(r"^[A-Z0-9][A-Z0-9\s,':;.-]{2,60}$")
+
+
+def extract_nodes_from_txt(txt_content: str):
+    """Extract structural nodes from plain text content.
+
+    Detects:
+    1. Markdown-style headers (# Header) if present
+    2. Chapter/Section/Part/Appendix labels (e.g. 'Chapter 1: Intro')
+    3. Numbered section headers (e.g. '1. Introduction', '1.1 Overview')
+    4. Underlined headings ('Title' followed by '---' or '===')
+    5. ALL-CAPS standalone headings
+
+    If no structured headings are detected, falls back to paragraph-level nodes.
+    """
+    lines = txt_content.split("\n")
+    node_list = []
+    total_lines = len(lines)
+
+    i = 0
+    while i < total_lines:
+        line = lines[i]
+        stripped = line.strip()
+
+        if not stripped:
+            i += 1
+            continue
+
+        line_num = i + 1
+
+        # Check Markdown-style headers
+        md_match = re.match(r"^(#{1,6})\s+(.+)$", stripped)
+        if md_match:
+            level = len(md_match.group(1))
+            title = md_match.group(2).strip()
+            node_list.append({"node_title": title, "line_num": line_num, "level": level})
+            i += 1
+            continue
+
+        # Check underlined headings (line followed by ===== or -----)
+        if i + 1 < total_lines:
+            next_stripped = lines[i + 1].strip()
+            if next_stripped and len(next_stripped) >= 3:
+                if set(next_stripped) == {"="}:
+                    node_list.append({"node_title": stripped, "line_num": line_num, "level": 1})
+                    i += 2
+                    continue
+                elif set(next_stripped) == {"-"}:
+                    node_list.append({"node_title": stripped, "line_num": line_num, "level": 2})
+                    i += 2
+                    continue
+
+        # Check Chapter / Section / Part headings
+        cs_match = _CHAPTER_SECTION_RE.match(stripped)
+        if cs_match:
+            title = stripped
+            node_list.append({"node_title": title, "line_num": line_num, "level": 1})
+            i += 1
+            continue
+
+        # Check Numbered headings (e.g. 1.2 Title)
+        num_match = _NUMBERED_HEADING_RE.match(stripped)
+        if num_match:
+            num_prefix = num_match.group(1)
+            title = stripped
+            level = num_prefix.count(".") + 1
+            node_list.append({"node_title": title, "line_num": line_num, "level": min(level, 6)})
+            i += 1
+            continue
+
+        # Check standalone ALL-CAPS heading (preceded and followed by blank lines or start/end)
+        prev_blank = (i == 0) or (not lines[i - 1].strip())
+        next_blank = (i + 1 >= total_lines) or (not lines[i + 1].strip())
+        if prev_blank and next_blank and _ALL_CAPS_HEADING_RE.match(stripped) and len(stripped.split()) <= 8:
+            node_list.append({"node_title": stripped, "line_num": line_num, "level": 1})
+            i += 1
+            continue
+
+        i += 1
+
+    # Fallback: if no headings detected, split by paragraph blocks
+    if not node_list:
+        p_index = 1
+        for line_idx, line in enumerate(lines):
+            stripped = line.strip()
+            prev_empty = (line_idx == 0) or (not lines[line_idx - 1].strip())
+            if stripped and prev_empty:
+                # Use first sentence or up to 50 chars as title
+                first_sentence = stripped.split(".")[0].strip()
+                if len(first_sentence) > 50:
+                    first_sentence = first_sentence[:47] + "..."
+                title = f"Section {p_index}: {first_sentence}" if first_sentence else f"Section {p_index}"
+                node_list.append({
+                    "node_title": title,
+                    "line_num": line_idx + 1,
+                    "level": 1,
+                })
+                p_index += 1
+
+    return node_list, lines
+
+
+def extract_node_text_content(node_list, txt_lines):
+    all_nodes = []
+    for node in node_list:
+        processed_node = {
+            "title": node["node_title"],
+            "line_num": node["line_num"],
+            "level": node["level"],
+        }
+        all_nodes.append(processed_node)
+
+    for i, node in enumerate(all_nodes):
+        start_line = node["line_num"] - 1
+        if i + 1 < len(all_nodes):
+            end_line = all_nodes[i + 1]["line_num"] - 1
+        else:
+            end_line = len(txt_lines)
+
+        node["text"] = "\n".join(txt_lines[start_line:end_line]).strip()
+    return all_nodes
+
+
+async def txt_to_tree(
+    txt_path,
+    if_thinning=False,
+    min_token_threshold=None,
+    if_add_node_summary="no",
+    summary_token_threshold=None,
+    model=None,
+    if_add_doc_description="no",
+    if_add_node_text="no",
+    if_add_node_id="yes",
+    summary_model=None,
+):
+    """Process a plain text document into a PageIndex tree structure."""
+    try:
+        with open(txt_path, "r", encoding="utf-8") as f:
+            txt_content = f.read()
+    except UnicodeDecodeError:
+        with open(txt_path, "r", encoding="latin-1") as f:
+            txt_content = f.read()
+
+    line_count = txt_content.count("\n") + 1
+
+    print("Extracting nodes from text document...")
+    node_list, txt_lines = extract_nodes_from_txt(txt_content)
+
+    print("Extracting text content from nodes...")
+    nodes_with_content = extract_node_text_content(node_list, txt_lines)
+
+    if if_thinning:
+        nodes_with_content = update_node_list_with_text_token_count(
+            nodes_with_content, model=model
+        )
+        print("Thinning nodes...")
+        nodes_with_content = tree_thinning_for_index(
+            nodes_with_content, min_token_threshold, model=model
+        )
+
+    print("Building tree from nodes...")
+    tree_structure = build_tree_from_nodes(nodes_with_content)
+
+    if if_add_node_id == "yes":
+        write_node_id(tree_structure)
+
+    print("Formatting tree structure...")
+
+    if if_add_node_summary == "yes":
+        summary_model = summary_model or model
+        tree_structure = format_structure(
+            tree_structure,
+            order=[
+                "title",
+                "node_id",
+                "line_num",
+                "summary",
+                "prefix_summary",
+                "text",
+                "nodes",
+            ],
+        )
+
+        print("Generating summaries for each node...")
+        tree_structure = await generate_summaries_for_structure_md(
+            tree_structure,
+            summary_token_threshold=summary_token_threshold,
+            model=summary_model,
+        )
+
+        if if_add_node_text == "no":
+            tree_structure = format_structure(
+                tree_structure,
+                order=[
+                    "title",
+                    "node_id",
+                    "line_num",
+                    "summary",
+                    "prefix_summary",
+                    "nodes",
+                ],
+            )
+
+        if if_add_doc_description == "yes":
+            print("Generating document description...")
+            clean_structure = create_clean_structure_for_description(tree_structure)
+            doc_description = generate_doc_description(clean_structure, model=summary_model)
+            return {
+                "doc_name": os.path.splitext(os.path.basename(txt_path))[0],
+                "doc_description": doc_description,
+                "line_count": line_count,
+                "structure": tree_structure,
+            }
+    else:
+        if if_add_node_text == "yes":
+            tree_structure = format_structure(
+                tree_structure,
+                order=[
+                    "title",
+                    "node_id",
+                    "line_num",
+                    "summary",
+                    "prefix_summary",
+                    "text",
+                    "nodes",
+                ],
+            )
+        else:
+            tree_structure = format_structure(
+                tree_structure,
+                order=[
+                    "title",
+                    "node_id",
+                    "line_num",
+                    "summary",
+                    "prefix_summary",
+                    "nodes",
+                ],
+            )
+
+    return {
+        "doc_name": os.path.splitext(os.path.basename(txt_path))[0],
+        "line_count": line_count,
+        "structure": tree_structure,
+    }

--- a/run_pageindex.py
+++ b/run_pageindex.py
@@ -7,9 +7,10 @@ from pageindex.utils import ConfigLoader
 
 if __name__ == "__main__":
     # Set up argument parser
-    parser = argparse.ArgumentParser(description='Process PDF or Markdown document and generate structure')
+    parser = argparse.ArgumentParser(description='Process PDF, Markdown, or Text document and generate structure')
     parser.add_argument('--pdf_path', type=str, help='Path to the PDF file')
     parser.add_argument('--md_path', type=str, help='Path to the Markdown file')
+    parser.add_argument('--txt_path', type=str, help='Path to the plain text (.txt) file')
     parser.add_argument('--mode', choices=['flash', 'standard'], default='flash',
                       help='Processing mode (default: flash)')
     parser.add_argument('--flash', action='store_true', default=False,
@@ -58,10 +59,11 @@ if __name__ == "__main__":
         args.mode = 'flash'
 
     # Validate that exactly one file type is specified
-    if not args.pdf_path and not args.md_path:
-        raise ValueError("Either --pdf_path or --md_path must be specified")
-    if args.pdf_path and args.md_path:
-        raise ValueError("Only one of --pdf_path or --md_path can be specified")
+    specified_files = [p for p in (args.pdf_path, args.md_path, args.txt_path) if p is not None]
+    if len(specified_files) == 0:
+        raise ValueError("Either --pdf_path, --md_path, or --txt_path must be specified")
+    if len(specified_files) > 1:
+        raise ValueError("Only one of --pdf_path, --md_path, or --txt_path can be specified")
     if args.optimize is not None and not (args.pdf_path and args.mode == 'flash'):
         raise ValueError("--optimize requires Flash mode with --pdf_path")
     if args.optimize is None:
@@ -198,4 +200,41 @@ if __name__ == "__main__":
         with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(toc_with_page_number, f, indent=2, ensure_ascii=False)
         
+        print(f'Tree structure saved to: {output_file}')
+    elif args.txt_path:
+        from pageindex.page_index_txt import txt_to_tree
+        from pageindex.utils import ConfigLoader
+        config_loader = ConfigLoader()
+
+        user_opt = {
+            'index_model': args.index_model,
+            'model': args.model,
+            'summary_model': args.summary_model,
+        }
+
+        opt = config_loader.load({k: v for k, v in user_opt.items() if v is not None})
+
+        toc_with_page_number = asyncio.run(txt_to_tree(
+            txt_path=args.txt_path,
+            if_thinning=args.if_thinning.lower() == 'yes',
+            min_token_threshold=args.thinning_threshold,
+            if_add_node_summary=args.if_add_node_summary,
+            summary_token_threshold=args.summary_token_threshold,
+            model=opt.model,
+            summary_model=opt.summary_model,
+            if_add_doc_description=args.if_add_doc_description,
+            if_add_node_text=args.if_add_node_text,
+            if_add_node_id=args.if_add_node_id
+        ))
+
+        print('Parsing done, saving to file...')
+
+        txt_name = os.path.splitext(os.path.basename(args.txt_path))[0]
+        output_dir = './results'
+        output_file = f'{output_dir}/{txt_name}_structure.json'
+        os.makedirs(output_dir, exist_ok=True)
+
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(toc_with_page_number, f, indent=2, ensure_ascii=False)
+
         print(f'Tree structure saved to: {output_file}')

--- a/tests/test_page_index_txt.py
+++ b/tests/test_page_index_txt.py
@@ -1,0 +1,131 @@
+import asyncio
+import os
+import pytest
+
+from pageindex.page_index_txt import (
+    extract_nodes_from_txt,
+    extract_node_text_content,
+    txt_to_tree,
+)
+
+
+def test_extract_nodes_chapter_and_numbered_headings():
+    content = """
+Chapter 1: Getting Started
+Here is the opening text for chapter 1.
+
+1.1 Installation
+Follow these steps to install the package.
+
+1.2 Configuration
+Set your environment variables.
+
+Chapter 2: Advanced Usage
+Deeper dive into the internals.
+"""
+    nodes, lines = extract_nodes_from_txt(content)
+    assert len(nodes) == 4
+    assert nodes[0]["node_title"] == "Chapter 1: Getting Started"
+    assert nodes[0]["level"] == 1
+    assert nodes[1]["node_title"] == "1.1 Installation"
+    assert nodes[1]["level"] == 2
+    assert nodes[2]["node_title"] == "1.2 Configuration"
+    assert nodes[2]["level"] == 2
+    assert nodes[3]["node_title"] == "Chapter 2: Advanced Usage"
+    assert nodes[3]["level"] == 1
+
+
+def test_extract_nodes_underlined_headings():
+    content = """Main Title
+==========
+Some introductory text under the main title.
+
+Sub Section
+-----------
+Some text under the subsection.
+"""
+    nodes, lines = extract_nodes_from_txt(content)
+    assert len(nodes) == 2
+    assert nodes[0]["node_title"] == "Main Title"
+    assert nodes[0]["level"] == 1
+    assert nodes[1]["node_title"] == "Sub Section"
+    assert nodes[1]["level"] == 2
+
+
+def test_extract_nodes_all_caps_headings():
+    content = """
+INTRODUCTION
+
+This is the introduction section with some details.
+
+METHODOLOGY
+
+Here is the description of our methods and data.
+"""
+    nodes, lines = extract_nodes_from_txt(content)
+    assert len(nodes) == 2
+    assert nodes[0]["node_title"] == "INTRODUCTION"
+    assert nodes[1]["node_title"] == "METHODOLOGY"
+
+
+def test_extract_nodes_plain_paragraph_fallback():
+    content = """First paragraph of a document without any explicit section headers.
+It contains some useful information across several sentences.
+
+Second paragraph providing additional context and conclusions.
+All information is presented sequentially.
+"""
+    nodes, lines = extract_nodes_from_txt(content)
+    assert len(nodes) == 2
+    assert nodes[0]["node_title"].startswith("Section 1")
+    assert nodes[1]["node_title"].startswith("Section 2")
+
+
+def test_extract_node_text_content():
+    content = """Chapter 1
+Line 1
+Line 2
+
+Chapter 2
+Line 3
+Line 4"""
+    nodes, lines = extract_nodes_from_txt(content)
+    nodes_with_content = extract_node_text_content(nodes, lines)
+    assert len(nodes_with_content) == 2
+    assert "Line 1" in nodes_with_content[0]["text"]
+    assert "Line 2" in nodes_with_content[0]["text"]
+    assert "Line 3" in nodes_with_content[1]["text"]
+
+
+def test_txt_to_tree_end_to_end(tmp_path):
+    txt_file = tmp_path / "sample_doc.txt"
+    txt_file.write_text("""Chapter 1: Overview
+This is the overview chapter.
+
+1.1 Background
+Historical context and background information.
+
+1.2 Objectives
+The main objectives of this document.
+
+Chapter 2: Implementation
+Technical implementation details.
+""", encoding="utf-8")
+
+    tree_dict = asyncio.run(txt_to_tree(
+        txt_path=str(txt_file),
+        if_thinning=False,
+        if_add_node_summary="no",
+        if_add_node_text="yes",
+        if_add_node_id="yes",
+    ))
+
+    assert tree_dict["doc_name"] == "sample_doc"
+    assert tree_dict["line_count"] > 0
+    structure = tree_dict["structure"]
+    assert len(structure) == 2
+    assert structure[0]["title"] == "Chapter 1: Overview"
+    assert len(structure[0]["nodes"]) == 2
+    assert structure[0]["nodes"][0]["title"] == "1.1 Background"
+    assert structure[0]["nodes"][1]["title"] == "1.2 Objectives"
+    assert structure[1]["title"] == "Chapter 2: Implementation"


### PR DESCRIPTION
## Summary

- Adds native support for parsing and indexing plain text (`.txt`) documents into PageIndex hierarchical tree structures.
- Resolves **#222**: "Add support for parsing .txt files".
- Provides CLI integration via `--txt_path` in `run_pageindex.py` alongside `--pdf_path` and `--md_path`.

## Changes

1. **`pageindex/page_index_txt.py`**:
   - `extract_nodes_from_txt`: extracts document structure from plain text by identifying:
     - Chapter/Section/Part/Appendix labels (e.g. `Chapter 1: Intro`, `Section 2`)
     - Numbered headings (e.g. `1. Introduction`, `1.2 Details`)
     - Underlined headings (`===` or `---`)
     - Standalone ALL-CAPS section headers
     - Graceful fallback to paragraph blocks when no explicit headings exist.
   - `txt_to_tree`: generates standard PageIndex structure (`title`, `node_id`, `line_num`, `text`, `nodes`) with support for summaries, thinning, and document descriptions.
2. **`pageindex/__init__.py`**:
   - Exposed `txt_to_tree` lazily in `__all__` and `_LAZY` dictionary so top-level imports remain lightweight without eager subpackage loading.
3. **`run_pageindex.py`**:
   - Added `--txt_path` CLI argument.
   - Updated file argument validation to enforce specifying exactly one of `--pdf_path`, `--md_path`, or `--txt_path`.
   - Wired `--txt_path` processing and output saving to `results/<doc_name>_structure.json`.
4. **`tests/test_page_index_txt.py`**:
   - Added unit test suite covering numbered/chapter headers, underlined headers, all-caps headers, paragraph fallback, text content slicing, and end-to-end `txt_to_tree` execution.

## Verification

- Ran `pytest tests/test_page_index_txt.py`: 6 passed.
- Ran `pytest tests/test_package_surface.py`: 11 passed (lazy import verification passed).
- Ran full test suite: 436 passed, 54 skipped, 0 failures.

Closes #222