### PR TITLE
Review view: tool results as MCP content (frozen base 348231c)

### DIFF
--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -30,6 +30,7 @@ import weakref
 from typing import Any, Callable, Optional
 
 from .errors import PageIndexAPIError
+from .mcp_bridge import render_text
 
 TOOL_RESPONSE_CHAR_LIMIT = 100_000
 STRUCTURE_FIRST_PAGE_THRESHOLD = 20
@@ -1357,13 +1358,13 @@ def _annotation_for(spec: dict) -> Any:
 
 
 def _bridge_invoker(bridge, name: str, schema: dict,
-                    ) -> "Callable[[dict], tuple[str, bool]]":
+                    ) -> "Callable[[dict], tuple[list, bool]]":
     """One cloud tool call proxied over MCP: string booleans are coerced
     (same as call_tool), None-valued arguments are dropped (None ≡ omitted,
     matching the contract's "omit if ..." semantics) and failures are
     contained in the error envelope — except 401/403, which re-raise.
-    Returns (envelope_text, is_error), like call_tool."""
-    def _invoke(arguments: dict[str, Any]) -> tuple[str, bool]:
+    Returns (content blocks, is_error), like the bridge."""
+    def _invoke(arguments: dict[str, Any]) -> tuple[list, bool]:
         try:
             arguments = {key: value for key, value in arguments.items()
                          if value is not None}
@@ -1381,16 +1382,17 @@ def _bridge_invoker(bridge, name: str, schema: dict,
                                "try the request again"},
                 "INTERNAL_ERROR",
             )
-            return _dumps(payload), True
+            return [{"type": "text", "text": _dumps(payload)}], True
     return _invoke
 
 
 def _make_tool_function(name: str, description: str, schema: dict,
-                        invoke: "Callable[[dict], tuple[str, bool]]",
+                        invoke: "Callable[[dict], tuple[list, bool]]",
                         ) -> Callable[..., str]:
     """One plain function for a tool: real signature and docstring from the
-    schema, errors contained by the invoker; arguments the signature
-    rejects come back as the guided envelope instead of raising."""
+    schema, the result rendered as text, errors contained by the invoker;
+    arguments the signature rejects come back as the guided envelope
+    instead of raising."""
     import keyword
 
     properties: dict[str, Any] = schema.get("properties") or {}
@@ -1398,11 +1400,11 @@ def _make_tool_function(name: str, description: str, schema: dict,
     _invoke = invoke
 
     params_usable = all(param.isidentifier() and not keyword.iskeyword(param)
-                        and param != "_invoke"
+                        and param not in ("_invoke", "_render")
                         for param in properties)
     if not params_usable:
         def inner(**kwargs: Any) -> str:
-            return _invoke(kwargs)[0]
+            return render_text(_invoke(kwargs)[0])
     else:
         ordered = ([p for p in properties if p in required]
                    + [p for p in properties if p not in required])
@@ -1411,9 +1413,10 @@ def _make_tool_function(name: str, description: str, schema: dict,
             for p in ordered
         )
         args_literal = "{" + ", ".join(f"'{p}': {p}" for p in ordered) + "}"
-        namespace: dict[str, Any] = {"_invoke": _invoke}
+        namespace: dict[str, Any] = {"_invoke": _invoke,
+                                     "_render": render_text}
         exec(f"def _synthesized({rendered}):\n"
-             f"    return _invoke({args_literal})[0]", namespace)
+             f"    return _render(_invoke({args_literal})[0])", namespace)
         inner = namespace["_synthesized"]
         # binding TypeErrors quote __qualname__, not __name__
         inner.__name__ = inner.__qualname__ = name or "tool"
@@ -1499,11 +1502,12 @@ def _require_local_scope(client, doc_ids) -> None:
 
 
 def _tool_specs(client, include_management: bool = False, doc_ids=None,
-                ) -> "list[tuple[str, str, dict, Callable[[dict], tuple[str, bool]]]]":
+                ) -> "list[tuple[str, str, dict, Callable[[dict], tuple[list, bool]]]]":
     """(name, description, schema, invoke) per tool, for adapters that take
-    the wire schema verbatim. ``invoke`` returns (envelope_text, is_error).
-    Schemas are copies (frameworks keep the dict by reference). ``doc_ids``
-    is the local chat scope."""
+    the wire schema verbatim. ``invoke`` returns (content blocks, is_error):
+    the MCP content as the server sent it, one text block from the local
+    tools. Schemas are copies (frameworks keep the dict by reference).
+    ``doc_ids`` is the local chat scope."""
     _require_local_scope(client, doc_ids)
     if getattr(client, "api_key", None):
         bridge = _cloud_bridge(client, gated=not include_management)
@@ -1522,9 +1526,11 @@ def _tool_specs(client, include_management: bool = False, doc_ids=None,
                                  meta.get("inputSchema") or {}))
                 for meta in tools_meta]
 
-    def local_invoke(name: str) -> "Callable[[dict], tuple[str, bool]]":
-        def invoke(arguments: dict) -> tuple[str, bool]:
-            return call_tool(client, name, arguments, doc_ids=doc_ids)
+    def local_invoke(name: str) -> "Callable[[dict], tuple[list, bool]]":
+        def invoke(arguments: dict) -> tuple[list, bool]:
+            text, is_error = call_tool(client, name, arguments,
+                                       doc_ids=doc_ids)
+            return [{"type": "text", "text": text}], is_error
         return invoke
 
     return [(name, _local_description(name), _local_schema(name),
@@ -1539,7 +1545,8 @@ def build_agent_tools(client, include_management: bool = False,
     Cloud: one function per tool of the live cloud MCP tool set, signatures
     synthesized from the server's schemas, calls proxied over MCP. Local:
     the built-in contract tools over the local store. Every function returns
-    the JSON envelope as a string and never raises for arguments its
+    the JSON envelope as a string (binary content, such as a cloud page
+    image, as a size stub) and never raises for arguments its
     signature accepts — except a cloud 401/403, which re-raises
     PageIndexAPIError (cloud-only parameters are absent from the local
     signatures; the call_tool path answers them with the guided envelope).

--- a/pageindex/chat_stream.py
+++ b/pageindex/chat_stream.py
@@ -42,9 +42,10 @@ class ChatStream:
         """The run as typed event dicts: {"type": "thinking"|"answer",
         "delta": ...}, {"type": "tool_call", "call_id", "name",
         "arguments"}, {"type": "tool_result", "call_id", "name",
-        "output"} — full data, never clipped. Consuming — not merely
-        reading the attribute — claims the view, so debugger panes and
-        getattr probing stay side-effect free."""
+        "output"} — the result as the framework recorded it (a string,
+        or its structured text/image items), never clipped. Consuming —
+        not merely reading the attribute — claims the view, so debugger
+        panes and getattr probing stay side-effect free."""
         def consume():
             if isinstance(self._events, str):
                 raise PageIndexAPIError(self._events)

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1546,7 +1546,9 @@ class PageIndexClient:
         ``get_document_structure``, ``get_page_content``).
 
         Each function takes JSON-serializable arguments, returns a JSON
-        string, and reports failures inside that JSON instead of raising —
+        string (binary results such as ``get_document_image`` as a size
+        stub — a string cannot carry an image; the framework adapters
+        can), and reports failures inside that JSON instead of raising —
         except a cloud 401/403, which raises PageIndexAPIError.
 
         Args:
@@ -1571,11 +1573,12 @@ class PageIndexClient:
         call).
 
         Cloud (default): the full live read tool set (search, folders,
-        images — as enabled for your key) as plain function tools,
-        discovered from the PageIndex MCP server and executed from your
-        process — works with any model backend. Binary tool results
-        (e.g. ``get_document_image``) arrive as text placeholder stubs
-        on this in-process path. Pass ``hosted=True`` to
+        images — as enabled for your key) as function tools, discovered
+        from the PageIndex MCP server and executed from your process —
+        works with any model backend. The tools are the framework's own
+        MCP conversion, so results reach the model in its shapes: text
+        as text, images (e.g. ``get_document_image``) as images. Pass
+        ``hosted=True`` to
         hand the connection to OpenAI instead: one hosted MCP tool, tool
         calls executed server-side (lowest latency; requires an
         OpenAI-hosted model on the Responses API). The framework's own
@@ -1715,8 +1718,9 @@ class PageIndexClient:
         enabled for your key), discovered from the PageIndex MCP server
         and executed from your process; the server's input schemas pass
         through verbatim (MCP and the Messages API share the schema
-        shape), and binary tool results (e.g. ``get_document_image``)
-        arrive as text placeholder stubs on this in-process path. The
+        shape), and results are the Anthropic SDK's own MCP conversion:
+        content block lists, text as text and images (e.g.
+        ``get_document_image``) as image blocks. The
         server-side alternative is the Messages API's beta
         MCP connector — ``mcp_servers=[{"type": "url", "name":
         "pageindex", "url": f"{BASE_URL}/mcp?tools=read",

--- a/pageindex/integrations/anthropic_sdk.py
+++ b/pageindex/integrations/anthropic_sdk.py
@@ -7,6 +7,10 @@ the in-process tools — the same set chat(protocol="messages") runs
 internally. Failed
 calls raise ToolError so the runner emits the tool_result with
 ``is_error: true`` and the envelope as its content.
+
+Tool results are MCP content, rendered by the Anthropic SDK's own MCP
+conversion (text as text, images as image blocks); the SDK carries the
+MCP types and renders nothing.
 """
 from __future__ import annotations
 
@@ -21,12 +25,14 @@ def build_anthropic_tools(client, include_management: bool = False,
     try:
         from anthropic import beta_async_tool, beta_tool
         from anthropic.lib.tools import ToolError
+        from anthropic.lib.tools.mcp import mcp_content
     except ImportError as exc:
         raise PageIndexAPIError(
             "as_anthropic_tools requires the Anthropic SDK tool runner "
             "(anthropic>=0.108.0) — pip install -U anthropic (or pip install "
             "'pageindex[anthropic]')."
         ) from exc
+    from mcp.types import CallToolResult
     from ..agent_tools import _tool_specs
 
     def wrap(name, description, schema, invoke):
@@ -34,21 +40,24 @@ def build_anthropic_tools(client, include_management: bool = False,
         async runner each accept only their own kind, and the async variant
         moves the blocking bridge/store call into a worker thread so it
         never blocks the caller's event loop."""
-        def run(kwargs: dict) -> str:
-            text, is_error = invoke(kwargs)
+        def run(kwargs: dict) -> list:
+            blocks, is_error = invoke(kwargs)
+            result = CallToolResult.model_validate(
+                {"content": blocks, "isError": is_error})
+            content = [mcp_content(block) for block in result.content]
             if is_error:
-                raise ToolError(text)
-            return text
+                raise ToolError(content)
+            return content
 
         if asynchronous:
-            async def _afn(**kwargs: Any) -> str:
+            async def _afn(**kwargs: Any) -> list:
                 return await asyncio.to_thread(run, kwargs)
 
             _afn.__name__ = name
             return beta_async_tool(_afn, name=name, description=description,
                                    input_schema=schema)
 
-        def _fn(**kwargs: Any) -> str:
+        def _fn(**kwargs: Any) -> list:
             return run(kwargs)
 
         _fn.__name__ = name

--- a/pageindex/integrations/claude_agent_sdk.py
+++ b/pageindex/integrations/claude_agent_sdk.py
@@ -3,7 +3,8 @@
 Cloud clients get the remote PageIndex MCP config — the framework connects
 directly, and include_management picks the endpoint (the read-only
 ``?tools=read`` URL by default); local clients get an in-process SDK MCP
-server over the same tool contract, gated the same way at registration.
+server over the same tool contract, gated the same way at registration,
+its results passed through as the MCP content they are.
 """
 from __future__ import annotations
 
@@ -39,8 +40,8 @@ def build_claude_mcp(client, include_management: bool = False, doc_ids=None,
 
     def make_handler(invoke):
         async def handler(arguments: dict[str, Any]) -> dict[str, Any]:
-            text, is_error = await asyncio.to_thread(invoke, arguments or {})
-            result: dict[str, Any] = {"content": [{"type": "text", "text": text}]}
+            blocks, is_error = await asyncio.to_thread(invoke, arguments or {})
+            result: dict[str, Any] = {"content": blocks}
             if is_error:
                 result["is_error"] = True
             return result

--- a/pageindex/integrations/openai_agents.py
+++ b/pageindex/integrations/openai_agents.py
@@ -1,34 +1,79 @@
 """OpenAI Agents SDK adapter for the Agent(tools=...) slot.
 
-Cloud clients default to the live read tool set as plain FunctionTools via
-the MCP bridge; pass hosted=True to use a single HostedMCPTool instead
-(the model connects to the PageIndex cloud MCP server from OpenAI's side —
-the read-only ``?tools=read`` endpoint by default). Local clients get the
-in-process tools wrapped as FunctionTools. Tools are built as FunctionTool
-directly so the contract/server JSON schema goes to the model verbatim —
-function_tool() would regenerate it from a Python signature, dropping
-items/enum/pattern/bounds and rejecting object-typed parameters.
+Cloud clients default to the live read tool set via the MCP bridge; pass
+hosted=True to use a single HostedMCPTool instead (the model connects to
+the PageIndex cloud MCP server from OpenAI's side — the read-only
+``?tools=read`` endpoint by default). Local clients get the in-process
+tools.
+
+Either way the tool set reaches the framework as an MCP server (an
+in-process one over the bridge or the local store), and the FunctionTools
+are the framework's own conversion of it: the schema goes to the model
+verbatim, and tool results reach it in the framework's shapes (text as
+text, images as images). The SDK carries MCP types and renders nothing.
 """
 from __future__ import annotations
 
 import asyncio
-import json
-from typing import Any
 
 from ..errors import PageIndexAPIError
+
+
+def build_mcp_server(client, include_management: bool = False, doc_ids=None):
+    """The tool set as an in-process MCP server for the Agents SDK."""
+    from agents.mcp import MCPServer
+    from mcp import types as mcp_types
+    from ..agent_tools import _tool_specs
+
+    specs = _tool_specs(client, include_management, doc_ids)
+
+    class _ToolServer(MCPServer):
+        def __init__(self):
+            super().__init__()
+            self.tools = [mcp_types.Tool(name=name, description=description,
+                                         inputSchema=schema)
+                          for name, description, schema, _ in specs]
+            self._invoke = {name: invoke for name, _, _, invoke in specs}
+
+        @property
+        def name(self) -> str:
+            return "pageindex"
+
+        async def connect(self):
+            pass
+
+        async def cleanup(self):
+            pass
+
+        async def list_tools(self, run_context=None, agent=None):
+            return self.tools
+
+        async def call_tool(self, tool_name: str, arguments, meta=None):
+            blocks, is_error = await asyncio.to_thread(
+                self._invoke[tool_name], arguments or {})
+            return mcp_types.CallToolResult.model_validate(
+                {"content": blocks, "isError": is_error})
+
+        async def list_prompts(self):
+            return mcp_types.ListPromptsResult(prompts=[])
+
+        async def get_prompt(self, name: str, arguments=None):
+            raise ValueError(f"No prompt named {name!r}")
+
+    return _ToolServer()
 
 
 def build_openai_tools(client, include_management: bool = False,
                        hosted: bool = False, doc_ids=None) -> list:
     try:
-        from agents import FunctionTool, HostedMCPTool
+        from agents import HostedMCPTool
+        from agents.mcp import MCPUtil
     except ImportError as exc:
         raise PageIndexAPIError(
             "as_openai_tools requires the OpenAI Agents SDK — "
             "pip install openai-agents."
         ) from exc
-    from ..agent_tools import (_dumps, _failure, _require_local_scope,
-                               _tool_specs)
+    from ..agent_tools import _require_local_scope
     _require_local_scope(client, doc_ids)
     if getattr(client, "api_key", None) and hosted:
         # include_management picks the endpoint — the URL itself is the
@@ -43,38 +88,6 @@ def build_openai_tools(client, include_management: bool = False,
             "require_approval": "never",
         })]
 
-    def wrap(name, description, schema, invoke):
-        async def on_invoke_tool(ctx: Any, args_json: str) -> str:
-            # strict_json_schema is off, so the provider never validates the
-            # payload; a malformed or non-object argument string must come
-            # back as the guided error envelope — raising here aborts the
-            # caller's whole run (hand-built FunctionTools have no
-            # failure_error_function to hand the error back to the model).
-            try:
-                parsed = json.loads(args_json) if args_json else {}
-            except ValueError:
-                parsed = None
-            if not isinstance(parsed, dict):
-                payload, _ = _failure(
-                    f"Invalid arguments for {name}: expected a JSON object, "
-                    f"got: {(args_json or '')[:200]!r}", None,
-                    {"summary": "Malformed tool arguments",
-                     "options": [f"Re-send the {name} call with a JSON "
-                                 "object of its parameters"]},
-                    "INVALID_INPUT")
-                return _dumps(payload)
-            arguments = {key: value for key, value in parsed.items()
-                         if value is not None}
-            # is_error has no per-result channel on hand-built FunctionTools
-            # (raising aborts the run — see above); the text is the signal.
-            text, _ = await asyncio.to_thread(invoke, arguments)
-            return text
-
-        return FunctionTool(name=name, description=description,
-                            params_json_schema=schema,
-                            on_invoke_tool=on_invoke_tool,
-                            strict_json_schema=False)
-
-    return [wrap(*spec)
-            for spec in _tool_specs(client, include_management,
-                                    doc_ids=doc_ids)]
+    server = build_mcp_server(client, include_management, doc_ids)
+    return [MCPUtil.to_function_tool(tool, server, False)
+            for tool in server.tools]

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -641,6 +641,18 @@ def _chat_agent(client, messages, doc_id, model, temperature=None,
     return agent, items, model_name
 
 
+def _output_text(output) -> str:
+    """A tool result for the display: a string as it is, the framework's
+    structured items by their text (anything else as JSON)."""
+    if isinstance(output, str):
+        return output
+    items = output if isinstance(output, list) else [output]
+    return "\n".join(
+        item["text"] if isinstance(item, dict) and item.get("type") == "text"
+        else json.dumps(item, ensure_ascii=False)
+        for item in items)
+
+
 def _clip(text, cap: int = 200) -> str:
     """One display line: whitespace flattened, capped for the terminal."""
     flat = " ".join(str(text).split())
@@ -785,7 +797,7 @@ def _weave(events, options) -> Iterator[str]:
             elif kind == "tool_result":
                 if not options["tool_result"]:
                     continue
-                out = _clip(ev["output"], cap)
+                out = _clip(_output_text(ev["output"]), cap)
                 if section == "tool" and ev["call_id"] == last_call:
                     # directly under its own call line
                     yield f"\n[tool_result] {ev['name']}: {out}"

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -643,14 +643,22 @@ def _chat_agent(client, messages, doc_id, model, temperature=None,
 
 def _output_text(output) -> str:
     """A tool result for the display: a string as it is, the framework's
-    structured items by their text (anything else as JSON)."""
+    structured items by their text, anything else as JSON with a data
+    URL's base64 payload elided."""
     if isinstance(output, str):
         return output
-    items = output if isinstance(output, list) else [output]
-    return "\n".join(
-        item["text"] if isinstance(item, dict) and item.get("type") == "text"
-        else json.dumps(item, ensure_ascii=False)
-        for item in items)
+    lines = []
+    for item in output if isinstance(output, list) else [output]:
+        kind = item.get("type") if isinstance(item, dict) else None
+        if kind == "text":
+            lines.append(item["text"])
+        elif kind == "image" and str(item.get("image_url", "")).startswith("data:"):
+            head, _, _ = item["image_url"].partition(",")
+            lines.append(json.dumps({**item, "image_url": head + ",..."},
+                                    ensure_ascii=False))
+        else:
+            lines.append(json.dumps(item, ensure_ascii=False))
+    return "\n".join(lines)
 
 
 def _clip(text, cap: int = 200) -> str:

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -198,32 +198,37 @@ class McpBridge:
         raise PageIndexAPIError(
             "MCP tools/list pagination did not terminate within 50 pages.")
 
-    def call_tool(self, name: str, arguments: dict[str, Any]) -> "tuple[str, bool]":
-        """Returns (text, is_error) — is_error is the server's MCP isError
-        marking, which callers must carry to their framework's own error
-        channel."""
+    def call_tool(self, name: str, arguments: dict[str, Any],
+                  ) -> "tuple[list[dict], bool]":
+        """Returns (content, is_error): the MCP content blocks untouched,
+        for each adapter to render what its framework carries (render_text
+        is the text-only rendering), and the server's isError marking,
+        which callers must carry to their framework's own error channel."""
         result = self._request("tools/call",
                                {"name": name, "arguments": arguments}) or {}
-        is_error = bool(result.get("isError"))
-        texts = []
-        for block in result.get("content") or []:
-            if isinstance(block, dict) and block.get("type") == "text":
-                texts.append(block.get("text", ""))
-            elif isinstance(block, dict) and isinstance(block.get("data"), str):
-                # Base64 payloads (image/audio) become a metadata stub —
-                # dumped verbatim they hand the model the raw blob. Revisit
-                # if tool results ever pass through as real multimodal input.
-                kind = block.get("mimeType") or block.get("type") or "binary"
-                size_kb = max(1, len(block["data"]) * 3 // 4096)
-                texts.append(f"[{kind} content omitted: ~{size_kb} KB]")
-            elif (isinstance(block, dict)
-                  and isinstance(block.get("resource"), dict)
-                  and isinstance(block["resource"].get("blob"), str)):
-                # EmbeddedResource nests its base64 one level down.
-                resource = block["resource"]
-                kind = resource.get("mimeType") or "binary"
-                size_kb = max(1, len(resource["blob"]) * 3 // 4096)
-                texts.append(f"[{kind} content omitted: ~{size_kb} KB]")
-            else:
-                texts.append(json.dumps(block, ensure_ascii=False))
-        return "\n".join(texts), is_error
+        return list(result.get("content") or []), bool(result.get("isError"))
+
+
+def render_text(blocks: list) -> str:
+    """The text-only rendering of MCP content: text verbatim, base64
+    payloads as a size stub (dumped whole they hand the model the raw
+    blob)."""
+    texts = []
+    for block in blocks:
+        if isinstance(block, dict) and block.get("type") == "text":
+            texts.append(block.get("text", ""))
+        elif isinstance(block, dict) and isinstance(block.get("data"), str):
+            kind = block.get("mimeType") or block.get("type") or "binary"
+            size_kb = max(1, len(block["data"]) * 3 // 4096)
+            texts.append(f"[{kind} content omitted: ~{size_kb} KB]")
+        elif (isinstance(block, dict)
+              and isinstance(block.get("resource"), dict)
+              and isinstance(block["resource"].get("blob"), str)):
+            # EmbeddedResource nests its base64 one level down.
+            resource = block["resource"]
+            kind = resource.get("mimeType") or "binary"
+            size_kb = max(1, len(resource["blob"]) * 3 // 4096)
+            texts.append(f"[{kind} content omitted: ~{size_kb} KB]")
+        else:
+            texts.append(json.dumps(block, ensure_ascii=False))
+    return "\n".join(texts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ requests = ">=2.28.0"
 openai = ">=1.70.0"
 # Older releases crash on current openai before the request is sent.
 openai-agents = ">=0.18.1"
+mcp = ">=1.19.0,<3"
 litellm = ">=1.97.0"
 PyPDF2 = ">=3.0.0"
 pypdfium2 = ">=5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ litellm==1.97.0
 openai>=1.70.0
 requests>=2.28.0
 openai-agents>=0.18.1
+mcp>=1.19.0,<3
 # pymupdf  # optional
 PyPDF2==3.0.1
 pypdfium2==5.13.0

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -1728,16 +1728,19 @@ def test_openai_mcp_server_carries_mcp_types(client, store_path, monkeypatch):
     local = build_mcp_server(client)
     assert [tool.name for tool in asyncio.run(local.list_tools())] == list(tool_names())
     result = asyncio.run(local.call_tool("get_document", {"doc_name": "ghost.pdf"}))
-    assert result.isError and isinstance(result.content[0], TextContent)
-    assert json.loads(result.content[0].text)["errorCode"] == "NOT_FOUND"
+    # Attribute names differ between mcp 1.x and 2.x; the wire aliases don't.
+    wire = result.model_dump(by_alias=True, exclude_none=True)
+    assert wire["isError"] and isinstance(result.content[0], TextContent)
+    assert json.loads(wire["content"][0]["text"])["errorCode"] == "NOT_FOUND"
 
     import pageindex.mcp_bridge as mcp_bridge
     monkeypatch.setattr(mcp_bridge, "McpBridge", _ImageBridge)
     cloud = build_mcp_server(PageIndexCloudClient(api_key="pi-test-key"))
     result = asyncio.run(cloud.call_tool("get_document_image", {"image_path": "x"}))
-    assert not result.isError
-    assert isinstance(result.content[1], ImageContent)
-    assert (result.content[1].mimeType, result.content[1].data) == ("image/png", "QUJD")
+    wire = result.model_dump(by_alias=True, exclude_none=True)
+    assert not wire["isError"] and isinstance(result.content[1], ImageContent)
+    assert wire["content"][1] == {"type": "image", "data": "QUJD",
+                                  "mimeType": "image/png"}
 
 
 def test_as_openai_tools_images_reach_the_model(monkeypatch):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -651,22 +651,9 @@ def test_as_openai_tools_invocation_runs_call_tool(client, store_path):
     tool = {t.name: t for t in client.as_openai_tools()}["get_document"]
     out = asyncio.run(tool.on_invoke_tool(
         None, json.dumps({"doc_name": "report.pdf", "folder_id": None})))
-    payload = json.loads(out)
+    # The framework's own MCP conversion: a text result is its text item.
+    payload = json.loads(out["text"])
     assert payload["success"] is True and payload["name"] == "report.pdf"
-
-
-def test_as_openai_tools_malformed_args_answer_the_model(client, store_path):
-    """strict_json_schema is off, so a truncated or non-object argument
-    string is reachable; raising here aborted the caller's whole run —
-    the model must get the guided envelope back and retry instead."""
-    pytest.importorskip("agents")
-    seed_doc(store_path, "pi-a", "report.pdf")
-    tool = {t.name: t for t in client.as_openai_tools()}["get_document"]
-    for bad in ('{not json', '[1, 2]', '"x"', 'null'):
-        out = asyncio.run(tool.on_invoke_tool(None, bad))
-        payload = json.loads(out)
-        assert payload["errorCode"] == "INVALID_INPUT"
-        assert "JSON object" in payload["error"]
 
 
 def test_as_openai_tools_cloud_object_params_survive(monkeypatch):
@@ -696,7 +683,7 @@ def test_as_openai_tools_cloud_object_params_survive(monkeypatch):
                      "inputSchema": schema}]
 
         def call_tool(self, name, arguments):
-            return json.dumps({"success": True}), False
+            return _text_block(json.dumps({"success": True})), False
 
     monkeypatch.setattr(mcp_bridge, "McpBridge", _ObjBridge)
     cloud = PageIndexCloudClient(api_key="pi-test-key")
@@ -953,10 +940,10 @@ def test_openai_agent_config_doc_scope_enforced_in_tools(client, store_path):
              for tool in client.openai_agent_config(doc_id="pi-a")["tools"]}
     out = asyncio.run(tools["get_page_content"].on_invoke_tool(
         None, json.dumps({"doc_name": "payroll.pdf", "pages": "1"})))
-    assert json.loads(out)["errorCode"] == "NOT_FOUND"
+    assert json.loads(out["text"])["errorCode"] == "NOT_FOUND"
     out = asyncio.run(tools["browse_documents"].on_invoke_tool(None, "{}"))
     assert [doc["name"]
-            for doc in json.loads(out)["documents"]] == ["report.pdf"]
+            for doc in json.loads(out["text"])["documents"]] == ["report.pdf"]
 
 
 def test_anthropic_runner_config_doc_scope_enforced_in_tools(client,
@@ -972,7 +959,7 @@ def test_anthropic_runner_config_doc_scope_enforced_in_tools(client,
     with pytest.raises(ToolError, match="NOT_FOUND"):
         tools["get_page_content"].call({"doc_name": "payroll.pdf",
                                         "pages": "1"})
-    browse = json.loads(tools["browse_documents"].call({}))
+    browse = json.loads(tools["browse_documents"].call({})[0]["text"])
     assert [doc["name"] for doc in browse["documents"]] == ["report.pdf"]
 
 
@@ -1065,10 +1052,10 @@ def test_bridge_invoker_reraises_auth_failures():
         def call_tool(self, name, arguments):
             raise PageIndexAPIError("HTTP 503", status_code=503)
 
-    text, is_error = agent_tools_module._bridge_invoker(
+    blocks, is_error = agent_tools_module._bridge_invoker(
         Down(), "get_document", {})({})
     assert is_error
-    assert json.loads(text)["errorCode"] == "INTERNAL_ERROR"
+    assert json.loads(blocks[0]["text"])["errorCode"] == "INTERNAL_ERROR"
 
 
 def test_cloud_bridge_gates_the_endpoint(monkeypatch):
@@ -1137,7 +1124,8 @@ def test_as_anthropic_tools_local_in_process(client, store_path):
     assert browse.input_schema == _local_schema("browse_documents")
     assert browse.description == _local_description("browse_documents")
     seed_doc(store_path, "pi-a", "report.pdf")
-    assert "report.pdf" in browse.call({})
+    # Results are the Anthropic SDK's own MCP conversion: content blocks.
+    assert "report.pdf" in browse.call({})[0]["text"]
 
 
 def test_as_anthropic_tools_async_flavor(client, store_path):
@@ -1148,7 +1136,7 @@ def test_as_anthropic_tools_async_flavor(client, store_path):
     assert [tool.name for tool in tools] == list(tool_names())
     seed_doc(store_path, "pi-a", "report.pdf")
     browse = {tool.name: tool for tool in tools}["browse_documents"]
-    assert "report.pdf" in asyncio.run(browse.call({}))
+    assert "report.pdf" in asyncio.run(browse.call({}))[0]["text"]
 
 
 def test_as_anthropic_tools_local_management_opt_in(client):
@@ -1168,8 +1156,8 @@ def test_as_anthropic_tools_local_failures_raise_toolerror(client, store_path):
     tools = {tool.name: tool for tool in client.as_anthropic_tools()}
     with pytest.raises(ToolError) as excinfo:
         tools["get_document"].call({"doc_name": "ghost.pdf"})
-    assert json.loads(excinfo.value.content)["errorCode"] == "NOT_FOUND"
-    assert "report.pdf" in tools["browse_documents"].call({})
+    assert json.loads(excinfo.value.content[0]["text"])["errorCode"] == "NOT_FOUND"
+    assert "report.pdf" in tools["browse_documents"].call({})[0]["text"]
 
 
 def test_as_anthropic_tools_cloud_iserror_raises_toolerror(
@@ -1181,10 +1169,10 @@ def test_as_anthropic_tools_cloud_iserror_raises_toolerror(
     cloud, created = cloud_with_fake_bridge
     tools = cloud.as_anthropic_tools()
     created["bridge"].call_tool = lambda name, arguments: (
-        '{"error": "denied"}', True)
+        _text_block('{"error": "denied"}'), True)
     with pytest.raises(ToolError) as excinfo:
         tools[0].call({"query": "q"})
-    assert json.loads(excinfo.value.content)["error"] == "denied"
+    assert json.loads(excinfo.value.content[0]["text"])["error"] == "denied"
 
 
 def test_as_anthropic_tools_cloud_schemas_pass_through(cloud_with_fake_bridge):
@@ -1201,7 +1189,7 @@ def test_as_anthropic_tools_cloud_schemas_pass_through(cloud_with_fake_bridge):
     # Calls route over the bridge; None-valued arguments mean "omitted".
     out = tools[1].call({"doc_name": "x.pdf", "folder_id": None})
     assert bridge.calls == [("get_document", {"doc_name": "x.pdf"})]
-    assert json.loads(out)["success"] is True
+    assert json.loads(out[0]["text"])["success"] is True
 
 
 def test_as_anthropic_tools_cloud_async_flavor(cloud_with_fake_bridge):
@@ -1212,7 +1200,7 @@ def test_as_anthropic_tools_cloud_async_flavor(cloud_with_fake_bridge):
     assert all(isinstance(tool, BetaAsyncFunctionTool) for tool in tools)
     out = asyncio.run(tools[1].call({"doc_name": "x.pdf"}))
     assert created["bridge"].calls == [("get_document", {"doc_name": "x.pdf"})]
-    assert json.loads(out)["success"] is True
+    assert json.loads(out[0]["text"])["success"] is True
 
 
 def test_as_anthropic_tools_cloud_management_opt_in(cloud_with_fake_bridge):
@@ -1239,7 +1227,7 @@ def test_as_anthropic_tools_cloud_contains_bridge_errors(cloud_with_fake_bridge)
     created["bridge"].call_tool = boom
     with pytest.raises(ToolError) as excinfo:
         tools[0].call({"query": "q"})
-    payload = json.loads(excinfo.value.content)
+    payload = json.loads(excinfo.value.content[0]["text"])
     assert payload["errorCode"] == "INTERNAL_ERROR"
     assert "bridge down" in payload["error"]
 
@@ -1254,6 +1242,11 @@ def test_agent_tools_work_without_frameworks(client, store_path, monkeypatch):
 
 
 # ── cloud agent_tools: MCP bridge ──
+
+def _text_block(text):
+    """A tool result as the bridge returns it: MCP content blocks."""
+    return [{"type": "text", "text": text}]
+
 
 class _FakeBridge:
     def __init__(self, url, headers):
@@ -1319,8 +1312,8 @@ class _FakeBridge:
 
     def call_tool(self, name, arguments):
         self.calls.append((name, arguments))
-        return json.dumps({"success": True, "tool": name,
-                           "args": arguments}), False
+        return _text_block(json.dumps({"success": True, "tool": name,
+                                       "args": arguments})), False
 
 
 @pytest.fixture
@@ -1389,7 +1382,7 @@ def test_cloud_agent_tools_null_description_survives():
 
     class _Bridge:
         def call_tool(self, name, arguments):
-            return json.dumps({"success": True}), False
+            return _text_block(json.dumps({"success": True})), False
 
     tool = _synth(_Bridge(), {
         "name": "search_documents",
@@ -1531,8 +1524,9 @@ def test_mcp_bridge_protocol(monkeypatch):
     assert list_headers["Authorization"] == "Bearer k"
 
     # First tools/call 404s (expired session) → re-initialize → retry succeeds.
-    text, is_error = bridge.call_tool("t1", {"a": 1})
-    assert (text, is_error) == ("hello\nworld", False)
+    blocks, is_error = bridge.call_tool("t1", {"a": 1})
+    assert (blocks, is_error) == ([{"type": "text", "text": "hello"},
+                                   {"type": "text", "text": "world"}], False)
     methods = [p["payload"]["method"] for p in posts]
     assert methods.count("initialize") == 2
     # The expired session's negotiated state must not leak into the new
@@ -1670,25 +1664,138 @@ def test_mcp_bridge_init_notification_bars_concurrent_requests(monkeypatch):
     assert events.count(("start", "initialize")) == 1
 
 
-def test_mcp_bridge_blob_blocks_become_stubs():
-    """Non-text content used to be json.dumps'd wholesale, handing the
-    model the raw base64 payload of an image tool's response."""
-    from pageindex.mcp_bridge import McpBridge
+_BLOB = "A" * 8192  # ~6 KB decoded
+
+
+def test_mcp_bridge_hands_content_blocks_through():
+    """The bridge used to flatten every result to text, dropping images
+    before any adapter could carry them; render_text is now the text-only
+    rendering, and it still never hands the model a raw base64 payload."""
+    from pageindex.mcp_bridge import McpBridge, render_text
 
     bridge = McpBridge("https://api.pageindex.ai/mcp", {})
-    blob = "A" * 8192  # ~6 KB decoded
-    bridge._request = lambda method, params: {"content": [
+    content = [
         {"type": "text", "text": "Page 3 of report.pdf"},
-        {"type": "image", "mimeType": "image/png", "data": blob},
+        {"type": "image", "mimeType": "image/png", "data": _BLOB},
         {"type": "resource",
-         "resource": {"mimeType": "image/jpeg", "blob": blob}},
-    ]}
-    text, is_error = bridge.call_tool("get_document_image", {})
-    assert not is_error
+         "resource": {"mimeType": "image/jpeg", "blob": _BLOB}},
+    ]
+    bridge._request = lambda method, params: {"content": content}
+    assert bridge.call_tool("get_document_image", {}) == (content, False)
+    text = render_text(content)
     assert "Page 3 of report.pdf" in text
     assert "AAAA" not in text
     assert "[image/png content omitted: ~6 KB]" in text
     assert "[image/jpeg content omitted: ~6 KB]" in text
+
+
+class _ImageBridge:
+    """A cloud tool whose result is multimodal: text and a PNG."""
+    is_error = False
+
+    def __init__(self, url, headers):
+        pass
+
+    def list_tools(self):
+        return [{"name": "get_document_image", "description": "d",
+                 "annotations": {"readOnlyHint": True},
+                 "inputSchema": {"type": "object",
+                                 "properties": {"image_path": {"type": "string"}},
+                                 "required": ["image_path"]}}]
+
+    def call_tool(self, name, arguments):
+        return [{"type": "text", "text": "page 1"},
+                {"type": "image", "mimeType": "image/png", "data": "QUJD"},
+                ], self.is_error
+
+
+def test_agent_tools_functions_render_images_as_stubs(monkeypatch):
+    """The str-returning surface keeps the size stub, never the blob."""
+    import pageindex.mcp_bridge as mcp_bridge
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _ImageBridge)
+    fn = PageIndexCloudClient(api_key="pi-test-key").agent_tools()[0]
+    assert fn(image_path="x") == "page 1\n[image/png content omitted: ~1 KB]"
+
+
+def test_openai_mcp_server_carries_mcp_types(client, store_path, monkeypatch):
+    """The in-process server hands the framework MCP types on both sides,
+    local and cloud alike: tools from the specs, results validated as
+    CallToolResult with the content untouched."""
+    pytest.importorskip("agents")
+    from mcp.types import ImageContent, TextContent
+    from pageindex.integrations.openai_agents import build_mcp_server
+    seed_doc(store_path, "pi-a", "report.pdf")
+    local = build_mcp_server(client)
+    assert [tool.name for tool in asyncio.run(local.list_tools())] == list(tool_names())
+    result = asyncio.run(local.call_tool("get_document", {"doc_name": "ghost.pdf"}))
+    assert result.isError and isinstance(result.content[0], TextContent)
+    assert json.loads(result.content[0].text)["errorCode"] == "NOT_FOUND"
+
+    import pageindex.mcp_bridge as mcp_bridge
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _ImageBridge)
+    cloud = build_mcp_server(PageIndexCloudClient(api_key="pi-test-key"))
+    result = asyncio.run(cloud.call_tool("get_document_image", {"image_path": "x"}))
+    assert not result.isError
+    assert isinstance(result.content[1], ImageContent)
+    assert (result.content[1].mimeType, result.content[1].data) == ("image/png", "QUJD")
+
+
+def test_as_openai_tools_images_reach_the_model(monkeypatch):
+    """Images ride as the framework's own image output (a data URL) — the
+    framework's MCP conversion, not the SDK's."""
+    pytest.importorskip("agents")
+    import pageindex.mcp_bridge as mcp_bridge
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _ImageBridge)
+    tool = PageIndexCloudClient(api_key="pi-test-key").as_openai_tools()[0]
+    out = asyncio.run(tool.on_invoke_tool(None, '{"image_path": "x"}'))
+    assert out == [{"type": "text", "text": "page 1"},
+                   {"type": "image", "image_url": "data:image/png;base64,QUJD"}]
+
+
+def test_as_anthropic_tools_images_reach_the_model(monkeypatch):
+    """Images ride as base64 image blocks, on the error channel too — the
+    Anthropic SDK's MCP conversion, not the SDK's."""
+    pytest.importorskip("anthropic")
+    from anthropic.lib.tools import ToolError
+    import pageindex.mcp_bridge as mcp_bridge
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _ImageBridge)
+    tool = PageIndexCloudClient(api_key="pi-test-key").as_anthropic_tools()[0]
+    content = [{"type": "text", "text": "page 1"},
+               {"type": "image", "source": {"type": "base64",
+                                            "media_type": "image/png",
+                                            "data": "QUJD"}}]
+    assert tool.call({"image_path": "x"}) == content
+    monkeypatch.setattr(_ImageBridge, "is_error", True)
+    with pytest.raises(ToolError) as excinfo:
+        tool.call({"image_path": "x"})
+    assert excinfo.value.content == content
+
+
+def test_integrations_carry_mcp_and_render_nothing():
+    """The rule behind the adapters: tool results reach a framework as MCP
+    content and the framework renders them. The SDK's only text rendering
+    (render_text) serves the str-returning plain functions."""
+    integrations = Path(__file__).resolve().parents[1] / "pageindex" / "integrations"
+    for path in integrations.glob("*.py"):
+        assert "render_text" not in path.read_text(encoding="utf-8"), path.name
+
+
+def test_as_claude_mcp_local_handler_passes_blocks_through(client, monkeypatch):
+    """The in-process SDK MCP server speaks MCP: content blocks go out as
+    they came in, images included, with the error marking."""
+    claude_agent_sdk = pytest.importorskip("claude_agent_sdk")
+    import pageindex.agent_tools as agent_tools
+    blocks = [{"type": "text", "text": "page 1"},
+              {"type": "image", "mimeType": "image/png", "data": "QUJD"}]
+    monkeypatch.setattr(agent_tools, "_tool_specs", lambda *args, **kwargs: [
+        ("get_page_content", "d", {"type": "object", "properties": {}},
+         lambda arguments: (blocks, True))])
+    captured = {}
+    monkeypatch.setattr(claude_agent_sdk, "create_sdk_mcp_server",
+                        lambda **kwargs: captured.update(kwargs))
+    client.as_claude_mcp()
+    result = asyncio.run(captured["tools"][0].handler({}))
+    assert result == {"content": blocks, "is_error": True}
 
 
 # ── review-round regressions ──
@@ -1712,7 +1819,7 @@ def test_synth_binding_error_names_the_tool():
 
     class _Bridge:
         def call_tool(self, name, args):
-            return json.dumps(args), False
+            return _text_block(json.dumps(args)), False
 
     meta = {"name": "browse_documents", "description": "d",
             "inputSchema": TOOL_CONTRACT["browse_documents"]["schema"]}
@@ -1733,7 +1840,7 @@ def test_bridge_invoker_coerces_string_booleans():
     class _Bridge:
         def call_tool(self, name, args):
             seen.update(args)
-            return "{}", False
+            return _text_block("{}"), False
 
     invoke = _bridge_invoker(_Bridge(), "get_document",
                              TOOL_CONTRACT["get_document"]["schema"])
@@ -1749,7 +1856,7 @@ def test_synth_optional_no_default_param_is_nullable():
 
     class _Bridge:
         def call_tool(self, name, args):
-            return json.dumps(args), False
+            return _text_block(json.dumps(args)), False
 
     meta = {"name": "browse_documents",
             "description": "d",
@@ -1766,7 +1873,7 @@ def test_synth_array_params_keep_their_item_type():
 
     class _Bridge:
         def call_tool(self, name, args):
-            return json.dumps(args), False
+            return _text_block(json.dumps(args)), False
 
     meta = {"name": "remove_documents", "description": "d",
             "inputSchema": {
@@ -1796,7 +1903,7 @@ def test_synth_escape_hatches():
     class _Bridge:
         def call_tool(self, name, args):
             calls.append((name, args))
-            return "ok", False
+            return _text_block("ok"), False
 
     # Tool named "_invoke" must not recurse into itself.
     invoke_named = _synth(_Bridge(), {
@@ -1916,7 +2023,8 @@ def test_bridge_call_tool_surfaces_iserror(monkeypatch):
         Session=lambda: types.SimpleNamespace(post=fake_post),
         RequestException=requests_mod.RequestException))
     bridge = McpBridge("https://api.pageindex.ai/mcp", {})
-    assert bridge.call_tool("t", {}) == ('{"error": "denied"}', True)
+    assert bridge.call_tool("t", {}) == (
+        [{"type": "text", "text": '{"error": "denied"}'}], True)
 
 
 def test_bridge_rejects_mismatched_reply_id(monkeypatch):
@@ -2174,21 +2282,23 @@ def test_live_cloud_envelope_field_parity(tmp_path):
     exist in the live cloud tool's response for the analogous call — a cloud
     rename of a shared field (has_more, next_offset, content, ...) fails
     here. Guidance wording is deliberately localized and not compared."""
-    from pageindex.mcp_bridge import McpBridge
+    from pageindex.mcp_bridge import McpBridge, render_text
     bridge = McpBridge("https://api.pageindex.ai/mcp",
                        {"Authorization": f"Bearer {LIVE_KEY}"})
-    cloud_browse = json.loads(
-        bridge.call_tool("browse_documents", {"limit": 2})[0])
+
+    def call(name, arguments):
+        return json.loads(render_text(bridge.call_tool(name, arguments)[0]))
+
+    cloud_browse = call("browse_documents", {"limit": 2})
     assert cloud_browse.get("success") is True and cloud_browse["documents"]
     doc_name = cloud_browse["documents"][0]["name"]
     cloud = {
         "browse_documents": cloud_browse,
-        "get_document": json.loads(bridge.call_tool(
-            "get_document", {"doc_name": doc_name})[0]),
-        "get_document_structure": json.loads(bridge.call_tool(
-            "get_document_structure", {"doc_name": doc_name})[0]),
-        "get_page_content": json.loads(bridge.call_tool(
-            "get_page_content", {"doc_name": doc_name, "pages": "1"})[0]),
+        "get_document": call("get_document", {"doc_name": doc_name}),
+        "get_document_structure": call("get_document_structure",
+                                       {"doc_name": doc_name}),
+        "get_page_content": call("get_page_content",
+                                 {"doc_name": doc_name, "pages": "1"}),
     }
 
     store = str(tmp_path / "store")

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2968,6 +2968,26 @@ def test_bridge_chat_runs_engine_over_cloud_tools(bridge_client, fake_model):
 
 
 @needs_agents
+def test_process_display_elides_image_payloads(bridge_client, fake_model):
+    """A [tool_result] line shows an image item as it is, minus the base64
+    payload; the model still receives the image itself."""
+    client, bridge = bridge_client
+    bridge.call_tool = lambda name, arguments: (
+        [{"type": "text", "text": "page 1"},
+         {"type": "image", "mimeType": "image/png", "data": "A" * 8192}],
+        False)
+    fake = fake_model([
+        [_call_item("get_document", {"doc_name": "r.pdf"})],
+        [_msg_item("The answer")],
+    ])
+    text = "".join(client.chat("What?", stream=True))
+    assert ('[tool_result] get_document: page 1 {"type": "image", '
+            '"image_url": "data:image/png;base64,..."}') in text
+    assert "AAAA" not in text
+    assert "AAAA" in json.dumps(fake.inputs[1])  # the model got the image
+
+
+@needs_agents
 def test_bridge_doc_id_targets_at_prompt_level(bridge_client, fake_model,
                                                monkeypatch):
     """On cloud tools there is no local allowlist: doc_id becomes the

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -704,7 +704,8 @@ def test_chat_stream_events_typed_sequence(client, store_path, fake_model):
     assert result["name"] == "get_document"
     assert result["call_id"] == "call_1"
     assert "... (+" not in str(result["output"])  # never clipped
-    assert '"next_steps"' in result["output"]
+    # The result as the framework recorded it: its text item.
+    assert '"next_steps"' in result["output"]["text"]
     assert "".join(ev["delta"] for ev in events
                    if ev["type"] == "answer") == "The answer"
 
@@ -1685,12 +1686,33 @@ def test_doc_id_scopes_tools_to_targeted_documents(client, store_path,
     client.chat_completions("q", doc_id="pi-a")
 
     def tool_outputs(items):
-        return [item["output"] for item in items
+        # function_call_output.output: the framework's structured text item
+        return [item["output"][0]["text"] for item in items
                 if item.get("type") == "function_call_output"]
 
     assert "NOT_FOUND" in tool_outputs(fake.inputs[1])[-1]
     browse = json.loads(tool_outputs(fake.inputs[2])[-1])
     assert [doc["name"] for doc in browse["documents"]] == ["report.pdf"]
+
+
+@needs_agents
+def test_malformed_tool_arguments_answer_the_model(client, store_path,
+                                                    fake_model):
+    """A truncated argument string reaches the tool (strict schemas are
+    off). The tools are the framework's own MCP conversion, so its failure
+    pipeline hands the model an error message and the run goes on: no
+    aborted run, no SDK envelope."""
+    from openai.types.responses import ResponseFunctionToolCall
+    seed_doc(store_path, "pi-a", "report.pdf")
+    bad_call = ResponseFunctionToolCall(
+        id="fc_1", type="function_call", call_id="call_1",
+        name="get_document", arguments="{not json", status="completed")
+    fake = fake_model([[bad_call], [_msg_item("The answer")]])
+    result = client.chat_completions("What?")
+    assert result["choices"][0]["message"]["content"] == "The answer"
+    outputs = [item["output"] for item in fake.inputs[1]
+               if item.get("type") == "function_call_output"]
+    assert "Invalid JSON" in json.dumps(outputs[-1])
 
 
 @needs_agents
@@ -2910,8 +2932,8 @@ class FakeBridge:
 
     def call_tool(self, name, arguments):
         self.calls.append((name, arguments))
-        return json.dumps({"status": "success",
-                           "data": {"doc": "cloud-doc"}}), False
+        return [{"type": "text", "text": json.dumps(
+            {"status": "success", "data": {"doc": "cloud-doc"}})}], False
 
 
 @pytest.fixture


### PR DESCRIPTION
Review-only view of #487 (tool results reach the frameworks as MCP content). Base frozen at `348231c` (`review/base-348231c`, never advances); never merge this PR.

Later review rounds run here. Fixes push to `feat/multimodal-tool-results` and reach `main` through their own small PRs.

https://claude.ai/code/session_01F8QMbFKngRT4TpBAKfuNVW
