### PR TITLE
Process display elides an image's base64 payload

### DIFF
--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -643,14 +643,22 @@ def _chat_agent(client, messages, doc_id, model, temperature=None,
 
 def _output_text(output) -> str:
     """A tool result for the display: a string as it is, the framework's
-    structured items by their text (anything else as JSON)."""
+    structured items by their text, anything else as JSON with a data
+    URL's base64 payload elided."""
     if isinstance(output, str):
         return output
-    items = output if isinstance(output, list) else [output]
-    return "\n".join(
-        item["text"] if isinstance(item, dict) and item.get("type") == "text"
-        else json.dumps(item, ensure_ascii=False)
-        for item in items)
+    lines = []
+    for item in output if isinstance(output, list) else [output]:
+        kind = item.get("type") if isinstance(item, dict) else None
+        if kind == "text":
+            lines.append(item["text"])
+        elif kind == "image" and str(item.get("image_url", "")).startswith("data:"):
+            head, _, _ = item["image_url"].partition(",")
+            lines.append(json.dumps({**item, "image_url": head + ",..."},
+                                    ensure_ascii=False))
+        else:
+            lines.append(json.dumps(item, ensure_ascii=False))
+    return "\n".join(lines)
 
 
 def _clip(text, cap: int = 200) -> str:

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -2968,6 +2968,26 @@ def test_bridge_chat_runs_engine_over_cloud_tools(bridge_client, fake_model):
 
 
 @needs_agents
+def test_process_display_elides_image_payloads(bridge_client, fake_model):
+    """A [tool_result] line shows an image item as it is, minus the base64
+    payload; the model still receives the image itself."""
+    client, bridge = bridge_client
+    bridge.call_tool = lambda name, arguments: (
+        [{"type": "text", "text": "page 1"},
+         {"type": "image", "mimeType": "image/png", "data": "A" * 8192}],
+        False)
+    fake = fake_model([
+        [_call_item("get_document", {"doc_name": "r.pdf"})],
+        [_msg_item("The answer")],
+    ])
+    text = "".join(client.chat("What?", stream=True))
+    assert ('[tool_result] get_document: page 1 {"type": "image", '
+            '"image_url": "data:image/png;base64,..."}') in text
+    assert "AAAA" not in text
+    assert "AAAA" in json.dumps(fake.inputs[1])  # the model got the image
+
+
+@needs_agents
 def test_bridge_doc_id_targets_at_prompt_level(bridge_client, fake_model,
                                                monkeypatch):
     """On cloud tools there is no local allowlist: doc_id becomes the


### PR DESCRIPTION
The woven `[tool_result]` line of `chat(stream=True)` clipped the framework's image item to its first 200 characters, which is the head of a base64 data URL. The line now shows the item as it is with the payload elided:

```
[tool_result] get_document_image: {"type": "image", "image_url": "data:image/png;base64,..."}
```

Display only: the item the model receives, `ChatStream` `tool_result` events, and the `items` transcript are unchanged. Same commit as `feat/multimodal-tool-results` b5d28fb (review view #488).

https://claude.ai/code/session_01F8QMbFKngRT4TpBAKfuNVW
