### PR TITLE
MCP prompts over the bridge + chat(citations=True)

### DIFF
--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, Optional
 import requests
 
 from .errors import PageIndexAPIError
-from .mcp_bridge import render_text
+from .mcp_bridge import render_prompt_text, render_text
 
 TOOL_RESPONSE_CHAR_LIMIT = 100_000
 STRUCTURE_FIRST_PAGE_THRESHOLD = 20
@@ -1639,6 +1639,67 @@ AGENT_INSTRUCTIONS = "\n\n".join([
     _AFTER_DISCOVERY,
     _PERSISTENCE,
 ])
+
+
+# Frozen from the cloud MCP server's ``cited_answer`` prompt (pageindex-chat
+# server/mcp/prompts/cited-answer.ts, one text per format; "markdown" is its
+# default), minus the bullet naming the cloud-only get_document_image() tool.
+# The live parity test pins the rest verbatim. Local page content carries no
+# block_id, so the block rules stay dormant and citations resolve to pages.
+LOCAL_CITATION_PROMPTS: dict[str, str] = {
+    "markdown": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs, as a bracketed reference: [{docName}, p. {pageNumber}] or [{docName}, p. {pageNumber}, block {blockId}]. Place immediately after the claim.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one reference per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each reference must reference a SINGLE page integer. For multi-page citations, use separate references.""",
+    "cite": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs: <cite doc="{docName}" page="{pageNumber}"/> or <cite doc="{docName}" page="{pageNumber}" block="{blockId}"/>. Place immediately after the claim.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one tag per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each tag must reference a SINGLE page integer. For multi-page citations, use separate tags.
+- Close every answer with a "Sources" section: one plain-text line per cited block, formatted `- <document name>, page <page> (block <block_id>)`. Keep it even when the inline tags are present — a client that strips unknown HTML tags would otherwise leave the answer with no visible citations at all.""",
+    "footnote": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs, as a Markdown footnote: put [^n] immediately after the claim and define it at the end of the answer as [^n]: {docName}, p. {pageNumber} or [^n]: {docName}, p. {pageNumber}, block {blockId}.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one footnote per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each footnote must reference a SINGLE page integer. For multi-page citations, use separate footnotes.
+- Number footnotes from 1 in order of first use; reuse a number when the same page and block support another claim. Every marker needs a definition and every definition a marker.""",
+}
+
+
+def fetch_citation_prompt(client, format: Optional[str] = None) -> str:
+    """The MCP server's ``cited_answer`` prompt as system-prompt text;
+    ``format`` rides as its one argument (None: the server's default).
+    Local: the frozen copy, page-level."""
+    if not getattr(client, "api_key", None):
+        try:
+            return LOCAL_CITATION_PROMPTS[format or "markdown"]
+        except KeyError:
+            raise PageIndexAPIError(
+                f"citations format {format!r} is not one of "
+                f"{', '.join(LOCAL_CITATION_PROMPTS)}.") from None
+    _, messages = _cloud_bridge(client, gated=True).get_prompt(
+        "cited_answer", {"format": format} if format else None)
+    text = render_prompt_text(messages)
+    if not text.strip():
+        raise PageIndexAPIError(
+            "The MCP server returned an empty cited_answer prompt.")
+    return text
 
 
 def _base_instructions(client, include_management: bool = False) -> str:

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1641,11 +1641,10 @@ AGENT_INSTRUCTIONS = "\n\n".join([
 ])
 
 
-# Frozen from the cloud MCP server's ``cited_answer`` prompt (pageindex-chat
-# server/mcp/prompts/cited-answer.ts, one text per format; "markdown" is its
-# default), minus the bullet naming the cloud-only get_document_image() tool.
-# The live parity test pins the rest verbatim. Local page content carries no
-# block_id, so the block rules stay dormant and citations resolve to pages.
+# Frozen from the cloud MCP server's ``cited_answer`` prompt, minus the
+# bullet naming the cloud-only get_document_image() tool. Local page
+# content carries no block_id, so the block rules stay dormant and
+# citations resolve to pages.
 LOCAL_CITATION_PROMPTS: dict[str, str] = {
     "markdown": """\
 GROUNDING

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1682,19 +1682,19 @@ CITATIONS
 }
 
 
-def fetch_citation_prompt(client, format: Optional[str] = None) -> str:
+def fetch_citation_prompt(client, format: str) -> str:
     """The MCP server's ``cited_answer`` prompt as system-prompt text;
-    ``format`` rides as its one argument (None: the server's default).
-    Local: the frozen copy, page-level."""
+    ``format`` rides as its one argument. Local: the frozen copy,
+    page-level."""
     if not getattr(client, "api_key", None):
         try:
-            return LOCAL_CITATION_PROMPTS[format or "markdown"]
+            return LOCAL_CITATION_PROMPTS[format]
         except KeyError:
             raise PageIndexAPIError(
                 f"citations format {format!r} is not one of "
                 f"{', '.join(LOCAL_CITATION_PROMPTS)}.") from None
     _, messages = _cloud_bridge(client, gated=True).get_prompt(
-        "cited_answer", {"format": format} if format else None)
+        "cited_answer", {"format": format})
     text = render_prompt_text(messages)
     if not text.strip():
         raise PageIndexAPIError(

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1033,16 +1033,18 @@ class PageIndexClient:
                 a list of Messages system blocks. On the answer lane and
                 ``protocol="chat_completions"`` it precedes any ``system``
                 rows in the history.
-            citations: Cite every claim the way PageIndex chat does —
-                ``<cite doc="…" page="…"/>`` tags, ``block="…"`` added
-                where the cloud document has blocks. The guidance is the
-                PageIndex MCP server's ``cited_answer`` prompt, joining
+            citations: Own-model chat: cite every claim the way PageIndex
+                chat does — ``<cite doc="…" page="…"/>`` tags, ``block="…"``
+                added where the cloud document has blocks. The guidance is
+                the PageIndex MCP server's ``cited_answer`` prompt, joining
                 the system prompt after the managed prompt and before
                 ``instructions``; local documents get the SDK's copy
-                (pages only); another format (own-model chat only):
-                ``citation_prompt()`` passed through ``instructions=``
-                instead. Managed chat: its own citations
-                (``chat_completions``'s ``enable_citations``).
+                (pages only); another format: ``citation_prompt()`` passed
+                through ``instructions=`` instead. Managed chat:
+                ``chat_completions``'s ``enable_citations`` — the endpoint
+                cites in its own inline markup, not ``<cite>`` tags, and
+                the resolved citations it returns come back only from
+                ``chat_completions``.
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1297,8 +1299,12 @@ class PageIndexClient:
             temperature: Sampling temperature, passed through to the model.
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
-            enable_citations: Managed chat only — own-model chat raises
-                (cite there with ``chat(citations=True)``).
+            enable_citations: Managed chat only — the endpoint cites
+                inline and returns the resolved citations (``citations``
+                in the response; with ``stream_metadata=True`` a trailing
+                citations chunk). Own-model chat raises; its
+                ``chat(citations=True)`` adds ``<cite>`` markup only,
+                nothing is resolved.
             model: Own-model chat only — backend model name (defaults to
                 ``chat_model``). The managed endpoint selects its own.
             max_turns: Own-model chat only — cap on agent turns per call.

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1131,8 +1131,7 @@ class PageIndexClient:
         enable_citations = False
         if citations:
             if self._local_chat:
-                from .agent_tools import fetch_citation_prompt
-                text = fetch_citation_prompt(self, "cite")
+                text = self.citation_prompt()
                 if isinstance(instructions, list):
                     instructions = [{"type": "text", "text": text},
                                     *instructions]

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -794,6 +794,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -812,6 +813,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -830,6 +832,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: Literal["chat_completions", "responses", "messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -848,6 +851,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: Literal["chat_completions", "responses"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -866,6 +870,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: Literal["messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -884,6 +889,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -903,6 +909,7 @@ class PageIndexClient:
         protocol: Optional[Literal["chat_completions", "responses",
                                    "messages"]] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -921,6 +928,7 @@ class PageIndexClient:
         protocol: Optional[Literal["chat_completions", "responses",
                                    "messages"]] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -1025,6 +1033,15 @@ class PageIndexClient:
                 a list of Messages system blocks. On the answer lane and
                 ``protocol="chat_completions"`` it precedes any ``system``
                 rows in the history.
+            citations: Cite every claim the way PageIndex chat does —
+                ``<cite doc="…" page="…"/>`` tags, ``block="…"`` added
+                where the cloud document has blocks. The guidance is the
+                PageIndex MCP server's ``cited_answer`` prompt, joining
+                the system prompt after the managed prompt and before
+                ``instructions``; local documents get the SDK's copy
+                (pages only); other formats: ``citation_prompt()``
+                passed through ``instructions=``. Managed chat: its own
+                citations (``chat_completions``'s ``enable_citations``).
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1105,6 +1122,19 @@ class PageIndexClient:
                 "system blocks; the other lanes take a string.")
         from .local_chat import _refuse_skeleton
         _refuse_skeleton(extra_body)
+        enable_citations = False
+        if citations:
+            if self._local_chat:
+                from .agent_tools import fetch_citation_prompt
+                text = fetch_citation_prompt(self, "cite")
+                if isinstance(instructions, list):
+                    instructions = [{"type": "text", "text": text},
+                                    *instructions]
+                else:
+                    instructions = (f"{text}\n\n{instructions}"
+                                    if instructions else text)
+            else:
+                enable_citations = True
         if protocol in ("responses", "messages"):
             self._require_own_chat(f"chat(protocol={protocol!r})")
             if protocol == "responses":
@@ -1154,6 +1184,7 @@ class PageIndexClient:
         if protocol == "chat_completions":
             return self.chat_completions(
                 messages, stream=stream, stream_metadata=True, doc_id=doc_id,
+                enable_citations=enable_citations,
                 model=model, max_turns=max_turns,
                 reasoning_effort=reasoning_effort, extra_body=extra_body,
                 extra_headers=extra_headers, backend=backend)
@@ -1172,6 +1203,7 @@ class PageIndexClient:
             from .local_chat import run_cloud_chat_stream
             chunks = self.chat_completions(messages, stream=True,
                                            stream_metadata=True,
+                                           enable_citations=enable_citations,
                                            doc_id=doc_id, model=model,
                                            reasoning_effort=reasoning_effort,
                                            max_turns=max_turns,
@@ -1181,6 +1213,7 @@ class PageIndexClient:
             return run_cloud_chat_stream(
                 cast(Iterator[dict[str, Any]], chunks), resolved)
         result = self.chat_completions(messages, doc_id=doc_id, model=model,
+                                       enable_citations=enable_citations,
                                        reasoning_effort=reasoning_effort,
                                        max_turns=max_turns, backend=backend,
                                        extra_headers=extra_headers,
@@ -1977,6 +2010,27 @@ class PageIndexClient:
         from .agent_tools import build_agent_instructions
         return build_agent_instructions(
             self, doc_id, include_management=include_management)
+
+    def citation_prompt(self, format: str = "cite") -> str:
+        """
+        The citation discipline for cited answers — grounding rules plus
+        how each citation is written — as served by the PageIndex MCP
+        server's ``cited_answer`` prompt — what own-model
+        ``chat(citations=...)`` adds. Fetch it here to append to
+        ``agent_instructions()`` for an agent you build with a framework,
+        or to pass another format through ``instructions=`` — it is
+        guidance, so it belongs in the system prompt.
+
+        ``format`` picks how a citation is written: ``"cite"`` (the
+        ``<cite doc= page= block=/>`` tags PageIndex chat writes and
+        renders — the default), ``"markdown"`` (a bracketed
+        ``[doc, p. N]`` reference, for hosts that strip tags) or
+        ``"footnote"`` (Markdown footnotes); the server rejects any
+        other value. Local documents: the SDK's frozen copy of the
+        same prompt (page-level — local page content has no blocks).
+        """
+        from .agent_tools import fetch_citation_prompt
+        return fetch_citation_prompt(self, format)
 
     # ---------- FOLDER MANAGEMENT ----------
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1039,9 +1039,10 @@ class PageIndexClient:
                 PageIndex MCP server's ``cited_answer`` prompt, joining
                 the system prompt after the managed prompt and before
                 ``instructions``; local documents get the SDK's copy
-                (pages only); other formats: ``citation_prompt()``
-                passed through ``instructions=``. Managed chat: its own
-                citations (``chat_completions``'s ``enable_citations``).
+                (pages only); another format (own-model chat only):
+                ``citation_prompt()`` passed through ``instructions=``
+                instead. Managed chat: its own citations
+                (``chat_completions``'s ``enable_citations``).
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1122,6 +1123,11 @@ class PageIndexClient:
                 "system blocks; the other lanes take a string.")
         from .local_chat import _refuse_skeleton
         _refuse_skeleton(extra_body)
+        if citations and citations is not True:
+            raise PageIndexAPIError(
+                "citations must be True or False — for another format pass "
+                "citation_prompt(format=...) as instructions= (own-model "
+                "chat).")
         enable_citations = False
         if citations:
             if self._local_chat:
@@ -1293,7 +1299,7 @@ class PageIndexClient:
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
             enable_citations: Managed chat only — own-model chat raises
-                (the in-process engine has no citation machinery).
+                (cite there with ``chat(citations=True)``).
             model: Own-model chat only — backend model name (defaults to
                 ``chat_model``). The managed endpoint selects its own.
             max_turns: Own-model chat only — cap on agent turns per call.
@@ -2016,9 +2022,10 @@ class PageIndexClient:
         The citation discipline for cited answers — grounding rules plus
         how each citation is written — as served by the PageIndex MCP
         server's ``cited_answer`` prompt — what own-model
-        ``chat(citations=...)`` adds. Fetch it here to append to
+        ``chat(citations=True)`` adds. Fetch it here to append to
         ``agent_instructions()`` for an agent you build with a framework,
-        or to pass another format through ``instructions=`` — it is
+        or to pass another format through own-model ``chat``'s
+        ``instructions=`` in place of ``citations=True`` — it is
         guidance, so it belongs in the system prompt.
 
         ``format`` picks how a citation is written: ``"cite"`` (the
@@ -2030,7 +2037,7 @@ class PageIndexClient:
         same prompt (page-level — local page content has no blocks).
         """
         from .agent_tools import fetch_citation_prompt
-        return fetch_citation_prompt(self, format)
+        return fetch_citation_prompt(self, format or "cite")
 
     # ---------- FOLDER MANAGEMENT ----------
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -958,7 +958,8 @@ def run_chat_completions(client, messages, stream: bool = False,
     if enable_citations:
         raise PageIndexAPIError(
             "enable_citations needs the managed chat endpoint — "
-            + ("drop the chat model configuration to use it."
+            + ("drop the chat model configuration to use it, or cite "
+               "with your own model via chat(citations=True)."
                if getattr(client, "api_key", None) else
                "local mode does not store the block-level OCR data "
                "citations need."))

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -958,11 +958,9 @@ def run_chat_completions(client, messages, stream: bool = False,
     if enable_citations:
         raise PageIndexAPIError(
             "enable_citations needs the managed chat endpoint — "
-            + ("drop the chat model configuration to use it, or cite "
-               "with your own model via chat(citations=True)."
-               if getattr(client, "api_key", None) else
-               "local mode does not store the block-level OCR data "
-               "citations need."))
+            + ("drop the chat model configuration to use it, or "
+               if getattr(client, "api_key", None) else "")
+            + "cite with your own model via chat(citations=True).")
     _require_openai_agents("chat")
     _validate_max_turns(max_turns)
     agent, items, model_name = _chat_agent(

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -2,8 +2,10 @@
 
 Backs the cloud branches of ``client.agent_tools()`` and
 ``client.agent_instructions()``: ``tools/list`` discovers the live tool set,
-``tools/call`` executes a tool, and the ``initialize`` handshake carries the
-server's agent instructions. Synchronous, requests-only.
+``tools/call`` executes a tool, ``prompts/list`` / ``prompts/get`` fetch the
+server's prompts (e.g. ``cited_answer``), and the ``initialize`` handshake
+carries the server's agent instructions and capabilities. Synchronous,
+requests-only.
 Works against both stateful and stateless servers: a session id returned by
 ``initialize`` is echoed back, and a session-carrying request rejected with
 HTTP 404 (the spec's expired-session status) re-initializes once and
@@ -58,6 +60,7 @@ class McpBridge:
         self._session_id: Optional[str] = None
         self._protocol_version: Optional[str] = None
         self._instructions: Optional[str] = None
+        self._capabilities: dict[str, Any] = {}
         self._initialized = False
         self._lock = threading.RLock()
         self._next_id = 0
@@ -176,6 +179,9 @@ class McpBridge:
             self._protocol_version = result.get("protocolVersion",
                                                 _PROTOCOL_VERSION)
             self._instructions = result.get("instructions")
+            capabilities = result.get("capabilities")
+            self._capabilities = (capabilities
+                                  if isinstance(capabilities, dict) else {})
             self._initialized = True
             # Sent inside the lock so no concurrent thread can slip a
             # request between the handshake and this notification.
@@ -193,21 +199,55 @@ class McpBridge:
         self._ensure_initialized()
         return self._instructions
 
-    def list_tools(self) -> list[dict]:
-        tools: list[dict] = []
+    def _list_paginated(self, method: str, key: str) -> list[dict]:
+        items: list[dict] = []
         cursor: Optional[str] = None
         # A server echoing its cursor (or cycling) must not hang the client:
         # no-progress terminates, the page cap turns a cycle into an error.
         for _ in range(50):
             params = {"cursor": cursor} if cursor else {}
-            result = self._request("tools/list", params) or {}
-            tools.extend(result.get("tools") or [])
+            result = self._request(method, params) or {}
+            items.extend(result.get(key) or [])
             next_cursor = result.get("nextCursor")
             if not next_cursor or next_cursor == cursor:
-                return tools
+                return items
             cursor = next_cursor
         raise PageIndexAPIError(
-            "MCP tools/list pagination did not terminate within 50 pages.")
+            f"MCP {method} pagination did not terminate within 50 pages.")
+
+    def list_tools(self) -> list[dict]:
+        return self._list_paginated("tools/list", "tools")
+
+    def _require_prompts(self) -> None:
+        """Prompts are an optional server capability; a server without it
+        answers -32601 to prompts/*, which reads as a protocol fault rather
+        than the real cause."""
+        self._ensure_initialized()
+        if "prompts" not in self._capabilities:
+            raise PageIndexAPIError(
+                f"The MCP server at {self._url} does not serve prompts.")
+
+    def list_prompts(self) -> list[dict]:
+        """The server's prompt catalog (``prompts/list``): name, title,
+        description and declared arguments per entry."""
+        self._require_prompts()
+        return self._list_paginated("prompts/list", "prompts")
+
+    def get_prompt(self, name: str,
+                   arguments: Optional[dict[str, Any]] = None,
+                   ) -> "tuple[Optional[str], list[dict]]":
+        """Returns (description, messages): the prompt's ``PromptMessage``
+        list untouched — each ``{"role", "content"}`` — for callers to place
+        as their framework carries it (render_prompt_text is the text-only
+        rendering). Argument values travel as strings, per the MCP prompt
+        contract; None means "no arguments", not an empty object."""
+        self._require_prompts()
+        params: dict[str, Any] = {"name": name}
+        if arguments is not None:
+            params["arguments"] = {key: str(value)
+                                   for key, value in arguments.items()}
+        result = self._request("prompts/get", params) or {}
+        return result.get("description"), list(result.get("messages") or [])
 
     def call_tool(self, name: str, arguments: dict[str, Any],
                   ) -> "tuple[list[dict], bool]":
@@ -243,3 +283,19 @@ def render_text(blocks: list) -> str:
         else:
             texts.append(json.dumps(block, ensure_ascii=False))
     return "\n".join(texts)
+
+
+def render_prompt_text(messages: list) -> str:
+    """The text-only rendering of prompt messages, roles dropped: the
+    server's prompts are standing guidance (grounding and citation rules),
+    which a system prompt carries as plain text. A message's content is one
+    block per the 2025-06-18 schema; a list is accepted for forward
+    compatibility."""
+    blocks: list = []
+    for message in messages:
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, list):
+            blocks.extend(content)
+        elif content is not None:
+            blocks.append(content)
+    return render_text(blocks)

--- a/pageindex/mcp_bridge.py
+++ b/pageindex/mcp_bridge.py
@@ -288,14 +288,10 @@ def render_text(blocks: list) -> str:
 def render_prompt_text(messages: list) -> str:
     """The text-only rendering of prompt messages, roles dropped: the
     server's prompts are standing guidance (grounding and citation rules),
-    which a system prompt carries as plain text. A message's content is one
-    block per the 2025-06-18 schema; a list is accepted for forward
-    compatibility."""
+    which a system prompt carries as plain text."""
     blocks: list = []
     for message in messages:
         content = message.get("content") if isinstance(message, dict) else None
-        if isinstance(content, list):
-            blocks.extend(content)
-        elif content is not None:
+        if content is not None:
             blocks.append(content)
     return render_text(blocks)

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2451,8 +2451,8 @@ def test_cloud_agent_instructions_served_live(monkeypatch):
 def test_citation_prompt_cloud(monkeypatch):
     """The citation prompt is the server's cited_answer prompt, fetched
     over the same bridge session as agent_tools(); format rides as the
-    prompt's argument; PageIndex chat's cite format by default, "" leaves
-    the server's default."""
+    prompt's argument; PageIndex chat's cite format by default ("" is
+    unset, so the default too)."""
     import pageindex.mcp_bridge as mcp_bridge
     created = []
 
@@ -2473,11 +2473,11 @@ def test_citation_prompt_cloud(monkeypatch):
     cloud.agent_tools()
     assert cloud.citation_prompt() == "CITATIONS — cite"
     assert cloud.citation_prompt(format="markdown") == "CITATIONS — markdown"
-    assert cloud.citation_prompt(format="") == "CITATIONS — markdown"
+    assert cloud.citation_prompt(format="") == "CITATIONS — cite"
     assert len(created) == 1
     assert created[0].prompts == [("cited_answer", {"format": "cite"}),
                                   ("cited_answer", {"format": "markdown"}),
-                                  ("cited_answer", None)]
+                                  ("cited_answer", {"format": "cite"})]
 
 
 def test_citation_prompt_empty_raises(monkeypatch):
@@ -2499,7 +2499,7 @@ def test_citation_prompt_local_frozen_copy(client):
     local tools named."""
     from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
     assert client.citation_prompt() == LOCAL_CITATION_PROMPTS["cite"]
-    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["markdown"]
+    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["cite"]
     for fmt in ("markdown", "cite", "footnote"):
         text = client.citation_prompt(format=fmt)
         assert text == LOCAL_CITATION_PROMPTS[fmt]
@@ -2526,14 +2526,13 @@ def test_live_local_citation_prompts_match_cloud():
 @pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
 def test_live_cloud_citation_prompt_formats():
     """The real server serves cited_answer in all three formats, each a
-    distinct rendering of the same rules; bare == markdown."""
+    distinct rendering of the same rules."""
     cloud = PageIndexCloudClient(api_key=LIVE_KEY)
     texts = {fmt: cloud.citation_prompt(format=fmt)
              for fmt in ("markdown", "cite", "footnote")}
     assert all("CITATIONS" in text for text in texts.values())
     assert len(set(texts.values())) == 3
     assert cloud.citation_prompt() == texts["cite"]
-    assert cloud.citation_prompt(format="") == texts["markdown"]  # server default
 
 
 def test_cloud_bridge_cache_threadsafe_and_pickle_clean(monkeypatch):

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -3076,7 +3076,8 @@ def _fake_requests(monkeypatch, fake_post):
     leak process-wide."""
     import requests as requests_mod
     monkeypatch.setattr("pageindex.mcp_bridge.requests", types.SimpleNamespace(
-        Session=lambda: types.SimpleNamespace(post=fake_post),
+        Session=lambda: types.SimpleNamespace(
+            post=fake_post, mount=lambda *a, **k: None),
         RequestException=requests_mod.RequestException))
 
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2448,6 +2448,94 @@ def test_cloud_agent_instructions_served_live(monkeypatch):
     assert len(created) == 1
 
 
+def test_citation_prompt_cloud(monkeypatch):
+    """The citation prompt is the server's cited_answer prompt, fetched
+    over the same bridge session as agent_tools(); format rides as the
+    prompt's argument; PageIndex chat's cite format by default, "" leaves
+    the server's default."""
+    import pageindex.mcp_bridge as mcp_bridge
+    created = []
+
+    class _Bridge(_FakeBridge):
+        def __init__(self, url, headers):
+            super().__init__(url, headers)
+            created.append(self)
+            self.prompts = []
+
+        def get_prompt(self, name, arguments=None):
+            self.prompts.append((name, arguments))
+            fmt = (arguments or {}).get("format", "markdown")
+            return "Cited answers", [{"role": "user", "content": {
+                "type": "text", "text": f"CITATIONS — {fmt}"}}]
+
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _Bridge)
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+    cloud.agent_tools()
+    assert cloud.citation_prompt() == "CITATIONS — cite"
+    assert cloud.citation_prompt(format="markdown") == "CITATIONS — markdown"
+    assert cloud.citation_prompt(format="") == "CITATIONS — markdown"
+    assert len(created) == 1
+    assert created[0].prompts == [("cited_answer", {"format": "cite"}),
+                                  ("cited_answer", {"format": "markdown"}),
+                                  ("cited_answer", None)]
+
+
+def test_citation_prompt_empty_raises(monkeypatch):
+    """No silent empty guidance: a prompt with no text raises."""
+    import pageindex.mcp_bridge as mcp_bridge
+
+    class _Bridge(_FakeBridge):
+        def get_prompt(self, name, arguments=None):
+            return None, []
+
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _Bridge)
+    with pytest.raises(PageIndexAPIError, match="empty cited_answer prompt"):
+        PageIndexCloudClient(api_key="pi-test-key").citation_prompt()
+
+
+def test_citation_prompt_local_frozen_copy(client):
+    """Local documents get the SDK's frozen copy of the server's prompt:
+    one text per format, PageIndex chat's cite format by default, only
+    local tools named."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    assert client.citation_prompt() == LOCAL_CITATION_PROMPTS["cite"]
+    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["markdown"]
+    for fmt in ("markdown", "cite", "footnote"):
+        text = client.citation_prompt(format=fmt)
+        assert text == LOCAL_CITATION_PROMPTS[fmt]
+        assert "CITATIONS" in text and "get_document_image" not in text
+        named = set(re.findall(r"\b(\w+)\(", text))
+        assert named and named <= set(tool_names(include_management=True))
+    with pytest.raises(PageIndexAPIError, match="markdown, cite, footnote"):
+        client.citation_prompt(format="bogus")
+
+
+@pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
+def test_live_local_citation_prompts_match_cloud():
+    """The frozen local copies are the server's texts minus the one bullet
+    naming get_document_image(); any other server edit fails here."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    cloud = PageIndexCloudClient(api_key=LIVE_KEY)
+    for fmt, frozen in LOCAL_CITATION_PROMPTS.items():
+        live = cloud.citation_prompt(format=fmt).split("\n")
+        dropped = [line for line in live if "get_document_image()" in line]
+        assert len(dropped) == 1, fmt
+        assert "\n".join(line for line in live if line not in dropped) == frozen
+
+
+@pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
+def test_live_cloud_citation_prompt_formats():
+    """The real server serves cited_answer in all three formats, each a
+    distinct rendering of the same rules; bare == markdown."""
+    cloud = PageIndexCloudClient(api_key=LIVE_KEY)
+    texts = {fmt: cloud.citation_prompt(format=fmt)
+             for fmt in ("markdown", "cite", "footnote")}
+    assert all("CITATIONS" in text for text in texts.values())
+    assert len(set(texts.values())) == 3
+    assert cloud.citation_prompt() == texts["cite"]
+    assert cloud.citation_prompt(format="") == texts["markdown"]  # server default
+
+
 def test_cloud_bridge_cache_threadsafe_and_pickle_clean(monkeypatch):
     """One bridge per client even under concurrent first calls, and the
     bridge lives off the instance so cloud clients stay picklable."""

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2987,8 +2987,7 @@ def _fake_requests(monkeypatch, fake_post):
     Session posts through ``fake_post`` — patching the shared module would
     leak process-wide."""
     import requests as requests_mod
-    import pageindex.mcp_bridge as mcp_bridge
-    monkeypatch.setattr(mcp_bridge, "requests", types.SimpleNamespace(
+    monkeypatch.setattr("pageindex.mcp_bridge.requests", types.SimpleNamespace(
         Session=lambda: types.SimpleNamespace(post=fake_post),
         RequestException=requests_mod.RequestException))
 

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2498,6 +2498,7 @@ def test_citation_prompt_local_frozen_copy(client):
     one text per format, PageIndex chat's cite format by default, only
     local tools named."""
     from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    assert len(set(LOCAL_CITATION_PROMPTS.values())) == 3
     assert client.citation_prompt() == LOCAL_CITATION_PROMPTS["cite"]
     assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["cite"]
     for fmt in ("markdown", "cite", "footnote"):
@@ -3183,10 +3184,9 @@ def test_render_prompt_text_flattens_messages():
 
     assert render_prompt_text([
         {"role": "user", "content": {"type": "text", "text": "a"}},
-        # A list-valued content is accepted for forward compatibility.
-        {"role": "assistant", "content": [{"type": "text", "text": "b"},
-                                          {"type": "image", "data": "QUJD",
-                                           "mimeType": "image/png"}]},
+        {"role": "assistant", "content": {"type": "text", "text": "b"}},
+        {"role": "user", "content": {"type": "image", "data": "QUJD",
+                                     "mimeType": "image/png"}},
         {"role": "user"},
     ]) == "a\nb\n[image/png content omitted: ~1 KB]"
     assert render_prompt_text([]) == ""

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2980,3 +2980,127 @@ def test_as_openai_tools_transport_failure_escapes_the_run(monkeypatch):
     with pytest.raises(Exception) as info:
         asyncio.run(tool.on_invoke_tool(None, '{"image_path": "x"}'))
     assert _pageindex_cause(info.value).status_code == 429
+
+
+def _fake_requests(monkeypatch, fake_post):
+    """Swap the bridge module's own ``requests`` binding for a fake whose
+    Session posts through ``fake_post`` — patching the shared module would
+    leak process-wide."""
+    import requests as requests_mod
+    import pageindex.mcp_bridge as mcp_bridge
+    monkeypatch.setattr(mcp_bridge, "requests", types.SimpleNamespace(
+        Session=lambda: types.SimpleNamespace(post=fake_post),
+        RequestException=requests_mod.RequestException))
+
+
+class _JsonResp:
+    def __init__(self, status, body=None, headers=None):
+        self.status_code = status
+        self._body = body
+        self.headers = headers or {"Content-Type": "application/json"}
+        self.text = json.dumps(body) if body else ""
+        self.content = self.text.encode("utf-8")
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+def test_mcp_bridge_prompts(monkeypatch):
+    """prompts/list paginates like tools/list; prompts/get sends arguments
+    only when given (stringified — the prompt contract carries strings)
+    and hands the messages back untouched."""
+    from pageindex.mcp_bridge import McpBridge, render_prompt_text
+
+    posts = []
+    catalog = {None: {"prompts": [{"name": "cited_answer",
+                                   "arguments": [{"name": "format",
+                                                  "required": False}]}],
+                      "nextCursor": "p2"},
+               "p2": {"prompts": [{"name": "other"}]}}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posts.append(json)
+        method, rid = json.get("method"), json.get("id")
+        if method == "initialize":
+            return _JsonResp(200, {"jsonrpc": "2.0", "id": rid, "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}, "prompts": {"listChanged": False}},
+                "instructions": "SERVER GUIDANCE"}})
+        if method == "notifications/initialized":
+            return _JsonResp(202)
+        if method == "prompts/list":
+            page = catalog[(json.get("params") or {}).get("cursor")]
+            return _JsonResp(200, {"jsonrpc": "2.0", "id": rid, "result": page})
+        if method == "prompts/get":
+            params = json["params"]
+            if params["name"] != "cited_answer":
+                return _JsonResp(200, {"jsonrpc": "2.0", "id": rid, "error": {
+                    "code": -32602,
+                    "message": f"Prompt {params['name']} not found"}})
+            fmt = (params.get("arguments") or {}).get("format", "markdown")
+            return _JsonResp(200, {"jsonrpc": "2.0", "id": rid, "result": {
+                "description": "Cited answers",
+                "messages": [{"role": "user", "content": {
+                    "type": "text", "text": f"CITATIONS — {fmt}"}}]}})
+        raise AssertionError(f"unexpected method {method}")
+
+    _fake_requests(monkeypatch, fake_post)
+    bridge = McpBridge("https://api.pageindex.ai/mcp", {"Authorization": "Bearer k"})
+
+    assert [p["name"] for p in bridge.list_prompts()] == ["cited_answer", "other"]
+
+    description, messages = bridge.get_prompt("cited_answer")
+    assert description == "Cited answers"
+    assert messages == [{"role": "user", "content": {"type": "text",
+                                                     "text": "CITATIONS — markdown"}}]
+    # None ≡ no arguments on the wire, not an empty object.
+    assert "arguments" not in posts[-1]["params"]
+    assert render_prompt_text(messages) == "CITATIONS — markdown"
+
+    _, messages = bridge.get_prompt("cited_answer", {"format": "cite"})
+    assert posts[-1]["params"]["arguments"] == {"format": "cite"}
+    assert render_prompt_text(messages) == "CITATIONS — cite"
+
+    with pytest.raises(PageIndexAPIError, match="-32602: Prompt nope not found"):
+        bridge.get_prompt("nope")
+
+
+def test_mcp_bridge_prompts_require_server_capability(monkeypatch):
+    """A server without the prompts capability would answer -32601 to
+    prompts/*; the bridge names the real cause instead, and never sends
+    the request."""
+    from pageindex.mcp_bridge import McpBridge
+
+    methods = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        methods.append(json.get("method"))
+        if json.get("method") == "initialize":
+            return _JsonResp(200, {"jsonrpc": "2.0", "id": json["id"], "result": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {"tools": {}, "resources": {}}}})
+        return _JsonResp(202)
+
+    _fake_requests(monkeypatch, fake_post)
+    bridge = McpBridge("https://api.pageindex.ai/mcp", {})
+    with pytest.raises(PageIndexAPIError, match="does not serve prompts"):
+        bridge.list_prompts()
+    with pytest.raises(PageIndexAPIError, match="does not serve prompts"):
+        bridge.get_prompt("cited_answer")
+    assert "prompts/list" not in methods and "prompts/get" not in methods
+
+
+def test_render_prompt_text_flattens_messages():
+    from pageindex.mcp_bridge import render_prompt_text
+
+    assert render_prompt_text([
+        {"role": "user", "content": {"type": "text", "text": "a"}},
+        # A list-valued content is accepted for forward compatibility.
+        {"role": "assistant", "content": [{"type": "text", "text": "b"},
+                                          {"type": "image", "data": "QUJD",
+                                           "mimeType": "image/png"}]},
+        {"role": "user"},
+    ]) == "a\nb\n[image/png content omitted: ~1 KB]"
+    assert render_prompt_text([]) == ""

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3525,6 +3525,8 @@ def test_chat_citations_managed(monkeypatch):
     assert seen[-1]["enable_citations"] is True
     cloud.chat("q")
     assert seen[-1]["enable_citations"] is False
+    cloud.chat("q", protocol="chat_completions", citations=True)
+    assert seen[-1]["enable_citations"] is True
     with pytest.raises(PageIndexAPIError, match="True or False"):
         cloud.chat("q", citations="cite")
 

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3455,6 +3455,94 @@ def test_chat_instructions_precede_history_system_rows(client, store_path,
     assert seen["extra"] == []
 
 
+def _citing(bridge):
+    """Teach a FakeBridge the cited_answer prompt, recording each fetch."""
+    bridge.prompts = []
+
+    def get_prompt(name, arguments=None):
+        bridge.prompts.append((name, arguments))
+        fmt = (arguments or {}).get("format", "markdown")
+        return "Cited answers", [{"role": "user", "content": {
+            "type": "text", "text": f"CITATIONS — {fmt}"}}]
+
+    bridge.get_prompt = get_prompt
+    return bridge
+
+
+@needs_agents
+def test_chat_citations_join_the_managed_prompt(bridge_client, fake_model):
+    """citations=True on own-model chat: the server's cited_answer prompt
+    (PageIndex chat's cite format) joins the system prompt after the
+    managed prompt and before the caller's instructions; off fetches
+    nothing."""
+    client, bridge = bridge_client
+    _citing(bridge)
+    fake = fake_model([[_msg_item("ok")], [_msg_item("ok")]])
+    assert client.chat("q", citations=True, instructions="analyst") == "ok"
+    system = fake.instructions[0]
+    assert (system.index("CLOUD LIVE INSTRUCTIONS")
+            < system.index("CITATIONS — cite") < system.index("analyst"))
+    assert bridge.prompts == [("cited_answer", {"format": "cite"})]
+    client.chat("q")
+    assert "CITATIONS" not in fake.instructions[1]
+    assert len(bridge.prompts) == 1
+
+
+def test_chat_citations_on_protocol_lanes(bridge_client, monkeypatch):
+    """The protocol lanes carry the same guidance in their instructions /
+    system: prepended to a string, a leading block before caller blocks."""
+    client, bridge = bridge_client
+    _citing(bridge)
+    seen = []
+    monkeypatch.setattr(local_chat, "run_responses",
+                        lambda c, input, **kw: seen.append(kw) or "door")
+    monkeypatch.setattr(local_chat, "run_messages",
+                        lambda c, messages, **kw: seen.append(kw) or "door")
+    client.chat("q", protocol="responses", citations=True,
+                instructions="be brief")
+    assert seen[-1]["instructions"] == "CITATIONS — cite\n\nbe brief"
+    blocks = [{"type": "text", "text": "persona"}]
+    client.chat("q", protocol="messages", model="claude-x", citations=True,
+                instructions=blocks)
+    assert seen[-1]["system"] == [
+        {"type": "text", "text": "CITATIONS — cite"}, *blocks]
+    client.chat("q", protocol="messages", model="claude-x", citations=True)
+    assert seen[-1]["system"] == "CITATIONS — cite"
+
+
+def test_chat_citations_managed(monkeypatch):
+    """Managed chat: citations=True is the endpoint's enable_citations."""
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+    seen = []
+    monkeypatch.setattr(
+        cloud._api, "chat_completions",
+        lambda **kw: seen.append(kw) or (
+            iter([_cloud_chunk("ok")]) if kw.get("stream")
+            else {"choices": [{"message": {"content": "ok"}}]}))
+    assert cloud.chat("q", citations=True) == "ok"
+    assert seen[-1]["enable_citations"] is True
+    assert "".join(cloud.chat("q", stream=True, citations=True)) == "ok"
+    assert seen[-1]["enable_citations"] is True
+    cloud.chat("q")
+    assert seen[-1]["enable_citations"] is False
+
+
+def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch):
+    """Local documents: the frozen copy joins the system prompt the same
+    way (pages are all local content has)."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    seen = []
+    monkeypatch.setattr(
+        local_chat, "run_chat_completions",
+        lambda c, messages, **kw: seen.append(messages) or {
+            "choices": [{"message": {"content": "ok"}}]})
+    assert client.chat("q", citations=True, instructions="analyst") == "ok"
+    assert seen[-1][0] == {"role": "system", "content":
+                           LOCAL_CITATION_PROMPTS["cite"] + "\n\nanalyst"}
+    client.chat("q")
+    assert seen[-1][0]["role"] == "user"
+
+
 def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):
     seen = {}
     monkeypatch.setattr(local_chat, "run_chat_completions",

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3466,7 +3466,6 @@ def _citing(bridge):
             "type": "text", "text": f"CITATIONS — {fmt}"}}]
 
     bridge.get_prompt = get_prompt
-    return bridge
 
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3510,7 +3510,8 @@ def test_chat_citations_on_protocol_lanes(bridge_client, monkeypatch):
 
 
 def test_chat_citations_managed(monkeypatch):
-    """Managed chat: citations=True is the endpoint's enable_citations."""
+    """Managed chat: citations=True is the endpoint's enable_citations; a
+    format name raises rather than silently meaning True."""
     cloud = PageIndexCloudClient(api_key="pi-test-key")
     seen = []
     monkeypatch.setattr(
@@ -3524,11 +3525,14 @@ def test_chat_citations_managed(monkeypatch):
     assert seen[-1]["enable_citations"] is True
     cloud.chat("q")
     assert seen[-1]["enable_citations"] is False
+    with pytest.raises(PageIndexAPIError, match="True or False"):
+        cloud.chat("q", citations="cite")
 
 
 def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch):
     """Local documents: the frozen copy joins the system prompt the same
-    way (pages are all local content has)."""
+    way (pages are all local content has); a format name raises rather
+    than silently meaning cite."""
     from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
     seen = []
     monkeypatch.setattr(
@@ -3540,6 +3544,8 @@ def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch)
                            LOCAL_CITATION_PROMPTS["cite"] + "\n\nanalyst"}
     client.chat("q")
     assert seen[-1][0]["role"] == "user"
+    with pytest.raises(PageIndexAPIError, match="True or False"):
+        client.chat("q", citations="markdown")
 
 
 def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):


### PR DESCRIPTION
Two pieces, one stack: the MCP bridge learns to fetch server prompts, and `chat(citations=True)` is the first consumer, folded in from #496.

## Bridge: server prompts over the MCP session

Adds `prompts/list` and `prompts/get` to `McpBridge`, so the SDK can fetch the server's `cited_answer` prompt (with its optional `format` argument) over the existing MCP session.

- `list_prompts()` / `get_prompt(name, arguments=None)`, plus `render_prompt_text()` for system-prompt placement.
- Server capabilities are recorded at initialize; prompt calls fail with a clear error when `prompts` is not advertised.

Wiring into the `*_agent_config` bundles stays a follow-up.

## `chat(citations=True)`

Own-model chat cites every claim the way PageIndex chat does: `<cite doc="…" page="…"/>` tags, `block="…"` added where the cloud document has blocks.

- Own-model chat over cloud documents: fetches the server's `cited_answer` prompt (`format=cite`, the same rules PageIndex chat uses) over the same bridge session as the tools, and folds it into the system prompt after the managed prompt and before the caller's `instructions`. All three lanes (answer lane, `protocol="responses"`, `protocol="messages"`) via the existing instructions plumbing; `local_chat.py` only reworded one refusal.
- Managed chat: `citations=True` passes `enable_citations=True` to the endpoint. The endpoint cites in its own `<doc=…;page=…>` markup, not `<cite>` tags, and the resolved citations it returns (bbox where the document has blocks) come back only from `chat_completions`.
- Local documents: a frozen copy of the same prompt (`LOCAL_CITATION_PROMPTS`, the live text minus the one bullet naming the cloud-only `get_document_image()` tool). Local page content carries no blocks, so citations resolve to pages.
- `citations` takes only `True`/`False`. Another format goes through `client.citation_prompt(format=...)` passed as `instructions=`; the getter also serves framework-built agents. `markdown` / `footnote` are the prompt's variants for hosts that strip tags.

## Verified

- 503 tests green (3 new bridge tests, 9 new citation tests, red-verified first), without-frameworks leg simulated, pyright clean. Bridge smoke-tested against `api.pageindex.ai/mcp`.
- Key-gated live tests: the three formats served and distinct; local frozen copies equal the live text minus that bullet.
- Live with real models: block document → `<cite doc="document_5.pdf" page="1" block="p1_text_1"/>`; legacy document → `<cite doc="1706.03762_24.pdf" page="1"/>`; locally indexed PDF → `<cite doc="q1-fy25-earnings.pdf" page="3"/>`; managed `citations=True` non-stream and stream.

## Not in this PR

- Docs (`agents.mdx`, `chat.mdx`'s hand-written `<cite>` system message becomes `citations=`) and a release-notes line, with the release.
- Server-side, for the prompt's owner: the managed API's citation prompt carries a literal example id `p1_text_001` that the model echoes on legacy documents (resolved citations then carry a `block_id` with no `bbox`); and a `granularity` argument on `cited_answer` would let the SDK offer page-only citations on block documents. Two more: the managed prompt writes the `<doc=…;page=…>` form its parser labels Old while `cited_answer` writes `<cite …/>` (the parser takes both, so moving the managed prompt to `<cite>` gives one syntax across lanes); and `cited_answer`'s GROUNDING ("never fill a gap from general knowledge") contradicts the MCP instructions' general-knowledge exemption, which the managed prompt keeps.

https://claude.ai/code/session_01XGBdRF2qoTcLNpRahj6QHx


