### PR TITLE
chat(citations=True): cite answers with the server's cited_answer prompt

### DIFF
--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1649,19 +1649,19 @@ CITATIONS
 }
 
 
-def fetch_citation_prompt(client, format: Optional[str] = None) -> str:
+def fetch_citation_prompt(client, format: str) -> str:
     """The MCP server's ``cited_answer`` prompt as system-prompt text;
-    ``format`` rides as its one argument (None: the server's default).
-    Local: the frozen copy, page-level."""
+    ``format`` rides as its one argument. Local: the frozen copy,
+    page-level."""
     if not getattr(client, "api_key", None):
         try:
-            return LOCAL_CITATION_PROMPTS[format or "markdown"]
+            return LOCAL_CITATION_PROMPTS[format]
         except KeyError:
             raise PageIndexAPIError(
                 f"citations format {format!r} is not one of "
                 f"{', '.join(LOCAL_CITATION_PROMPTS)}.") from None
     _, messages = _cloud_bridge(client, gated=True).get_prompt(
-        "cited_answer", {"format": format} if format else None)
+        "cited_answer", {"format": format})
     text = render_prompt_text(messages)
     if not text.strip():
         raise PageIndexAPIError(

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -30,7 +30,7 @@ import weakref
 from typing import Any, Callable, Optional
 
 from .errors import PageIndexAPIError
-from .mcp_bridge import render_text
+from .mcp_bridge import render_prompt_text, render_text
 
 TOOL_RESPONSE_CHAR_LIMIT = 100_000
 STRUCTURE_FIRST_PAGE_THRESHOLD = 20
@@ -1606,6 +1606,67 @@ AGENT_INSTRUCTIONS = "\n\n".join([
     _AFTER_DISCOVERY,
     _PERSISTENCE,
 ])
+
+
+# Frozen from the cloud MCP server's ``cited_answer`` prompt (pageindex-chat
+# server/mcp/prompts/cited-answer.ts, one text per format; "markdown" is its
+# default), minus the bullet naming the cloud-only get_document_image() tool.
+# The live parity test pins the rest verbatim. Local page content carries no
+# block_id, so the block rules stay dormant and citations resolve to pages.
+LOCAL_CITATION_PROMPTS: dict[str, str] = {
+    "markdown": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs, as a bracketed reference: [{docName}, p. {pageNumber}] or [{docName}, p. {pageNumber}, block {blockId}]. Place immediately after the claim.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one reference per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each reference must reference a SINGLE page integer. For multi-page citations, use separate references.""",
+    "cite": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs: <cite doc="{docName}" page="{pageNumber}"/> or <cite doc="{docName}" page="{pageNumber}" block="{blockId}"/>. Place immediately after the claim.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one tag per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each tag must reference a SINGLE page integer. For multi-page citations, use separate tags.
+- Close every answer with a "Sources" section: one plain-text line per cited block, formatted `- <document name>, page <page> (block <block_id>)`. Keep it even when the inline tags are present — a client that strips unknown HTML tags would otherwise leave the answer with no visible citations at all.""",
+    "footnote": """\
+GROUNDING
+- Answer only from the user's PageIndex documents. Call get_page_content() and state only what was actually read there.
+- Never fill a gap from general knowledge. When the documents do not answer the question, say so.
+
+CITATIONS
+- Cite only statements supported by tool outputs, as a Markdown footnote: put [^n] immediately after the claim and define it at the end of the answer as [^n]: {docName}, p. {pageNumber} or [^n]: {docName}, p. {pageNumber}, block {blockId}.
+- When page content includes block_id values, citations MUST be block-level: copy the exact block_id of the supporting block. Page-only cites are allowed ONLY when the tool output carries no block_id (legacy documents, structure outlines). NEVER invent or alter block_id values.
+- For a claim drawn from multiple blocks on one page, add one footnote per supporting block (at most 3); beyond that, cite the single strongest block.
+- Each footnote must reference a SINGLE page integer. For multi-page citations, use separate footnotes.
+- Number footnotes from 1 in order of first use; reuse a number when the same page and block support another claim. Every marker needs a definition and every definition a marker.""",
+}
+
+
+def fetch_citation_prompt(client, format: Optional[str] = None) -> str:
+    """The MCP server's ``cited_answer`` prompt as system-prompt text;
+    ``format`` rides as its one argument (None: the server's default).
+    Local: the frozen copy, page-level."""
+    if not getattr(client, "api_key", None):
+        try:
+            return LOCAL_CITATION_PROMPTS[format or "markdown"]
+        except KeyError:
+            raise PageIndexAPIError(
+                f"citations format {format!r} is not one of "
+                f"{', '.join(LOCAL_CITATION_PROMPTS)}.") from None
+    _, messages = _cloud_bridge(client, gated=True).get_prompt(
+        "cited_answer", {"format": format} if format else None)
+    text = render_prompt_text(messages)
+    if not text.strip():
+        raise PageIndexAPIError(
+            "The MCP server returned an empty cited_answer prompt.")
+    return text
 
 
 def _base_instructions(client, include_management: bool = False) -> str:

--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1608,11 +1608,10 @@ AGENT_INSTRUCTIONS = "\n\n".join([
 ])
 
 
-# Frozen from the cloud MCP server's ``cited_answer`` prompt (pageindex-chat
-# server/mcp/prompts/cited-answer.ts, one text per format; "markdown" is its
-# default), minus the bullet naming the cloud-only get_document_image() tool.
-# The live parity test pins the rest verbatim. Local page content carries no
-# block_id, so the block rules stay dormant and citations resolve to pages.
+# Frozen from the cloud MCP server's ``cited_answer`` prompt, minus the
+# bullet naming the cloud-only get_document_image() tool. Local page
+# content carries no block_id, so the block rules stay dormant and
+# citations resolve to pages.
 LOCAL_CITATION_PROMPTS: dict[str, str] = {
     "markdown": """\
 GROUNDING

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1105,8 +1105,7 @@ class PageIndexClient:
         enable_citations = False
         if citations:
             if self._local_chat:
-                from .agent_tools import fetch_citation_prompt
-                text = fetch_citation_prompt(self, "cite")
+                text = self.citation_prompt()
                 if isinstance(instructions, list):
                     instructions = [{"type": "text", "text": text},
                                     *instructions]

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1023,9 +1023,10 @@ class PageIndexClient:
                 PageIndex MCP server's ``cited_answer`` prompt, joining
                 the system prompt after the managed prompt and before
                 ``instructions``; local documents get the SDK's copy
-                (pages only); other formats: ``citation_prompt()``
-                passed through ``instructions=``. Managed chat: its own
-                citations (``chat_completions``'s ``enable_citations``).
+                (pages only); another format (own-model chat only):
+                ``citation_prompt()`` passed through ``instructions=``
+                instead. Managed chat: its own citations
+                (``chat_completions``'s ``enable_citations``).
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1096,6 +1097,11 @@ class PageIndexClient:
                 "instructions blocks are the Messages protocol's shape — "
                 "with protocol=\"messages\" they append after the managed "
                 "system blocks; the other lanes take a string.")
+        if citations and citations is not True:
+            raise PageIndexAPIError(
+                "citations must be True or False — for another format pass "
+                "citation_prompt(format=...) as instructions= (own-model "
+                "chat).")
         enable_citations = False
         if citations:
             if self._local_chat:
@@ -1255,7 +1261,7 @@ class PageIndexClient:
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
             enable_citations: Managed chat only — own-model chat raises
-                (the in-process engine has no citation machinery).
+                (cite there with ``chat(citations=True)``).
             model: Own-model chat only — backend model name (defaults to
                 ``chat_model``). The managed endpoint selects its own.
             max_turns: Own-model chat only — cap on agent turns per call.
@@ -1964,9 +1970,10 @@ class PageIndexClient:
         The citation discipline for cited answers — grounding rules plus
         how each citation is written — as served by the PageIndex MCP
         server's ``cited_answer`` prompt — what own-model
-        ``chat(citations=...)`` adds. Fetch it here to append to
+        ``chat(citations=True)`` adds. Fetch it here to append to
         ``agent_instructions()`` for an agent you build with a framework,
-        or to pass another format through ``instructions=`` — it is
+        or to pass another format through own-model ``chat``'s
+        ``instructions=`` in place of ``citations=True`` — it is
         guidance, so it belongs in the system prompt.
 
         ``format`` picks how a citation is written: ``"cite"`` (the
@@ -1978,7 +1985,7 @@ class PageIndexClient:
         same prompt (page-level — local page content has no blocks).
         """
         from .agent_tools import fetch_citation_prompt
-        return fetch_citation_prompt(self, format)
+        return fetch_citation_prompt(self, format or "cite")
 
     # ---------- FOLDER MANAGEMENT ----------
 

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -792,6 +792,7 @@ class PageIndexClient:
         *,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -810,6 +811,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -828,6 +830,7 @@ class PageIndexClient:
         *,
         protocol: Literal["responses", "messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -846,6 +849,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: Literal["responses"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -864,6 +868,7 @@ class PageIndexClient:
         show_process: Union[bool, Mapping[str, Any], None] = None,
         protocol: Literal["messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -882,6 +887,7 @@ class PageIndexClient:
         *,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -900,6 +906,7 @@ class PageIndexClient:
         *,
         protocol: Optional[str] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -917,6 +924,7 @@ class PageIndexClient:
         *,
         protocol: Optional[str] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
+        citations: bool = False,
         max_turns: Optional[int] = None,
         backend: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
@@ -1009,6 +1017,15 @@ class PageIndexClient:
                 string on every lane; with ``protocol="messages"`` also
                 a list of Messages system blocks. On the answer lane it
                 precedes any ``system`` rows in the history.
+            citations: Cite every claim the way PageIndex chat does —
+                ``<cite doc="…" page="…"/>`` tags, ``block="…"`` added
+                where the cloud document has blocks. The guidance is the
+                PageIndex MCP server's ``cited_answer`` prompt, joining
+                the system prompt after the managed prompt and before
+                ``instructions``; local documents get the SDK's copy
+                (pages only); other formats: ``citation_prompt()``
+                passed through ``instructions=``. Managed chat: its own
+                citations (``chat_completions``'s ``enable_citations``).
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1079,6 +1096,19 @@ class PageIndexClient:
                 "instructions blocks are the Messages protocol's shape — "
                 "with protocol=\"messages\" they append after the managed "
                 "system blocks; the other lanes take a string.")
+        enable_citations = False
+        if citations:
+            if self._local_chat:
+                from .agent_tools import fetch_citation_prompt
+                text = fetch_citation_prompt(self, "cite")
+                if isinstance(instructions, list):
+                    instructions = [{"type": "text", "text": text},
+                                    *instructions]
+                else:
+                    instructions = (f"{text}\n\n{instructions}"
+                                    if instructions else text)
+            else:
+                enable_citations = True
         if protocol is not None:
             self._require_own_chat(f"chat(protocol={protocol!r})")
             if protocol == "responses":
@@ -1140,6 +1170,7 @@ class PageIndexClient:
             from .local_chat import run_cloud_chat_stream
             chunks = self.chat_completions(messages, stream=True,
                                            stream_metadata=True,
+                                           enable_citations=enable_citations,
                                            doc_id=doc_id, model=model,
                                            reasoning_effort=reasoning_effort,
                                            max_turns=max_turns,
@@ -1149,6 +1180,7 @@ class PageIndexClient:
             return run_cloud_chat_stream(
                 cast(Iterator[dict[str, Any]], chunks), resolved)
         result = self.chat_completions(messages, doc_id=doc_id, model=model,
+                                       enable_citations=enable_citations,
                                        reasoning_effort=reasoning_effort,
                                        max_turns=max_turns, backend=backend,
                                        extra_headers=extra_headers,
@@ -1926,6 +1958,27 @@ class PageIndexClient:
         from .agent_tools import build_agent_instructions
         return build_agent_instructions(
             self, doc_id, include_management=include_management)
+
+    def citation_prompt(self, format: str = "cite") -> str:
+        """
+        The citation discipline for cited answers — grounding rules plus
+        how each citation is written — as served by the PageIndex MCP
+        server's ``cited_answer`` prompt — what own-model
+        ``chat(citations=...)`` adds. Fetch it here to append to
+        ``agent_instructions()`` for an agent you build with a framework,
+        or to pass another format through ``instructions=`` — it is
+        guidance, so it belongs in the system prompt.
+
+        ``format`` picks how a citation is written: ``"cite"`` (the
+        ``<cite doc= page= block=/>`` tags PageIndex chat writes and
+        renders — the default), ``"markdown"`` (a bracketed
+        ``[doc, p. N]`` reference, for hosts that strip tags) or
+        ``"footnote"`` (Markdown footnotes); the server rejects any
+        other value. Local documents: the SDK's frozen copy of the
+        same prompt (page-level — local page content has no blocks).
+        """
+        from .agent_tools import fetch_citation_prompt
+        return fetch_citation_prompt(self, format)
 
     # ---------- FOLDER MANAGEMENT ----------
 

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -935,11 +935,9 @@ def run_chat_completions(client, messages, stream: bool = False,
     if enable_citations:
         raise PageIndexAPIError(
             "enable_citations needs the managed chat endpoint — "
-            + ("drop the chat model configuration to use it, or cite "
-               "with your own model via chat(citations=True)."
-               if getattr(client, "api_key", None) else
-               "local mode does not store the block-level OCR data "
-               "citations need."))
+            + ("drop the chat model configuration to use it, or "
+               if getattr(client, "api_key", None) else "")
+            + "cite with your own model via chat(citations=True).")
     _require_openai_agents("chat_completions")
     _validate_max_turns(max_turns)
     agent, items, model_name = _chat_agent(

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -935,7 +935,8 @@ def run_chat_completions(client, messages, stream: bool = False,
     if enable_citations:
         raise PageIndexAPIError(
             "enable_citations needs the managed chat endpoint — "
-            + ("drop the chat model configuration to use it."
+            + ("drop the chat model configuration to use it, or cite "
+               "with your own model via chat(citations=True)."
                if getattr(client, "api_key", None) else
                "local mode does not store the block-level OCR data "
                "citations need."))

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2404,6 +2404,94 @@ def test_cloud_agent_instructions_served_live(monkeypatch):
     assert len(created) == 1
 
 
+def test_citation_prompt_cloud(monkeypatch):
+    """The citation prompt is the server's cited_answer prompt, fetched
+    over the same bridge session as agent_tools(); format rides as the
+    prompt's argument; PageIndex chat's cite format by default, "" leaves
+    the server's default."""
+    import pageindex.mcp_bridge as mcp_bridge
+    created = []
+
+    class _Bridge(_FakeBridge):
+        def __init__(self, url, headers):
+            super().__init__(url, headers)
+            created.append(self)
+            self.prompts = []
+
+        def get_prompt(self, name, arguments=None):
+            self.prompts.append((name, arguments))
+            fmt = (arguments or {}).get("format", "markdown")
+            return "Cited answers", [{"role": "user", "content": {
+                "type": "text", "text": f"CITATIONS — {fmt}"}}]
+
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _Bridge)
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+    cloud.agent_tools()
+    assert cloud.citation_prompt() == "CITATIONS — cite"
+    assert cloud.citation_prompt(format="markdown") == "CITATIONS — markdown"
+    assert cloud.citation_prompt(format="") == "CITATIONS — markdown"
+    assert len(created) == 1
+    assert created[0].prompts == [("cited_answer", {"format": "cite"}),
+                                  ("cited_answer", {"format": "markdown"}),
+                                  ("cited_answer", None)]
+
+
+def test_citation_prompt_empty_raises(monkeypatch):
+    """No silent empty guidance: a prompt with no text raises."""
+    import pageindex.mcp_bridge as mcp_bridge
+
+    class _Bridge(_FakeBridge):
+        def get_prompt(self, name, arguments=None):
+            return None, []
+
+    monkeypatch.setattr(mcp_bridge, "McpBridge", _Bridge)
+    with pytest.raises(PageIndexAPIError, match="empty cited_answer prompt"):
+        PageIndexCloudClient(api_key="pi-test-key").citation_prompt()
+
+
+def test_citation_prompt_local_frozen_copy(client):
+    """Local documents get the SDK's frozen copy of the server's prompt:
+    one text per format, PageIndex chat's cite format by default, only
+    local tools named."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    assert client.citation_prompt() == LOCAL_CITATION_PROMPTS["cite"]
+    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["markdown"]
+    for fmt in ("markdown", "cite", "footnote"):
+        text = client.citation_prompt(format=fmt)
+        assert text == LOCAL_CITATION_PROMPTS[fmt]
+        assert "CITATIONS" in text and "get_document_image" not in text
+        named = set(re.findall(r"\b(\w+)\(", text))
+        assert named and named <= set(tool_names(include_management=True))
+    with pytest.raises(PageIndexAPIError, match="markdown, cite, footnote"):
+        client.citation_prompt(format="bogus")
+
+
+@pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
+def test_live_local_citation_prompts_match_cloud():
+    """The frozen local copies are the server's texts minus the one bullet
+    naming get_document_image(); any other server edit fails here."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    cloud = PageIndexCloudClient(api_key=LIVE_KEY)
+    for fmt, frozen in LOCAL_CITATION_PROMPTS.items():
+        live = cloud.citation_prompt(format=fmt).split("\n")
+        dropped = [line for line in live if "get_document_image()" in line]
+        assert len(dropped) == 1, fmt
+        assert "\n".join(line for line in live if line not in dropped) == frozen
+
+
+@pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
+def test_live_cloud_citation_prompt_formats():
+    """The real server serves cited_answer in all three formats, each a
+    distinct rendering of the same rules; bare == markdown."""
+    cloud = PageIndexCloudClient(api_key=LIVE_KEY)
+    texts = {fmt: cloud.citation_prompt(format=fmt)
+             for fmt in ("markdown", "cite", "footnote")}
+    assert all("CITATIONS" in text for text in texts.values())
+    assert len(set(texts.values())) == 3
+    assert cloud.citation_prompt() == texts["cite"]
+    assert cloud.citation_prompt(format="") == texts["markdown"]  # server default
+
+
 def test_cloud_bridge_cache_threadsafe_and_pickle_clean(monkeypatch):
     """One bridge per client even under concurrent first calls, and the
     bridge lives off the instance so cloud clients stay picklable."""

--- a/tests/test_agent_tools.py
+++ b/tests/test_agent_tools.py
@@ -2407,8 +2407,8 @@ def test_cloud_agent_instructions_served_live(monkeypatch):
 def test_citation_prompt_cloud(monkeypatch):
     """The citation prompt is the server's cited_answer prompt, fetched
     over the same bridge session as agent_tools(); format rides as the
-    prompt's argument; PageIndex chat's cite format by default, "" leaves
-    the server's default."""
+    prompt's argument; PageIndex chat's cite format by default ("" is
+    unset, so the default too)."""
     import pageindex.mcp_bridge as mcp_bridge
     created = []
 
@@ -2429,11 +2429,11 @@ def test_citation_prompt_cloud(monkeypatch):
     cloud.agent_tools()
     assert cloud.citation_prompt() == "CITATIONS — cite"
     assert cloud.citation_prompt(format="markdown") == "CITATIONS — markdown"
-    assert cloud.citation_prompt(format="") == "CITATIONS — markdown"
+    assert cloud.citation_prompt(format="") == "CITATIONS — cite"
     assert len(created) == 1
     assert created[0].prompts == [("cited_answer", {"format": "cite"}),
                                   ("cited_answer", {"format": "markdown"}),
-                                  ("cited_answer", None)]
+                                  ("cited_answer", {"format": "cite"})]
 
 
 def test_citation_prompt_empty_raises(monkeypatch):
@@ -2455,7 +2455,7 @@ def test_citation_prompt_local_frozen_copy(client):
     local tools named."""
     from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
     assert client.citation_prompt() == LOCAL_CITATION_PROMPTS["cite"]
-    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["markdown"]
+    assert client.citation_prompt(format="") == LOCAL_CITATION_PROMPTS["cite"]
     for fmt in ("markdown", "cite", "footnote"):
         text = client.citation_prompt(format=fmt)
         assert text == LOCAL_CITATION_PROMPTS[fmt]
@@ -2482,14 +2482,13 @@ def test_live_local_citation_prompts_match_cloud():
 @pytest.mark.skipif(not LIVE_KEY, reason="PAGEINDEX_API_KEY not set")
 def test_live_cloud_citation_prompt_formats():
     """The real server serves cited_answer in all three formats, each a
-    distinct rendering of the same rules; bare == markdown."""
+    distinct rendering of the same rules."""
     cloud = PageIndexCloudClient(api_key=LIVE_KEY)
     texts = {fmt: cloud.citation_prompt(format=fmt)
              for fmt in ("markdown", "cite", "footnote")}
     assert all("CITATIONS" in text for text in texts.values())
     assert len(set(texts.values())) == 3
     assert cloud.citation_prompt() == texts["cite"]
-    assert cloud.citation_prompt(format="") == texts["markdown"]  # server default
 
 
 def test_cloud_bridge_cache_threadsafe_and_pickle_clean(monkeypatch):

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3325,6 +3325,94 @@ def test_chat_instructions_precede_history_system_rows(client, store_path,
     assert seen["extra"] == []
 
 
+def _citing(bridge):
+    """Teach a FakeBridge the cited_answer prompt, recording each fetch."""
+    bridge.prompts = []
+
+    def get_prompt(name, arguments=None):
+        bridge.prompts.append((name, arguments))
+        fmt = (arguments or {}).get("format", "markdown")
+        return "Cited answers", [{"role": "user", "content": {
+            "type": "text", "text": f"CITATIONS — {fmt}"}}]
+
+    bridge.get_prompt = get_prompt
+    return bridge
+
+
+@needs_agents
+def test_chat_citations_join_the_managed_prompt(bridge_client, fake_model):
+    """citations=True on own-model chat: the server's cited_answer prompt
+    (PageIndex chat's cite format) joins the system prompt after the
+    managed prompt and before the caller's instructions; off fetches
+    nothing."""
+    client, bridge = bridge_client
+    _citing(bridge)
+    fake = fake_model([[_msg_item("ok")], [_msg_item("ok")]])
+    assert client.chat("q", citations=True, instructions="analyst") == "ok"
+    system = fake.instructions[0]
+    assert (system.index("CLOUD LIVE INSTRUCTIONS")
+            < system.index("CITATIONS — cite") < system.index("analyst"))
+    assert bridge.prompts == [("cited_answer", {"format": "cite"})]
+    client.chat("q")
+    assert "CITATIONS" not in fake.instructions[1]
+    assert len(bridge.prompts) == 1
+
+
+def test_chat_citations_on_protocol_lanes(bridge_client, monkeypatch):
+    """The protocol lanes carry the same guidance in their instructions /
+    system: prepended to a string, a leading block before caller blocks."""
+    client, bridge = bridge_client
+    _citing(bridge)
+    seen = []
+    monkeypatch.setattr(local_chat, "run_responses",
+                        lambda c, input, **kw: seen.append(kw) or "door")
+    monkeypatch.setattr(local_chat, "run_messages",
+                        lambda c, messages, **kw: seen.append(kw) or "door")
+    client.chat("q", protocol="responses", citations=True,
+                instructions="be brief")
+    assert seen[-1]["instructions"] == "CITATIONS — cite\n\nbe brief"
+    blocks = [{"type": "text", "text": "persona"}]
+    client.chat("q", protocol="messages", model="claude-x", citations=True,
+                instructions=blocks)
+    assert seen[-1]["system"] == [
+        {"type": "text", "text": "CITATIONS — cite"}, *blocks]
+    client.chat("q", protocol="messages", model="claude-x", citations=True)
+    assert seen[-1]["system"] == "CITATIONS — cite"
+
+
+def test_chat_citations_managed(monkeypatch):
+    """Managed chat: citations=True is the endpoint's enable_citations."""
+    cloud = PageIndexCloudClient(api_key="pi-test-key")
+    seen = []
+    monkeypatch.setattr(
+        cloud._api, "chat_completions",
+        lambda **kw: seen.append(kw) or (
+            iter([_cloud_chunk("ok")]) if kw.get("stream")
+            else {"choices": [{"message": {"content": "ok"}}]}))
+    assert cloud.chat("q", citations=True) == "ok"
+    assert seen[-1]["enable_citations"] is True
+    assert "".join(cloud.chat("q", stream=True, citations=True)) == "ok"
+    assert seen[-1]["enable_citations"] is True
+    cloud.chat("q")
+    assert seen[-1]["enable_citations"] is False
+
+
+def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch):
+    """Local documents: the frozen copy joins the system prompt the same
+    way (pages are all local content has)."""
+    from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
+    seen = []
+    monkeypatch.setattr(
+        local_chat, "run_chat_completions",
+        lambda c, messages, **kw: seen.append(messages) or {
+            "choices": [{"message": {"content": "ok"}}]})
+    assert client.chat("q", citations=True, instructions="analyst") == "ok"
+    assert seen[-1][0] == {"role": "system", "content":
+                           LOCAL_CITATION_PROMPTS["cite"] + "\n\nanalyst"}
+    client.chat("q")
+    assert seen[-1][0]["role"] == "user"
+
+
 def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):
     seen = {}
     monkeypatch.setattr(local_chat, "run_chat_completions",

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3336,7 +3336,6 @@ def _citing(bridge):
             "type": "text", "text": f"CITATIONS — {fmt}"}}]
 
     bridge.get_prompt = get_prompt
-    return bridge
 
 
 @needs_agents

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -3380,7 +3380,8 @@ def test_chat_citations_on_protocol_lanes(bridge_client, monkeypatch):
 
 
 def test_chat_citations_managed(monkeypatch):
-    """Managed chat: citations=True is the endpoint's enable_citations."""
+    """Managed chat: citations=True is the endpoint's enable_citations; a
+    format name raises rather than silently meaning True."""
     cloud = PageIndexCloudClient(api_key="pi-test-key")
     seen = []
     monkeypatch.setattr(
@@ -3394,11 +3395,14 @@ def test_chat_citations_managed(monkeypatch):
     assert seen[-1]["enable_citations"] is True
     cloud.chat("q")
     assert seen[-1]["enable_citations"] is False
+    with pytest.raises(PageIndexAPIError, match="True or False"):
+        cloud.chat("q", citations="cite")
 
 
 def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch):
     """Local documents: the frozen copy joins the system prompt the same
-    way (pages are all local content has)."""
+    way (pages are all local content has); a format name raises rather
+    than silently meaning cite."""
     from pageindex.agent_tools import LOCAL_CITATION_PROMPTS
     seen = []
     monkeypatch.setattr(
@@ -3410,6 +3414,8 @@ def test_chat_citations_local_documents_use_the_frozen_copy(client, monkeypatch)
                            LOCAL_CITATION_PROMPTS["cite"] + "\n\nanalyst"}
     client.chat("q")
     assert seen[-1][0]["role"] == "user"
+    with pytest.raises(PageIndexAPIError, match="True or False"):
+        client.chat("q", citations="markdown")
 
 
 def test_chat_answer_lane_forwards_the_promoted_knobs(client, monkeypatch):


### PR DESCRIPTION
`chat(citations=True)` makes the answer cite every claim the way PageIndex chat does: `<cite doc="…" page="…"/>` tags, `block="…"` added where the cloud document has blocks. Stacks on #494 (bridge `prompts/get`); this PR's diff is the four files on top of it.

**How it works**
- Own-model chat over cloud documents: fetches the MCP server's `cited_answer` prompt (`format=cite`, the rules `citation-contract.ts` also feeds PageIndex chat) over the same bridge session as the tools, and folds it into the system prompt after the managed prompt and before the caller's `instructions`. All three lanes (answer lane, `protocol="responses"`, `protocol="messages"`) via the existing instructions plumbing; `local_chat.py` untouched.
- Managed chat: `citations=True` passes `enable_citations=True` to the endpoint.
- Local documents: a frozen copy of the same prompt (`LOCAL_CITATION_PROMPTS`, generated from the live text minus the one bullet naming the cloud-only `get_document_image()` tool). Local page content carries no blocks, so citations resolve to pages.
- `client.citation_prompt(format="cite")` exposes the same text for framework-built agents; `markdown` / `footnote` are the MCP prompt's variants for hosts that strip tags.

**Verified**
- 503 tests green (10 new, red-verified first), without-frameworks leg simulated, pyright clean.
- Key-gated live tests: the three formats served and distinct; local frozen copies equal the live text minus that bullet.
- Live with real models: block document → `<cite doc="document_5.pdf" page="1" block="p1_text_1"/>`; legacy document → `<cite doc="1706.03762_24.pdf" page="1"/>`; locally indexed PDF → `<cite doc="q1-fy25-earnings.pdf" page="3"/>`; managed `citations=True` non-stream and stream.

**Not in this PR**
- Docs (`agents.mdx`, `chat.mdx`'s hand-written `<cite>` system message becomes `citations=`) and a release-notes line, with the release.
- Server-side, for the prompt's owner: the managed API's citation prompt (pageindex-compute) carries a literal example id `p1_text_001` that the model echoes on legacy documents (resolved citations then carry a `block_id` with no `bbox`); and a `granularity` argument on `cited_answer` would let the SDK offer page-only citations on block documents.

https://claude.ai/code/session_01Ex6uKLsDrQjZkqypjSyPwA
