### PR TITLE
fix: stop masking utils import errors in page_index_md

### DIFF
--- a/pageindex/page_index_md.py
+++ b/pageindex/page_index_md.py
@@ -2,9 +2,10 @@ import asyncio
 import json
 import re
 import os
-try:
+if __package__:
     from .utils import *
-except:
+else:
+    # Run as a script (no parent package): resolve utils from the same directory.
     from utils import *
 
 async def get_node_summary(node, summary_token_threshold=200, model=None):

--- a/tests/test_page_index_md.py
+++ b/tests/test_page_index_md.py
@@ -1,6 +1,28 @@
+import subprocess
+import sys
 import unittest
+from pathlib import Path
 
 from pageindex.page_index_md import extract_nodes_from_markdown
+
+
+class UtilsImportFallbackTest(unittest.TestCase):
+    def test_script_mode_import_resolves_sibling_utils(self):
+        # Without a parent package the module must fall back to `from utils import *`.
+        module_dir = Path(__file__).resolve().parents[1] / "pageindex"
+        result = subprocess.run(
+            [sys.executable, "-c", "import page_index_md; print(page_index_md.count_tokens.__name__)"],
+            cwd=module_dir,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "count_tokens")
+
+    def test_package_import_does_not_swallow_errors(self):
+        source = (Path(__file__).resolve().parents[1] / "pageindex" / "page_index_md.py").read_text()
+        self.assertNotIn("except:", source)
 
 
 class ExtractNodesFromMarkdownTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #486

`pageindex/page_index_md.py` guarded its relative import with a bare `except:`. When `utils` failed to import for a real reason (missing dependency, syntax error), the fallback `from utils import *` ran instead and, in an installed package, died with `ModuleNotFoundError: No module named 'utils'`, hiding the original traceback.

**Change:** choose the import form by `__package__`: inside the package the relative import runs on its own and surfaces its own errors; when the file is executed as a script (no parent package) the sibling `utils` module is imported as before. No behaviour change for the normal `import pageindex.page_index_md` path.

**Tests** (`tests/test_page_index_md.py`): the script-mode fallback still resolves `utils` (run in a subprocess from the `pageindex/` directory), and the module no longer contains a bare `except:`.

```
pytest tests/test_page_index_md.py -q   # 5 passed
```
