### PR TITLE
Folders on chat: chat(folder_id=) and folder_context()

### DIFF
--- a/pageindex/agent_tools.py
+++ b/pageindex/agent_tools.py
@@ -1651,3 +1651,45 @@ def doc_targeting_block(client, doc_id) -> Optional[str]:
         "Use these documents' names to retrieve their content with "
         "get_document_structure() and get_page_content()."
     )
+
+
+def folder_targeting_block(client, folder_id) -> Optional[str]:
+    """The folder_id targeting text, rendered as the cloud's managed chat
+    renders its own: the folder's name and metadata and the directive to
+    discover its documents there. None for no folder — None, "", and
+    "root", the library itself, which the managed chat leaves untargeted.
+    A folder proper is cloud-only: local libraries have none."""
+    if folder_id is None:
+        return None
+    if not isinstance(folder_id, str):
+        raise PageIndexAPIError("folder_id must be a string.")
+    if folder_id in ("", "root"):
+        return None
+    if not getattr(client, "api_key", None):
+        raise PageIndexAPIError(
+            "folder_id is cloud-only — folders are not supported in local "
+            "mode. Create the client with an api_key to use folders.")
+    folders = client.list_folders().get("folders") or []
+    folder = next((f for f in folders if f.get("id") == folder_id), None)
+    if folder is None:
+        raise PageIndexAPIError(
+            f"Folder not found or access denied: {folder_id}")
+    metadata = {key: folder[key] for key in ("id", "name", "description")
+                if folder.get(key)}
+    return (
+        f"The user has specified folder: {folder.get('name')}\n"
+        f"Folder metadata: {json.dumps(metadata, ensure_ascii=False)}\n"
+        "Discover its documents with "
+        f'browse_documents(folder_id="{folder_id}", recursive=true) '
+        f'or search_documents(query, folder_id="{folder_id}", '
+        "recursive=true)."
+    )
+
+
+def targeting_block(client, doc_id, folder_id=None) -> Optional[str]:
+    """The chat lanes' leading user message: the folder block, then the
+    document block, joined as the managed chat joins them; None when
+    there is nothing to place."""
+    blocks = [folder_targeting_block(client, folder_id),
+              doc_targeting_block(client, doc_id)]
+    return "\n\n".join(block for block in blocks if block) or None

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -790,6 +790,7 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        folder_id: Optional[str] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -808,6 +809,7 @@ class PageIndexClient:
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
+        folder_id: Optional[str] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -826,6 +828,7 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        folder_id: Optional[str] = None,
         protocol: Literal["responses", "messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -844,6 +847,7 @@ class PageIndexClient:
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
+        folder_id: Optional[str] = None,
         protocol: Literal["responses"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -862,6 +866,7 @@ class PageIndexClient:
         model: Optional[str] = None,
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
+        folder_id: Optional[str] = None,
         protocol: Literal["messages"],
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -880,6 +885,7 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        folder_id: Optional[str] = None,
         protocol: None = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -898,6 +904,7 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        folder_id: Optional[str] = None,
         protocol: Optional[str] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -915,6 +922,7 @@ class PageIndexClient:
         reasoning_effort: Optional[str] = None,
         show_process: Union[bool, Mapping[str, Any], None] = None,
         *,
+        folder_id: Optional[str] = None,
         protocol: Optional[str] = None,
         instructions: Optional[Union[str, list[dict[str, Any]]]] = None,
         max_turns: Optional[int] = None,
@@ -957,6 +965,12 @@ class PageIndexClient:
                 documents: also enforced at the tool layer, not just
                 prompted. Cloud documents: the managed chat scopes
                 server-side; own-model chat targets at the prompt level.
+            folder_id: Folder ID to steer discovery toward that folder's
+                documents. Cloud-only. The managed chat scopes it
+                server-side; own-model chat leads the conversation with
+                the folder's targeting text (``folder_context``), ahead
+                of the document block. ``"root"`` is the whole library.
+                Keep it identical across a conversation's calls.
             stream: Answer lane: return a ``ChatStream`` — iterate it for
                 the answer as text chunks as they are produced
                 (``show_process`` is on by default, so the run's process
@@ -1092,6 +1106,7 @@ class PageIndexClient:
                         **given.get("reasoning", {})}}
                 return self._responses(
                     messages, model=model, stream=stream, doc_id=doc_id,
+                    folder_id=folder_id,
                     instructions=cast(Optional[str], instructions),
                     max_turns=max_turns, extra_body=body,
                     extra_headers=extra_headers, backend=backend)
@@ -1110,6 +1125,7 @@ class PageIndexClient:
                     **given.get("output_config", {})}}
             return self._messages(
                 messages, model=model, stream=stream, doc_id=doc_id,
+                folder_id=folder_id,
                 system=instructions, max_turns=max_turns, extra_body=body,
                 extra_headers=extra_headers, backend=backend)
         if instructions:
@@ -1131,7 +1147,7 @@ class PageIndexClient:
             if self._local_chat:
                 from .local_chat import run_chat_stream
                 return run_chat_stream(self, messages, doc_id=doc_id,
-                                       model=model,
+                                       folder_id=folder_id, model=model,
                                        reasoning_effort=reasoning_effort,
                                        show_process=resolved,
                                        max_turns=max_turns, backend=backend,
@@ -1141,6 +1157,7 @@ class PageIndexClient:
             chunks = self.chat_completions(messages, stream=True,
                                            stream_metadata=True,
                                            doc_id=doc_id, model=model,
+                                           folder_id=folder_id,
                                            reasoning_effort=reasoning_effort,
                                            max_turns=max_turns,
                                            backend=backend,
@@ -1149,6 +1166,7 @@ class PageIndexClient:
             return run_cloud_chat_stream(
                 cast(Iterator[dict[str, Any]], chunks), resolved)
         result = self.chat_completions(messages, doc_id=doc_id, model=model,
+                                       folder_id=folder_id,
                                        reasoning_effort=reasoning_effort,
                                        max_turns=max_turns, backend=backend,
                                        extra_headers=extra_headers,
@@ -1177,6 +1195,7 @@ class PageIndexClient:
         extra_body: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         backend: Optional[dict[str, Any]] = None,
+        folder_id: Optional[str] = None,
     ) -> Union[dict[str, Any], Iterator[str], Iterator[dict[str, Any]]]:
         """
         PageIndex Chat Completions: document QA in one call.
@@ -1219,6 +1238,11 @@ class PageIndexClient:
                 enforced at the tool layer, not just prompted. Cloud
                 documents: the managed chat scopes server-side;
                 own-model chat targets at the prompt level.
+            folder_id: Folder ID to steer discovery toward that folder's
+                documents (cloud-only): the managed chat scopes it
+                server-side; own-model chat leads the conversation with
+                the folder's targeting text, ahead of the document block.
+                ``"root"`` is the whole library.
             temperature: Sampling temperature, passed through to the model.
             stream_metadata: With stream=True, yield chunk dicts instead of
                 text pieces.
@@ -1274,6 +1298,7 @@ class PageIndexClient:
             from .local_chat import run_chat_completions
             return run_chat_completions(
                 self, messages, stream=stream, doc_id=doc_id,
+                folder_id=folder_id,
                 temperature=temperature, stream_metadata=stream_metadata,
                 enable_citations=enable_citations, model=model,
                 max_turns=max_turns, top_p=top_p, max_tokens=max_tokens,
@@ -1299,6 +1324,7 @@ class PageIndexClient:
         from .cloud_api import CloudAPI
         return cast(CloudAPI, self._api).chat_completions(
             messages=messages, stream=stream, doc_id=doc_id,
+            folder_id=folder_id,
             temperature=temperature, stream_metadata=stream_metadata,
             enable_citations=enable_citations,
         )
@@ -1318,6 +1344,7 @@ class PageIndexClient:
         extra_body: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         backend: Optional[dict[str, Any]] = None,
+        folder_id: Optional[str] = None,
     ) -> Union[dict[str, Any], Iterator[dict[str, Any]]]:
         """
         The engine behind ``chat(protocol="responses")``: document QA over
@@ -1359,6 +1386,10 @@ class PageIndexClient:
                 of the cached prompt prefix. Local documents: also
                 enforced at the tool layer; cloud documents:
                 prompt-level targeting only.
+            folder_id: Folder ID to steer discovery toward that folder's
+                documents (cloud-only), as the leading targeting text
+                ahead of the document block. ``"root"`` is the whole
+                library.
             instructions: Appended to the managed system prompt.
             temperature / top_p: Passed through to the model.
             max_turns: Cap on agent turns per call.
@@ -1386,6 +1417,7 @@ class PageIndexClient:
         from .local_chat import run_responses
         return run_responses(
             self, input, model=model, stream=stream, doc_id=doc_id,
+            folder_id=folder_id,
             instructions=instructions, temperature=temperature, top_p=top_p,
             max_turns=max_turns, max_output_tokens=max_output_tokens,
             reasoning=reasoning, extra_body=extra_body,
@@ -1409,6 +1441,7 @@ class PageIndexClient:
         extra_body: Optional[dict[str, Any]] = None,
         extra_headers: Optional[dict[str, str]] = None,
         backend: Optional[dict[str, Any]] = None,
+        folder_id: Optional[str] = None,
     ) -> Union[dict[str, Any], Iterator[Any]]:
         """
         The engine behind ``chat(protocol="messages")``: document QA over
@@ -1447,6 +1480,10 @@ class PageIndexClient:
                 targeting block it adds is re-set each call. Local
                 documents: also enforced at the tool layer; cloud
                 documents: prompt-level targeting only.
+            folder_id: Folder ID to steer discovery toward that folder's
+                documents (cloud-only), as the leading targeting text
+                ahead of the document block. ``"root"`` is the whole
+                library.
             system: Appended after the managed system blocks.
             temperature / top_p / top_k / stop_sequences: Passed through.
             max_turns: Cap on agent turns per call (default 10, like the
@@ -1472,7 +1509,7 @@ class PageIndexClient:
         from .local_chat import run_messages
         return run_messages(
             self, messages, model=model, max_tokens=max_tokens,
-            stream=stream, doc_id=doc_id, system=system,
+            stream=stream, doc_id=doc_id, folder_id=folder_id, system=system,
             temperature=temperature, top_p=top_p, top_k=top_k,
             stop_sequences=stop_sequences, max_turns=max_turns,
             thinking=thinking, extra_body=extra_body,
@@ -1629,8 +1666,9 @@ class PageIndexClient:
         instructions and ``as_openai_tools`` as the tools; clients with a
         configured ``chat_model`` — local mode, or cloud with
         ``chat_model=`` — also carry it (a plain cloud client omits
-        ``model`` so the framework default applies). To target documents,
-        prepend ``document_context(doc_id)`` to your first message; to
+        ``model`` so the framework default applies). To target documents
+        or a folder, prepend ``document_context(doc_id)`` /
+        ``folder_context(folder_id)`` to your first message; to
         customize further, switch to those methods directly. You run this
         config in your own environment, so its model auth comes from
         there — ``chat_backend`` does not travel with it.
@@ -1757,8 +1795,9 @@ class PageIndexClient:
         growing prompt from cache (pop the key if you place your own
         breakpoints — the API allows four). Unlike the chat lane,
         ``system`` here is the bare instructions string, without the chat
-        header or its block-level breakpoint. To target documents,
-        prepend ``document_context(doc_id)`` to your first message; to
+        header or its block-level breakpoint. To target documents or a
+        folder, prepend ``document_context(doc_id)`` /
+        ``folder_context(folder_id)`` to your first message; to
         customize further, switch to those methods directly.
 
         Args:
@@ -1841,10 +1880,10 @@ class PageIndexClient:
         (``agent_instructions``) and the server entry (``as_claude_mcp``,
         itself the tool gate) with its ``allowed_tools`` pre-approval,
         one ``include_management`` and ``server_name`` applied
-        everywhere. To target documents, prepend
-        ``document_context(doc_id)`` to your prompt; to customize (your
-        own system prompt, extra servers), switch to those methods
-        directly.
+        everywhere. To target documents or a folder, prepend
+        ``document_context(doc_id)`` / ``folder_context(folder_id)`` to
+        your prompt; to customize (your own system prompt, extra
+        servers), switch to those methods directly.
 
         Args:
             include_management (bool): Also allow tools that modify the
@@ -1908,6 +1947,23 @@ class PageIndexClient:
             raise PageIndexAPIError("doc_id must be a string or a list of "
                                     "strings.")
         return cast(str, doc_targeting_block(self, doc_id))
+
+    def folder_context(self, folder_id: str) -> str:
+        """
+        Folder targeting text for the first user message, placed as
+        ``document_context`` is (and ahead of it, the managed chat's
+        order): the folder's name and metadata, and the directive to
+        discover its documents there, rendered as the managed chat renders
+        its own ``folder_id``. ``chat(folder_id=...)`` places it for you.
+        Cloud-only: local libraries have no folders. ``"root"`` is the
+        library itself: ``""``, nothing to place, as the managed chat
+        places nothing for it. Raises PageIndexAPIError if the folder does
+        not exist.
+        """
+        from .agent_tools import folder_targeting_block
+        if folder_id is None:
+            raise PageIndexAPIError("folder_id must be a string.")
+        return folder_targeting_block(self, folder_id) or ""
 
     # ---------- FOLDER MANAGEMENT ----------
 

--- a/pageindex/cloud_api.py
+++ b/pageindex/cloud_api.py
@@ -197,7 +197,8 @@ class CloudAPI:
         doc_id: Optional[Union[str, List[str]]] = None,
         temperature: Optional[float] = None,
         stream_metadata: bool = False,
-        enable_citations: bool = False
+        enable_citations: bool = False,
+        folder_id: Optional[str] = None,
     ) -> Union[Dict[str, Any], Iterator[str], Iterator[Dict[str, Any]]]:
         """
         PageIndex Chat Completions. Optionally scoped to specific PageIndex documents.
@@ -209,6 +210,7 @@ class CloudAPI:
             temperature (Optional[float], optional): Sampling temperature. Default is None (uses API default).
             stream_metadata (bool, optional): If True and stream=True, return raw chunks with metadata instead of just text. Default is False.
             enable_citations (bool, optional): Enable citation instructions in responses. Default is False.
+            folder_id (Optional[str], optional): Folder ID to steer discovery toward one folder; "root" means the whole library.
 
         Returns:
             Union[Dict[str, Any], Iterator[str], Iterator[Dict[str, Any]]]:
@@ -223,6 +225,9 @@ class CloudAPI:
 
         if doc_id is not None:
             payload["doc_id"] = doc_id
+
+        if folder_id:
+            payload["folder_id"] = folder_id
 
         if temperature is not None:
             payload["temperature"] = temperature

--- a/pageindex/local_chat.py
+++ b/pageindex/local_chat.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from typing import Any, Iterator, Mapping, Optional, Union
 
-from .agent_tools import _base_instructions, doc_targeting_block
+from .agent_tools import _base_instructions, targeting_block
 from .chat_stream import ChatStream
 from .errors import PageIndexAPIError
 
@@ -386,7 +386,7 @@ def _validate_max_turns(max_turns) -> None:
 
 
 def _conversation_cache_key(model_name: str, instructions: str, doc_id,
-                            items) -> str:
+                            items, folder_id=None) -> str:
     """Stable per-conversation cache-routing key, sent as the OpenAI
     ``prompt_cache_key`` through ModelSettings.extra_body (openai-agents
     0.20 no longer derives it from RunConfig.group_id — verified against a
@@ -396,10 +396,11 @@ def _conversation_cache_key(model_name: str, instructions: str, doc_id,
     Callers pass the conversation's own items, never the SDK-prepended
     doc-targeting block: that block is byte-identical for every
     conversation about a document and would pool them all under one key.
-    doc_id carries the targeting identity instead — the same opening
-    question against different documents is different conversations."""
+    doc_id and folder_id carry the targeting identity instead — the same
+    opening question against different documents is different
+    conversations."""
     scope = [doc_id] if isinstance(doc_id, str) else doc_id
-    seed = json.dumps([model_name, instructions, scope,
+    seed = json.dumps([model_name, instructions, scope, folder_id,
                        items[0] if items else None],
                       sort_keys=True, default=str)
     return "pageindex-" + hashlib.sha256(seed.encode()).hexdigest()[:16]
@@ -608,19 +609,21 @@ def _responses_usage(raw_responses) -> dict:
 def _chat_agent(client, messages, doc_id, model, temperature=None,
                 top_p=None, reasoning_effort=None, extra_body=None,
                 max_tokens=None, backend=None, extra_headers=None,
+                folder_id=None,
                 ) -> "tuple[Any, list, str]":
     """The chat lane's shared prologue: validated history, doc targeting,
     and the configured agent. Returns (agent, input items, model name)."""
     system_texts, history = _split_chat_messages(messages)
     scope = client._local_doc_scope(doc_id)
-    block = doc_targeting_block(client, doc_id)
+    block = targeting_block(client, doc_id, folder_id)
     items = ([{"role": "user", "content": block}] if block else []) + history
     model_name = model or client.chat_model
     managed = _managed_instructions(client, system_texts)
     agent = _openai_agent(client, "chat", model_name, managed,
                           temperature, top_p, doc_ids=scope,
                           cache_key=_conversation_cache_key(
-                              model_name, managed, doc_id, history),
+                              model_name, managed, doc_id, history,
+                              folder_id),
                           reasoning_effort=reasoning_effort,
                           extra_body=extra_body, max_tokens=max_tokens,
                           backend=_merged_backend(client, backend),
@@ -878,7 +881,7 @@ def run_chat_stream(client, messages, doc_id=None, model=None,
                     reasoning_effort=None,
                     show_process: Union[bool, Mapping[str, Any]] = False,
                     max_turns=None, backend=None, extra_headers=None,
-                    extra_body=None,
+                    extra_body=None, folder_id=None,
                     ) -> ChatStream:
     """chat(stream=True): validation and the agent build run here, eagerly;
     the run itself starts when the returned stream's chosen view is first
@@ -896,7 +899,8 @@ def run_chat_stream(client, messages, doc_id=None, model=None,
     agent, items, _ = _chat_agent(client, messages, doc_id, model,
                                   reasoning_effort=reasoning_effort,
                                   extra_body=extra_body, backend=backend,
-                                  extra_headers=extra_headers)
+                                  extra_headers=extra_headers,
+                                  folder_id=folder_id)
     run_kwargs = _run_kwargs(max_turns)
 
     def events():
@@ -918,6 +922,7 @@ def run_chat_completions(client, messages, stream: bool = False,
                          extra_body: Optional[dict] = None,
                          extra_headers: Optional[dict] = None,
                          backend: Optional[dict] = None,
+                         folder_id: Optional[str] = None,
                          ) -> Union[dict, Iterator[str], Iterator[dict]]:
     if enable_citations:
         raise PageIndexAPIError(
@@ -932,7 +937,7 @@ def run_chat_completions(client, messages, stream: bool = False,
         client, messages, doc_id, model, temperature=temperature,
         top_p=top_p, reasoning_effort=reasoning_effort,
         extra_body=extra_body, max_tokens=max_tokens, backend=backend,
-        extra_headers=extra_headers)
+        extra_headers=extra_headers, folder_id=folder_id)
     reported_model = _reported_model(model_name)
     recorded: dict = {}
     _record_chat_finish(agent, recorded)
@@ -1019,6 +1024,7 @@ def run_responses(client, input, model: Optional[str] = None,
                   extra_body: Optional[dict] = None,
                   extra_headers: Optional[dict] = None,
                   backend: Optional[dict] = None,
+                  folder_id: Optional[str] = None,
                   ) -> Union[dict, Iterator[dict]]:
     _require_openai_agents("chat(protocol='responses')")
     _validate_max_turns(max_turns)
@@ -1031,7 +1037,7 @@ def run_responses(client, input, model: Optional[str] = None,
         raise PageIndexAPIError("messages must be a non-empty string or list "
                                 "of item dicts.")
     scope = client._local_doc_scope(doc_id)
-    block = doc_targeting_block(client, doc_id)
+    block = targeting_block(client, doc_id, folder_id)
     conversation = items
     if block:
         items = [{"role": "user", "content": block}] + items
@@ -1041,7 +1047,8 @@ def run_responses(client, input, model: Optional[str] = None,
     agent = _openai_agent(client, "responses", model_name, managed,
                           temperature, top_p, doc_ids=scope,
                           cache_key=_conversation_cache_key(
-                              model_name, managed, doc_id, conversation),
+                              model_name, managed, doc_id, conversation,
+                              folder_id),
                           reasoning=reasoning, extra_body=extra_body,
                           max_tokens=max_output_tokens,
                           backend=_merged_backend(client, backend),
@@ -1332,6 +1339,7 @@ def run_messages(client, messages, model: str,
                  extra_body: Optional[dict] = None,
                  extra_headers: Optional[dict] = None,
                  backend: Optional[dict] = None,
+                 folder_id: Optional[str] = None,
                  ) -> Union[dict, Iterator[Any]]:
     from .integrations.anthropic_sdk import build_anthropic_tools
 
@@ -1346,7 +1354,7 @@ def run_messages(client, messages, model: str,
         raise PageIndexAPIError("messages must be a non-empty string or a "
                                 "list of message dicts.")
     scope = client._local_doc_scope(doc_id)
-    block = doc_targeting_block(client, doc_id)
+    block = targeting_block(client, doc_id, folder_id)
     prepared = [dict(message) for message in messages]
     if block:
         prepared = [{"role": "user", "content": block}] + prepared

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1349,6 +1349,9 @@ def test_folders_are_cloud_only(local_client):
         local_client.create_folder("team")
     with pytest.raises(PageIndexAPIError, match="cloud-only"):
         local_client.list_folders()
+    with pytest.raises(PageIndexAPIError, match="cloud-only"):
+        local_client.folder_context("f")
+    assert local_client.folder_context("root") == ""  # the library itself
 
 
 # ── local: retrieval endpoints are cloud-only ──
@@ -1475,6 +1478,7 @@ def test_cloud_errors_carry_status_code(cloud, monkeypatch, sample_pdf):
         lambda: client.list_documents(),
         lambda: client.create_folder("f"),
         lambda: client.list_folders(),
+        lambda: client.folder_context("f"),
     ]
     for attempt in attempts:
         with pytest.raises(PageIndexAPIError) as err:
@@ -1537,6 +1541,19 @@ def test_cloud_chat_accepts_query_string(cloud):
         client.chat_completions("   ")
 
 
+def test_cloud_chat_folder_id_rides_the_wire(cloud):
+    """The managed chat scopes folder_id server-side: it goes out as the
+    request's own field, with no folder lookup on this side."""
+    client, calls, fake = cloud
+    fake.payload = {"choices": [{"message": {"content": "ok"}}]}
+    assert client.chat("q", folder_id="f-1") == "ok"
+    assert calls[-1]["url"].endswith("/chat/completions/")
+    assert calls[-1]["json"]["folder_id"] == "f-1"
+    assert len(calls) == 1
+    client.chat_completions("q", folder_id="")
+    assert "folder_id" not in calls[-1]["json"]
+
+
 def test_parse_pages_overlap_counts_union():
     from pageindex.client import _parse_pages
     pages = _parse_pages("1-5000,2000-9000")
@@ -1547,6 +1564,35 @@ def test_parse_pages_overlap_counts_union():
     # on — surfaced as the documented SDK error type
     with pytest.raises(PageIndexAPIError, match="positive"):
         _parse_pages("0-3")
+
+
+def test_folder_context(cloud):
+    """Folder targeting renders as the managed chat renders folder_id: the
+    name, an id/name/description metadata row (empty description dropped),
+    and the discovery directive carrying the id."""
+    client, calls, fake = cloud
+    fake.payload = {"folders": [
+        {"id": "f-1", "name": "Research", "description": "",
+         "parent_folder_id": None, "file_count": 2, "children_count": 1},
+        {"id": "f-2", "name": "Q3", "description": "quarterly",
+         "parent_folder_id": "f-1", "file_count": 1, "children_count": 0},
+    ], "total": 2}
+    text = client.folder_context("f-2")
+    assert calls[-1]["url"] == "https://api.pageindex.ai/folders/"
+    assert text.startswith("The user has specified folder: Q3\n")
+    assert ('Folder metadata: {"id": "f-2", "name": "Q3", '
+            '"description": "quarterly"}\n') in text
+    assert 'browse_documents(folder_id="f-2", recursive=true)' in text
+    assert ('Folder metadata: {"id": "f-1", "name": "Research"}\n'
+            in client.folder_context("f-1"))
+    with pytest.raises(PageIndexAPIError, match="not found"):
+        client.folder_context("f-9")
+    with pytest.raises(PageIndexAPIError, match="must be a string"):
+        client.folder_context(["f-1"])
+    calls.clear()
+    assert client.folder_context("root") == ""
+    assert client.folder_context("") == ""
+    assert calls == []
 
 
 # ── backend: the indexing lane ──

--- a/tests/test_local_chat.py
+++ b/tests/test_local_chat.py
@@ -1006,8 +1006,8 @@ def test_doc_id_conversations_get_distinct_cache_keys(client, store_path,
     keys = []
     real = local_chat._conversation_cache_key
 
-    def spy(model_name, instructions, doc_id, items):
-        key = real(model_name, instructions, doc_id, items)
+    def spy(model_name, instructions, doc_id, items, folder_id=None):
+        key = real(model_name, instructions, doc_id, items, folder_id)
         keys.append(key)
         return key
 
@@ -3010,6 +3010,86 @@ def test_bridge_doc_id_targets_at_prompt_level(bridge_client, fake_model,
     first = fake.inputs[0][0]
     assert "specified document" in first["content"]
     assert "r.pdf" in first["content"]
+
+
+def test_targeting_block_orders_folder_before_documents(bridge_client,
+                                                        monkeypatch):
+    """The folder block leads the document block, joined as the managed
+    chat joins them; "root" and no folder place nothing of their own."""
+    from pageindex.agent_tools import targeting_block
+    client, _ = bridge_client
+    monkeypatch.setattr(client, "list_folders", lambda: {"folders": [
+        {"id": "f-1", "name": "Team", "description": None}]})
+    monkeypatch.setattr(client, "get_document",
+                        lambda doc_id: {"name": "r.pdf", "status": "completed"})
+    both = targeting_block(client, "pi-a", "f-1")
+    assert both is not None
+    folder, doc = both.split("\n\n")
+    assert folder.startswith("The user has specified folder: Team\n")
+    assert 'Folder metadata: {"id": "f-1", "name": "Team"}\n' in folder
+    assert doc.startswith("The user has specified document: r.pdf\n")
+    assert targeting_block(client, "pi-a", "root") == doc
+    assert targeting_block(client, None, "f-1") == folder
+    assert targeting_block(client, None, None) is None
+
+
+@needs_agents
+def test_bridge_folder_id_targets_ahead_of_documents(bridge_client, fake_model,
+                                                     monkeypatch):
+    """folder_id is prompt-level targeting on cloud tools, one leading
+    user message with the folder block ahead of the document block."""
+    client, _ = bridge_client
+    monkeypatch.setattr(client, "list_folders", lambda: {"folders": [
+        {"id": "f-1", "name": "Team", "description": "shared"}]})
+    monkeypatch.setattr(client, "get_document",
+                        lambda doc_id: {"name": "r.pdf", "status": "completed"})
+    fake = fake_model([[_msg_item("ok")]])
+    with pytest.raises(PageIndexAPIError, match="not found"):
+        client.chat_completions("q", folder_id="f-9")
+    client.chat_completions("q", doc_id="pi-a", folder_id="f-1")
+    first, question = fake.inputs[0][:2]
+    assert first["content"].startswith("The user has specified folder: Team\n")
+    assert "The user has specified document: r.pdf" in first["content"]
+    assert question == {"role": "user", "content": "q"}
+
+
+@needs_agents
+def test_bridge_folder_id_reaches_the_protocol_lanes(bridge_client, fake_model,
+                                                     monkeypatch):
+    """chat(protocol="responses") threads folder_id to its engine."""
+    client, _ = bridge_client
+    monkeypatch.setattr(client, "list_folders", lambda: {"folders": [
+        {"id": "f-1", "name": "Team"}]})
+    fake = fake_model([[_msg_item("ok")]])
+    client.chat("q", protocol="responses", folder_id="f-1")
+    assert fake.inputs[0][0]["content"].startswith(
+        "The user has specified folder: Team\n")
+    assert fake.inputs[0][1] == {"role": "user", "content": "q"}
+
+
+@needs_anthropic
+def test_bridge_folder_id_reaches_the_messages_lane(bridge_client,
+                                                    fake_anthropic,
+                                                    monkeypatch):
+    """chat(protocol="messages") threads folder_id to its engine."""
+    client, _ = bridge_client
+    monkeypatch.setattr(client, "list_folders", lambda: {"folders": [
+        {"id": "f-1", "name": "Team"}]})
+    calls = fake_anthropic([
+        _anthropic_message([{"type": "text", "text": "ok"}], "end_turn")])
+    client.chat("q", protocol="messages", model="claude-test",
+                folder_id="f-1")
+    first, second = calls[0]["messages"][:2]
+    assert first["content"].startswith("The user has specified folder: Team\n")
+    assert second == {"role": "user", "content": "q"}
+
+
+@needs_agents
+def test_folder_id_is_cloud_only(client):
+    """A local library has no folders: folder_id refuses before any model
+    call, like the folder methods."""
+    with pytest.raises(PageIndexAPIError, match="cloud-only"):
+        client.chat_completions("q", folder_id="f-1")
 
 
 def test_bridge_gate_and_citations(monkeypatch):


### PR DESCRIPTION
Stacked on #495 (base `feat/document-context`); merge after it.

## What
- `client.folder_context(folder_id)`: the folder targeting text for the first user message, the folder analogue of `document_context()`.
- `chat(folder_id=)`, also on `chat_completions()` and the `responses` / `messages` protocol lanes: places it, or on the managed lane sends the field the server already accepts.

## Wire truth
- The managed `/chat/completions` takes `folder_id` (`ChatCompletionRequest.folder_id`, pageindex-compute `server/api/api.py:491`) and renders "The user has specified folder: ..." ahead of the document block (`api.py:3182`); the metadata row is the server's `FolderContext`: id, name, description (`server/lib/db/folders.py:50`). The SDK renders the same text.
- `/folders/` lists the same partition the chat validates against (`userId` + `api_surface_sql`, no LIMIT), so what the helper finds is what the server accepts; it carries `require_folder_plan`, so a non-Max key fails at the helper, not mid-run.

## Decisions
- `"root"` (and `""`) is the library itself: `folder_context` returns `""`, `chat` places nothing, on every lane and in every mode, as the server treats `folder_id="root"`.
- Own-model lanes: one leading user message, folder block then document block, joined with a blank line as the server joins them.
- `folder_id` joins the prompt-cache key, for the reason `doc_id` does.
- Keyword-only on `chat()`, trailing on every other signature: no positional call shifts.
- Cloud-only: a local client raises before any model call, like `create_folder` / `list_folders`.

## Verification
- 437/437 in test_client / test_agent_tools / test_local_chat, full suite green (one live-network test flaked on a proxy SSL EOF and passed on rerun); the without-frameworks leg passes.
- pyright: zero new diagnostics against the base branch.
- Live: managed `chat(q, folder_id=F)` lists the folder's documents; `folder_id="root"` answers normally; own-model over cloud tools calls `browse_documents(folder_id=F, recursive=true)` first and gives the same list.

Docs: VectifyAI/pageindex-docs#53.

https://claude.ai/code/session_01NsQjN5HMmmX4n5NVsZWYaw