### PR TITLE
Three docstring truths the 0.2.16 merges outran

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -1057,9 +1057,9 @@ class PageIndexClient:
                 ``"chat_completions"``, which the managed chat serves too.
             instructions: Persona or extra guidance for this call,
                 appended after the managed system prompt (which stays: it
-                carries the tool guidance and the document context) and
-                the client's own ``instructions``. A string on every
-                lane; with ``protocol="messages"`` also a list of
+                carries the tool guidance) and the client's own
+                ``instructions``. A string on every lane; with
+                ``protocol="messages"`` also a list of
                 Messages system blocks. On the answer lane and
                 ``protocol="chat_completions"`` it precedes any ``system``
                 rows in the history; the managed cloud chat receives them
@@ -1074,8 +1074,10 @@ class PageIndexClient:
                 through ``instructions=`` instead. Managed chat:
                 ``chat_completions``'s ``enable_citations`` — the endpoint
                 cites in its own inline markup, not ``<cite>`` tags, and
-                the resolved citations it returns come back only from
-                ``chat_completions``.
+                the resolved citations it returns ride the response
+                envelope, so they need ``chat_completions()`` or
+                ``protocol="chat_completions"``; the answer lane returns
+                the answer string alone.
             max_turns: Own-model chat only — cap on agent turns per call
                 (default 10). The OpenAI lanes raise at the cap;
                 ``protocol="messages"`` returns the truncated run
@@ -1977,8 +1979,7 @@ class PageIndexClient:
         guidance natively — not the client's ``instructions``, which only
         ``system_prompt`` carries; passing both duplicates the guidance
         (harmless). ``system_prompt`` stays the recommended channel: it is
-        guaranteed delivery, and the only
-        channel local mode has.
+        guaranteed delivery, and the only channel local mode has.
 
         Usage (or ``claude_agent_config()`` for all three slots in one
         call)::


### PR DESCRIPTION
Docstring-only. Three clauses in `client.py` that the five 0.2.16 merges made untrue — each was written on a branch cut before the change that voided it, and survived because neither side of the merge conflicted.

- **`chat(instructions=)`** called the managed system prompt the carrier of "the tool guidance and the document context". Document targeting moved to the first user message (#495), so it carries the tool guidance alone.
- **`chat(citations=)`** said the managed endpoint's resolved citations come back "only from `chat_completions`". They ride the response envelope, which `protocol="chat_completions"` (#493) returns whole as well; what cannot reach them is the answer lane, which returns the answer string.
- **`as_claude_mcp()`** gets back a line its paragraph lost to a merge.

No behavior change, no release needed — it rides the next one. 609 tests green.
