### PR TITLE
Block citations resolve to bounding boxes: get_block() and resolve_citations()

### DIFF
--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -45,6 +45,44 @@ def _parse_pages(pages: str) -> list[int]:
         raise PageIndexAPIError(str(exc)) from exc
 
 
+# The two citation tag formats PageIndex chat writes and renders, parsed as
+# the cloud parses them (the same expressions).
+_OLD_CITATION_RE = re.compile(
+    r"<doc=([^;]+);page=(\d+)(?:;block(?:_id)?=([^;>]+))?>")
+_CITE_TAG_RE = re.compile(
+    r"<cite\s+([^>]*?)\s*/?>|<cite\s+([^>]*?)>[^<]*</cite>")
+_CITE_ATTR_RE = re.compile(r"""(\w+)=["']([^"']*)["']""")
+
+
+def _parse_citations(text: str) -> list[dict[str, Any]]:
+    """``<doc=…;page=…;block=…>`` tags (the managed chat's format), then
+    ``<cite doc= page= block=/>`` tags; deduplicated, ``block_id`` only
+    when the tag carries one."""
+    found: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, Optional[str]]] = set()
+
+    def add(doc: str, page_str: str, block_id: Optional[str]) -> None:
+        try:
+            page = int(page_str.split("-")[0])
+        except ValueError:
+            return
+        key = (doc, page, block_id)
+        if doc and page > 0 and key not in seen:
+            seen.add(key)
+            entry: dict[str, Any] = {"document": doc, "page": page}
+            if block_id:
+                entry["block_id"] = block_id
+            found.append(entry)
+
+    for m in _OLD_CITATION_RE.finditer(text):
+        add(m.group(1).strip(), m.group(2), m.group(3) or None)
+    for m in _CITE_TAG_RE.finditer(text):
+        attrs = dict(_CITE_ATTR_RE.findall(m.group(1) or m.group(2) or ""))
+        add(attrs.get("doc", "").strip(), attrs.get("page", ""),
+            attrs.get("block") or None)
+    return found
+
+
 def _agents_sdk_model_name(model: str) -> str:
     """Preserve supported Agents SDK prefixes and route other provider paths via LiteLLM."""
     passthrough_prefixes = ("litellm/", "openai/")
@@ -717,6 +755,29 @@ class PageIndexClient:
                 f"(status: {result.get('status', 'unknown')})"
             )
         return [p for p in all_pages if p["page_index"] in wanted]
+
+    def get_block(self, doc_id: str, block_id: str) -> dict[str, Any]:
+        """
+        One layout block of a cloud document — the page, bounding box, type
+        and content behind a ``block_id`` from page content or a
+        block-level citation. Cloud-only: local page content has no
+        blocks, so local mode raises PageIndexAPIError.
+
+        Args:
+            doc_id (str): Document ID.
+            block_id (str): Block ID as page content and citations carry
+                it, e.g. ``"p3_text_5"``.
+
+        Returns:
+            dict: The block as the API returns it: {'doc_id', 'page',
+            'block_id', 'bbox', 'block_type', ...}. PageIndexAPIError with
+            ``status_code == 404`` when the document or the block does not
+            exist.
+        """
+        return self._require_cloud(
+            "get_block is cloud-only — local page content has no layout "
+            "blocks. Create the client with an api_key to look up blocks."
+        ).get_block(doc_id=doc_id, block_id=block_id)
 
     # ---------- TREE GENERATION ----------
 
@@ -2100,6 +2161,87 @@ class PageIndexClient:
         """
         from .agent_tools import fetch_citation_prompt
         return fetch_citation_prompt(self, format or "cite")
+
+    def resolve_citations(
+        self,
+        answer: str,
+        doc_ids: Optional[Union[str, list[str]]] = None,
+    ) -> list[dict[str, Any]]:
+        """
+        The citations in a cited answer, each with the id of the document
+        it names and, for a block-level citation on a cloud document, the
+        block behind it from ``get_block()`` — page, bounding box, type and
+        content: the managed chat's ``citations`` entries, plus ``doc_id``
+        and the block's ``text``. Reads both tag formats PageIndex chat
+        writes: ``<cite doc= page= block=/>`` (own-model
+        ``chat(citations=True)``) and ``<doc=…;page=…;block=…>`` (the
+        managed chat). The markdown and footnote formats of
+        ``citation_prompt()`` are prose for readers and are not parsed.
+
+        Args:
+            answer (str): The answer text, tags included.
+            doc_ids (str | list[str], optional): The documents the answer
+                was about — what ``chat(doc_id=...)`` took. Citations name
+                documents, and the ids come from here; without it your own
+                library is listed, so a document shared with you resolves
+                only through ``doc_ids``. Two documents sharing a cited
+                name raise PageIndexAPIError naming both ids: pass
+                ``doc_ids`` to pick.
+
+        Returns:
+            list: One dict per distinct citation: ``{'document', 'doc_id',
+            'page'}`` for a page-level citation, plus ``'block_id'`` and
+            the block's fields (``'bbox'``, ``'block_type'``, ...) for a
+            block-level one. A document not in the library keeps
+            ``doc_id: None``; a block the document does not have (a
+            model's slip) keeps its citation without a bbox.
+        """
+        if not isinstance(answer, str):
+            raise PageIndexAPIError("answer must be a str — the answer text "
+                                    "with its citation tags.")
+        if doc_ids is not None and not isinstance(doc_ids, (str, list)):
+            raise PageIndexAPIError("doc_ids must be a string or a list of "
+                                    "strings.")
+        citations = _parse_citations(answer)
+        if not citations:
+            return []
+        names: dict[str, list[str]] = {}
+        if doc_ids is not None:
+            if isinstance(doc_ids, str):
+                doc_ids = [doc_ids]
+            for doc_id in dict.fromkeys(doc_ids):
+                name = self.get_document(doc_id)["name"]
+                names.setdefault(name, []).append(doc_id)
+        else:
+            offset = 0
+            while True:
+                page = self.list_documents(limit=100, offset=offset)
+                for doc in page["documents"]:
+                    names.setdefault(doc["name"], []).append(doc["id"])
+                offset += len(page["documents"])
+                if not page["documents"] or offset >= page["total"]:
+                    break
+        resolved: list[dict[str, Any]] = []
+        for citation in citations:
+            ids = names.get(citation["document"], [])
+            if len(ids) > 1:
+                raise PageIndexAPIError(
+                    f"{citation['document']!r} names {len(ids)} documents "
+                    f"({', '.join(ids)}) — pass doc_ids= to pick one.")
+            entry: dict[str, Any] = {"document": citation["document"],
+                                     "doc_id": ids[0] if ids else None,
+                                     "page": citation["page"]}
+            block_id = citation.get("block_id")
+            if block_id:
+                entry["block_id"] = block_id
+                if entry["doc_id"]:
+                    try:
+                        entry.update(self.get_block(entry["doc_id"], block_id))
+                    except PageIndexAPIError as exc:
+                        if exc.status_code != 404:
+                            raise
+            resolved.append(entry)
+        return resolved
 
     def folder_context(self, folder_id: str) -> str:
         """

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -46,12 +46,12 @@ def _parse_pages(pages: str) -> list[int]:
 
 
 # The two citation tag formats PageIndex chat writes and renders, parsed as
-# the cloud parses them (the same expressions).
+# the cloud parses them.
 _OLD_CITATION_RE = re.compile(
-    r"<doc=([^;]+);page=(\d+)(?:;block(?:_id)?=([^;>]+))?>")
+    r"<doc=([^;<>]+);page=(\d+)(?:;block(?:_id)?=([^;>]+))?>")
 _CITE_TAG_RE = re.compile(
     r"<cite\s+([^>]*?)\s*/?>|<cite\s+([^>]*?)>[^<]*</cite>")
-_CITE_ATTR_RE = re.compile(r"""(\w+)=["']([^"']*)["']""")
+_CITE_ATTR_RE = re.compile(r"""(\w+)=(["'])(.*?)\2""", re.S)
 
 
 def _parse_citations(text: str) -> list[dict[str, Any]]:
@@ -77,7 +77,8 @@ def _parse_citations(text: str) -> list[dict[str, Any]]:
     for m in _OLD_CITATION_RE.finditer(text):
         add(m.group(1).strip(), m.group(2), m.group(3) or None)
     for m in _CITE_TAG_RE.finditer(text):
-        attrs = dict(_CITE_ATTR_RE.findall(m.group(1) or m.group(2) or ""))
+        attrs = {name: value for name, _, value in
+                 _CITE_ATTR_RE.findall(m.group(1) or m.group(2) or "")}
         add(attrs.get("doc", "").strip(), attrs.get("page", ""),
             attrs.get("block") or None)
     return found
@@ -770,7 +771,9 @@ class PageIndexClient:
 
         Returns:
             dict: The block as the API returns it: {'doc_id', 'page',
-            'block_id', 'bbox', 'block_type', ...}. PageIndexAPIError with
+            'block_id', 'bbox', 'block_type', ...}. ``bbox`` is
+            ``[x0, y0, x1, y1]`` in thousandths of the page's width and
+            height (0-1000), origin top-left. PageIndexAPIError with
             ``status_code == 404`` when the document or the block does not
             exist.
         """
@@ -2183,18 +2186,19 @@ class PageIndexClient:
             doc_ids (str | list[str], optional): The documents the answer
                 was about — what ``chat(doc_id=...)`` took. Citations name
                 documents, and the ids come from here; without it your own
-                library is listed, so a document shared with you resolves
-                only through ``doc_ids``. Two documents sharing a cited
-                name raise PageIndexAPIError naming both ids: pass
-                ``doc_ids`` to pick.
+                library is listed. Two documents sharing a cited name
+                raise PageIndexAPIError naming both ids: pass ``doc_ids``
+                to pick.
 
         Returns:
             list: One dict per distinct citation: ``{'document', 'doc_id',
             'page'}`` for a page-level citation, plus ``'block_id'`` and
-            the block's fields (``'bbox'``, ``'block_type'``, ...) for a
-            block-level one. A document not in the library keeps
-            ``doc_id: None``; a block the document does not have (a
-            model's slip) keeps its citation without a bbox.
+            the block's fields as ``get_block()`` returns them (``'bbox'``,
+            ``'block_type'``, ...) for a block-level one. A document not in
+            the library keeps ``doc_id: None``; a block the document does
+            not have (a model's slip), or that cannot be looked up (local
+            mode, a document you cannot read), keeps its citation without
+            a bbox.
         """
         if not isinstance(answer, str):
             raise PageIndexAPIError("answer must be a str — the answer text "
@@ -2202,6 +2206,10 @@ class PageIndexClient:
         if doc_ids is not None and not isinstance(doc_ids, (str, list)):
             raise PageIndexAPIError("doc_ids must be a string or a list of "
                                     "strings.")
+        if doc_ids is not None and not doc_ids:
+            raise PageIndexAPIError("doc_ids is empty. Pass the answer's "
+                                    "document ids, or omit doc_ids to "
+                                    "resolve against your library.")
         citations = _parse_citations(answer)
         if not citations:
             return []
@@ -2213,17 +2221,12 @@ class PageIndexClient:
                 name = self.get_document(doc_id)["name"]
                 names.setdefault(name, []).append(doc_id)
         else:
-            offset = 0
-            while True:
-                page = self.list_documents(limit=100, offset=offset)
-                for doc in page["documents"]:
-                    names.setdefault(doc["name"], []).append(doc["id"])
-                offset += len(page["documents"])
-                if not page["documents"] or offset >= page["total"]:
-                    break
+            from .agent_tools import _all_documents
+            for doc in _all_documents(self):
+                names.setdefault(doc["name"], []).append(doc["id"])
         resolved: list[dict[str, Any]] = []
         for citation in citations:
-            ids = names.get(citation["document"], [])
+            ids = list(dict.fromkeys(names.get(citation["document"], [])))
             if len(ids) > 1:
                 raise PageIndexAPIError(
                     f"{citation['document']!r} names {len(ids)} documents "
@@ -2238,7 +2241,8 @@ class PageIndexClient:
                     try:
                         entry.update(self.get_block(entry["doc_id"], block_id))
                     except PageIndexAPIError as exc:
-                        if exc.status_code != 404:
+                        # Local raises carry no status; 429/5xx propagate.
+                        if exc.status_code not in (None, 403, 404):
                             raise
             resolved.append(entry)
         return resolved

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -47,7 +47,7 @@ def _parse_pages(pages: str) -> list[int]:
 
 # The two citation tag formats PageIndex chat writes and renders.
 _OLD_CITATION_RE = re.compile(
-    r"<doc=([^;<>]+);page=(\d+)(?:;block(?:_id)?=([^;>]+))?>")
+    r"<doc=([^;<>]+);page=(\d+)(?:;block(?:_id)?=([^;<>]+))?>")
 _CITE_TAG_RE = re.compile(r"<cite\s([^<>]*)>")
 _CITE_ATTR_RE = re.compile(r"""(\w+)=(["'])(.*?)\2""", re.S)
 
@@ -2221,7 +2221,8 @@ class PageIndexClient:
         else:
             from .agent_tools import _all_documents
             for doc in _all_documents(self):
-                names.setdefault(doc["name"], []).append(doc["id"])
+                if doc.get("name") and doc.get("id"):
+                    names.setdefault(doc["name"], []).append(doc["id"])
         resolved: list[dict[str, Any]] = []
         for citation in citations:
             ids = list(dict.fromkeys(names.get(citation["document"], [])))

--- a/pageindex/client.py
+++ b/pageindex/client.py
@@ -45,12 +45,10 @@ def _parse_pages(pages: str) -> list[int]:
         raise PageIndexAPIError(str(exc)) from exc
 
 
-# The two citation tag formats PageIndex chat writes and renders, parsed as
-# the cloud parses them.
+# The two citation tag formats PageIndex chat writes and renders.
 _OLD_CITATION_RE = re.compile(
     r"<doc=([^;<>]+);page=(\d+)(?:;block(?:_id)?=([^;>]+))?>")
-_CITE_TAG_RE = re.compile(
-    r"<cite\s+([^>]*?)\s*/?>|<cite\s+([^>]*?)>[^<]*</cite>")
+_CITE_TAG_RE = re.compile(r"<cite\s([^<>]*)>")
 _CITE_ATTR_RE = re.compile(r"""(\w+)=(["'])(.*?)\2""", re.S)
 
 
@@ -78,7 +76,7 @@ def _parse_citations(text: str) -> list[dict[str, Any]]:
         add(m.group(1).strip(), m.group(2), m.group(3) or None)
     for m in _CITE_TAG_RE.finditer(text):
         attrs = {name: value for name, _, value in
-                 _CITE_ATTR_RE.findall(m.group(1) or m.group(2) or "")}
+                 _CITE_ATTR_RE.findall(m.group(1))}
         add(attrs.get("doc", "").strip(), attrs.get("page", ""),
             attrs.get("block") or None)
     return found

--- a/pageindex/cloud_api.py
+++ b/pageindex/cloud_api.py
@@ -121,7 +121,9 @@ class CloudAPI:
 
         Returns:
             dict: The block as the API returns it: {'doc_id', 'page',
-                'block_id', 'bbox', 'block_type', ...}. A 404 means the
+                'block_id', 'bbox', 'block_type', ...}. bbox is
+                [x0, y0, x1, y1] in thousandths of the page's width and
+                height (0-1000), origin top-left. A 404 means the
                 document has no such block.
         """
         response = requests.get(

--- a/pageindex/cloud_api.py
+++ b/pageindex/cloud_api.py
@@ -110,6 +110,31 @@ class CloudAPI:
                 status_code=response.status_code)
         return response.json()
 
+    def get_block(self, doc_id: str, block_id: str) -> Dict[str, Any]:
+        """
+        Get one layout block of a document by the block_id its page content
+        and block-level citations carry.
+
+        Args:
+            doc_id (str): Document ID.
+            block_id (str): Block ID, e.g. "p3_text_5".
+
+        Returns:
+            dict: The block as the API returns it: {'doc_id', 'page',
+                'block_id', 'bbox', 'block_type', ...}. A 404 means the
+                document has no such block.
+        """
+        response = requests.get(
+            f"{self.BASE_URL}/doc/{_enc(doc_id)}/block/{_enc(block_id)}/",
+            headers=self._headers(),
+            timeout=30
+        )
+        if response.status_code != 200:
+            raise PageIndexAPIError(
+                f"Failed to get block: {response.text}",
+                status_code=response.status_code)
+        return response.json()
+
     # ---------- TREE GENERATION ----------
 
     def get_tree(self, doc_id: str, node_summary: bool = False,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -610,6 +610,21 @@ def test_get_page_content_span_bomb_rejected(local_client, indexed_doc):
     assert local_client.get_page_content(indexed_doc, "5-10004") == []
 
 
+def test_local_citations_resolve_to_pages_only(local_client, indexed_doc):
+    """Local page content has no blocks: page citations resolve to the
+    document id, block lookups name the cloud-only exit."""
+    answer = 'Apples <cite doc="sample.pdf" page="1"/> and none <cite doc="other.pdf" page="2"/>.'
+    assert local_client.resolve_citations(answer) == [
+        {"document": "sample.pdf", "doc_id": indexed_doc, "page": 1},
+        {"document": "other.pdf", "doc_id": None, "page": 2},
+    ]
+    with pytest.raises(PageIndexAPIError, match="get_block is cloud-only"):
+        local_client.get_block(indexed_doc, "p1_text_1")
+    with pytest.raises(PageIndexAPIError, match="get_block is cloud-only"):
+        local_client.resolve_citations(
+            '<cite doc="sample.pdf" page="1" block="p1_text_1"/>')
+
+
 def test_submit_does_not_create_cwd_logs(local_client, sample_pdf, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     def fake_page_index_main(doc, opt=None, logger=None, page_list=None):
@@ -1475,6 +1490,7 @@ def test_cloud_errors_carry_status_code(cloud, monkeypatch, sample_pdf):
         lambda: client.chat_completions(
             messages=[{"role": "user", "content": "q"}]),
         lambda: client.get_document("pi-1"),
+        lambda: client.get_block("pi-1", "p1_text_1"),
         lambda: client.delete_document("pi-1"),
         lambda: client.list_documents(),
         lambda: client.create_folder("f"),
@@ -1485,6 +1501,144 @@ def test_cloud_errors_carry_status_code(cloud, monkeypatch, sample_pdf):
         with pytest.raises(PageIndexAPIError) as err:
             attempt()
         assert err.value.status_code == 418
+
+
+def test_parse_citations_mirrors_the_cloud_parser():
+    """Both tag formats PageIndex chat writes, in the cloud parser's terms:
+    old tags first, then <cite> tags (self-closing or paired, either
+    quote), block_id only when carried, page ranges to their first page,
+    page 0 and nameless tags dropped, duplicates collapsed."""
+    from pageindex.client import _parse_citations
+    text = (
+        'A <cite doc="a.pdf" page="3" block="p3_text_5"/> B '
+        "<cite doc='b.pdf' page='1-2'>quoted</cite> "
+        '<cite doc="a.pdf" page="3" block="p3_text_5"/> '
+        '<cite doc="" page="1"/> <cite doc="a.pdf" page="0"/> '
+        '<cite doc="a.pdf" page="x"/> '
+        "<doc=c.pdf;page=7> <doc=c.pdf;page=7;block_id=p7_text_1> "
+        "<doc= d.pdf ;page=2;block=p2_img_1>"
+    )
+    assert _parse_citations(text) == [
+        {"document": "c.pdf", "page": 7},
+        {"document": "c.pdf", "page": 7, "block_id": "p7_text_1"},
+        {"document": "d.pdf", "page": 2, "block_id": "p2_img_1"},
+        {"document": "a.pdf", "page": 3, "block_id": "p3_text_5"},
+        {"document": "b.pdf", "page": 1},
+    ]
+    assert _parse_citations("no tags, just [a.pdf, p. 3] prose") == []
+
+
+def _library(docs):
+    """A cloud handler serving /docs/ (100 per page) and /doc/<id>/block/
+    lookups from {doc_id: (name, {block_id: block})}."""
+    def handler(method, url, kw):
+        if url.endswith("/docs/"):
+            offset = kw["params"]["offset"]
+            entries = [{"id": doc_id, "name": name}
+                       for doc_id, (name, _) in docs.items()]
+            return FakeResponse({"documents": entries[offset:offset + 100],
+                                 "total": len(entries), "limit": 100,
+                                 "offset": offset})
+        m = re.fullmatch(r".*/doc/([^/]+)/metadata/", url)
+        if m:
+            return FakeResponse({"id": m.group(1), "name": docs[m.group(1)][0]})
+        m = re.fullmatch(r".*/doc/([^/]+)/block/([^/]+)/", url)
+        block = docs[m.group(1)][1].get(m.group(2))
+        if block is None:
+            return FakeResponse(status_code=404, text="Block not found.")
+        return FakeResponse(block)
+    return handler
+
+
+def test_resolve_citations_cloud(cloud, monkeypatch):
+    """Names become ids from the library, block citations pick up the
+    block's fields, a block the document lacks keeps a bbox-less entry,
+    an unknown document keeps doc_id None."""
+    client, calls, fake = cloud
+    block = {"doc_id": "pi-a", "page": 3, "block_id": "p3_text_5",
+             "bbox": [163, 398, 842, 589], "block_type": "text",
+             "text": "Apples."}
+    _patch_requests(monkeypatch, _library({
+        "pi-a": ("a.pdf", {"p3_text_5": block}),
+        "pi-b": ("b.pdf", {}),
+    }))
+    answer = ('X <cite doc="a.pdf" page="3" block="p3_text_5"/> '
+              'Y <cite doc="a.pdf" page="9" block="p9_text_9"/> '
+              'Z <cite doc="b.pdf" page="2"/> W <cite doc="c.pdf" page="1"/>')
+    assert client.resolve_citations(answer) == [
+        {"document": "a.pdf", **block},
+        {"document": "a.pdf", "doc_id": "pi-a", "page": 9,
+         "block_id": "p9_text_9"},
+        {"document": "b.pdf", "doc_id": "pi-b", "page": 2},
+        {"document": "c.pdf", "doc_id": None, "page": 1},
+    ]
+    assert client.resolve_citations("no citations here") == []
+
+    # doc_ids= skips the library listing: one metadata call per id.
+    library = _library({"pi-a": ("a.pdf", {"p3_text_5": block})})
+    def no_listing(method, url, kw):
+        assert not url.endswith("/docs/"), "doc_ids= must not list the library"
+        return library(method, url, kw)
+    _patch_requests(monkeypatch, no_listing)
+    for scope in ("pi-a", ["pi-a", "pi-a"]):  # a repeated id is not a collision
+        assert client.resolve_citations(
+            '<cite doc="a.pdf" page="3" block="p3_text_5"/>', doc_ids=scope,
+        ) == [{"document": "a.pdf", **block}]
+
+    for not_text in (None, ['<cite doc="a.pdf" page="1"/>']):
+        with pytest.raises(PageIndexAPIError, match="answer must be a str"):
+            client.resolve_citations(not_text)
+    with pytest.raises(PageIndexAPIError, match="doc_ids must be a string or a list"):
+        client.resolve_citations(answer, doc_ids=5)
+
+
+def test_resolve_citations_lists_the_whole_library(cloud, monkeypatch):
+    client, calls, fake = cloud
+    seen_offsets = []
+    library = _library({f"pi-{i}": (f"{i}.pdf", {}) for i in range(150)})
+    def handler(method, url, kw):
+        if url.endswith("/docs/"):
+            seen_offsets.append(kw["params"]["offset"])
+        return library(method, url, kw)
+    _patch_requests(monkeypatch, handler)
+    assert client.resolve_citations('<cite doc="149.pdf" page="1"/>') == [
+        {"document": "149.pdf", "doc_id": "pi-149", "page": 1}]
+    assert seen_offsets == [0, 100]
+
+
+def test_resolve_citations_refuses_a_shared_name(cloud, monkeypatch):
+    """Two documents under one cited name would silently pick a bbox from
+    the wrong one: raise, name both ids, point at doc_ids=."""
+    client, calls, fake = cloud
+    _patch_requests(monkeypatch, _library({"pi-1": ("a.pdf", {}),
+                                           "pi-2": ("a.pdf", {})}))
+    with pytest.raises(PageIndexAPIError, match=r"pi-1, pi-2.*doc_ids="):
+        client.resolve_citations('<cite doc="a.pdf" page="1"/>')
+    assert client.resolve_citations('<cite doc="a.pdf" page="1"/>',
+                                    doc_ids=["pi-2"]) == [
+        {"document": "a.pdf", "doc_id": "pi-2", "page": 1}]
+
+
+def test_resolve_citations_only_swallows_404(cloud, monkeypatch):
+    client, calls, fake = cloud
+    def handler(method, url, kw):
+        if "/block/" in url:
+            return FakeResponse(status_code=500, text="boom")
+        return _library({"pi-a": ("a.pdf", {})})(method, url, kw)
+    _patch_requests(monkeypatch, handler)
+    with pytest.raises(PageIndexAPIError, match="Failed to get block: boom") as err:
+        client.resolve_citations('<cite doc="a.pdf" page="1" block="p1_text_1"/>')
+    assert err.value.status_code == 500
+
+
+def test_get_block_request_wiring(cloud):
+    client, calls, fake = cloud
+    fake.payload = {"doc_id": "pi/1", "page": 3, "block_id": "p3_text_5",
+                    "bbox": [1, 2, 3, 4], "block_type": "text"}
+    assert client.get_block("pi/1", "p3_text_5") == fake.payload
+    assert calls[-1]["url"] == "https://api.pageindex.ai/doc/pi%2F1/block/p3_text_5/"
+    assert calls[-1]["headers"] == {"api_key": "secret"}
+    assert calls[-1]["timeout"] == 30
 
 
 def test_cloud_chat_stream_parsing(cloud, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -612,7 +612,8 @@ def test_get_page_content_span_bomb_rejected(local_client, indexed_doc):
 
 def test_local_citations_resolve_to_pages_only(local_client, indexed_doc):
     """Local page content has no blocks: page citations resolve to the
-    document id, block lookups name the cloud-only exit."""
+    document id, get_block names the cloud-only exit, and a block citation
+    keeps its entry without a bbox."""
     answer = 'Apples <cite doc="sample.pdf" page="1"/> and none <cite doc="other.pdf" page="2"/>.'
     assert local_client.resolve_citations(answer) == [
         {"document": "sample.pdf", "doc_id": indexed_doc, "page": 1},
@@ -620,9 +621,10 @@ def test_local_citations_resolve_to_pages_only(local_client, indexed_doc):
     ]
     with pytest.raises(PageIndexAPIError, match="get_block is cloud-only"):
         local_client.get_block(indexed_doc, "p1_text_1")
-    with pytest.raises(PageIndexAPIError, match="get_block is cloud-only"):
-        local_client.resolve_citations(
-            '<cite doc="sample.pdf" page="1" block="p1_text_1"/>')
+    assert local_client.resolve_citations(
+        '<cite doc="sample.pdf" page="1" block="p1_text_1"/>') == [
+        {"document": "sample.pdf", "doc_id": indexed_doc, "page": 1,
+         "block_id": "p1_text_1"}]
 
 
 def test_submit_does_not_create_cwd_logs(local_client, sample_pdf, tmp_path, monkeypatch):
@@ -1590,6 +1592,22 @@ def test_resolve_citations_cloud(cloud, monkeypatch):
             client.resolve_citations(not_text)
     with pytest.raises(PageIndexAPIError, match="doc_ids must be a string or a list"):
         client.resolve_citations(answer, doc_ids=5)
+    with pytest.raises(PageIndexAPIError, match="doc_ids is empty"):
+        client.resolve_citations(answer, doc_ids=[])
+
+
+def test_resolve_citations_quotes_and_tag_edges(cloud, monkeypatch):
+    """A quoted name keeps its apostrophe, and a managed-chat tag without
+    its own ';' stops at the next tag instead of swallowing it."""
+    client, calls, fake = cloud
+    _patch_requests(monkeypatch, _library({"pi-m": ("Moody's Outlook.pdf", {}),
+                                           "pi-b": ("b.pdf", {})}))
+    answer = ("""Held <cite doc="Moody's Outlook.pdf" page="3"/> and overall """
+              "<doc=b.pdf> is long, but revenue rose <doc=b.pdf;page=7>.")
+    assert client.resolve_citations(answer) == [
+        {"document": "b.pdf", "doc_id": "pi-b", "page": 7},
+        {"document": "Moody's Outlook.pdf", "doc_id": "pi-m", "page": 3},
+    ]
 
 
 def test_resolve_citations_lists_the_whole_library(cloud, monkeypatch):
@@ -1606,6 +1624,22 @@ def test_resolve_citations_lists_the_whole_library(cloud, monkeypatch):
     assert seen_offsets == [0, 100]
 
 
+def test_resolve_citations_listing_survives_a_shifting_library(cloud, monkeypatch):
+    """A listing without 'total' ends on the empty page, and a document
+    re-served after an upload shifted the window is still one document."""
+    client, calls, fake = cloud
+    def handler(method, url, kw):
+        assert url.endswith("/docs/")
+        offset = kw["params"]["offset"]
+        entries = [{"id": f"pi-{i}", "name": f"{i}.pdf"} for i in range(150)]
+        if offset:
+            entries.insert(0, {"id": "pi-new", "name": "new.pdf"})
+        return FakeResponse({"documents": entries[offset:offset + 100]})
+    _patch_requests(monkeypatch, handler)
+    assert client.resolve_citations('<cite doc="99.pdf" page="1"/>') == [
+        {"document": "99.pdf", "doc_id": "pi-99", "page": 1}]
+
+
 def test_resolve_citations_refuses_a_shared_name(cloud, monkeypatch):
     """Two documents under one cited name would silently pick a bbox from
     the wrong one: raise, name both ids, point at doc_ids=."""
@@ -1619,15 +1653,22 @@ def test_resolve_citations_refuses_a_shared_name(cloud, monkeypatch):
         {"document": "a.pdf", "doc_id": "pi-2", "page": 1}]
 
 
-def test_resolve_citations_only_swallows_404(cloud, monkeypatch):
+def test_resolve_citations_keeps_blocks_it_cannot_read(cloud, monkeypatch):
+    """A denied block (403) keeps its bbox-less entry like a missing one;
+    a transport failure still propagates with its status."""
     client, calls, fake = cloud
+    status = {"code": 403}
     def handler(method, url, kw):
         if "/block/" in url:
-            return FakeResponse(status_code=500, text="boom")
+            return FakeResponse(status_code=status["code"], text="boom")
         return _library({"pi-a": ("a.pdf", {})})(method, url, kw)
     _patch_requests(monkeypatch, handler)
+    answer = '<cite doc="a.pdf" page="1" block="p1_text_1"/>'
+    assert client.resolve_citations(answer) == [
+        {"document": "a.pdf", "doc_id": "pi-a", "page": 1, "block_id": "p1_text_1"}]
+    status["code"] = 500
     with pytest.raises(PageIndexAPIError, match="Failed to get block: boom") as err:
-        client.resolve_citations('<cite doc="a.pdf" page="1" block="p1_text_1"/>')
+        client.resolve_citations(answer)
     assert err.value.status_code == 500
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1530,6 +1530,17 @@ def test_parse_citations_mirrors_the_cloud_parser():
     assert _parse_citations("no tags, just [a.pdf, p. 3] prose") == []
 
 
+def test_parse_citations_is_linear_on_unterminated_tags():
+    """An unterminated '<cite ' followed by whitespace is caller-supplied
+    text; the scan must stay linear, not backtrack for minutes."""
+    import time
+    from pageindex.client import _parse_citations
+    started = time.perf_counter()
+    assert _parse_citations("<cite " + " " * 2000) == []
+    assert _parse_citations(("<cite " + " " * 40) * 200) == []
+    assert time.perf_counter() - started < 2
+
+
 def _library(docs):
     """A cloud handler serving /docs/ (100 per page) and /doc/<id>/block/
     lookups from {doc_id: (name, {block_id: block})}."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1608,8 +1608,9 @@ def test_resolve_citations_cloud(cloud, monkeypatch):
 
 
 def test_resolve_citations_quotes_and_tag_edges(cloud, monkeypatch):
-    """A quoted name keeps its apostrophe, and a managed-chat tag without
-    its own ';' stops at the next tag instead of swallowing it."""
+    """A quoted name keeps its apostrophe, and neither field of a
+    managed-chat tag runs past the tag: an unterminated name and an
+    unterminated block both stop at the next tag instead of eating it."""
     client, calls, fake = cloud
     _patch_requests(monkeypatch, _library({"pi-m": ("Moody's Outlook.pdf", {}),
                                            "pi-b": ("b.pdf", {})}))
@@ -1619,6 +1620,10 @@ def test_resolve_citations_quotes_and_tag_edges(cloud, monkeypatch):
         {"document": "b.pdf", "doc_id": "pi-b", "page": 7},
         {"document": "Moody's Outlook.pdf", "doc_id": "pi-m", "page": 3},
     ]
+    # A block= that never closes must not swallow the citation after it.
+    assert client.resolve_citations(
+        '<doc=b.pdf;page=3;block=p3_text_5 <cite doc="b.pdf" page="9"/>'
+    ) == [{"document": "b.pdf", "doc_id": "pi-b", "page": 9}]
 
 
 def test_resolve_citations_lists_the_whole_library(cloud, monkeypatch):
@@ -1636,13 +1641,16 @@ def test_resolve_citations_lists_the_whole_library(cloud, monkeypatch):
 
 
 def test_resolve_citations_listing_survives_a_shifting_library(cloud, monkeypatch):
-    """A listing without 'total' ends on the empty page, and a document
-    re-served after an upload shifted the window is still one document."""
+    """A listing without 'total' ends on the empty page, a document
+    re-served after an upload shifted the window is still one document,
+    and an entry missing 'name' or 'id' is skipped, not a KeyError."""
     client, calls, fake = cloud
     def handler(method, url, kw):
         assert url.endswith("/docs/")
         offset = kw["params"]["offset"]
         entries = [{"id": f"pi-{i}", "name": f"{i}.pdf"} for i in range(150)]
+        entries[7] = {"id": "pi-7"}
+        entries[8] = {"name": "8.pdf"}
         if offset:
             entries.insert(0, {"id": "pi-new", "name": "new.pdf"})
         return FakeResponse({"documents": entries[offset:offset + 100]})


### PR DESCRIPTION
## What

Two client methods for turning block-level citations into page coordinates:

- `client.get_block(doc_id, block_id)` — one layout block as the API returns it (`doc_id, page, block_id, bbox, block_type, text`), via `GET /doc/{doc_id}/block/{block_id}/`. `bbox` is `[x0, y0, x1, y1]` in thousandths of the page's width and height (0-1000), origin top-left. Cloud-only; local mode raises, because local page content has no blocks.
- `client.resolve_citations(answer, doc_id=None)` — parses the `<cite doc= page= block=/>` tags own-model `chat(citations=True)` writes and the `<doc=…;page=…;block=…>` tags the managed chat writes (the cloud parser's expressions, tightened: quotes paired, names and tag bodies stopped at the tag's edge, attribute names anchored at a word boundary, so an unterminated or malformed tag scans in linear time; names and block ids trimmed), deduplicates, maps document names to ids, and merges `get_block()`'s fields into each block-level entry. Output is the managed chat's `citations` entry shape plus `doc_id` and `text`.

## Semantics

- `doc_id` — what `chat(doc_id=...)` took — scopes the name → id lookup; without it the client lists your own library (100 per page, ids deduplicated). `doc_id=[]` fails loud like `chat(doc_id=[])`.
- Two documents under one cited name raise `PageIndexAPIError` naming both ids — no guessing.
- A block the document does not have (a model's slip) keeps its entry without `bbox`; so does a block that cannot be looked up (local mode, a document you cannot read). Every other status re-raises.
- A document not in the library keeps `doc_id: None`. The markdown / footnote formats of `citation_prompt()` are prose and are not parsed.

## Depends on

VectifyAI/pageindex-compute PR #607 — the block route — squash-merged into `dev` as 6842852a and deployed to Dev (Sep 13). Live-verified there against a document submitted with `beta_headers=["block_reference"]`: `get_block()` returns the bbox; `resolve_citations()` merges it on both the library and the `doc_id=` path, keeps a missing block without a bbox, returns `doc_id: None` for an unknown name, and resolves the `<doc=…;page=…;block=…>` tag the managed chat itself wrote (`enable_citations=True`) to a table block's bbox. Tests here run against fakes.

## Tests

11 in `tests/test_client.py`: parser cases for both tag formats (padded names and block ids trimmed), a linear-time bound on unterminated tags and on a tag whose body is one long word, cloud resolution (found / missing block / unknown document / `doc_id` scope including a repeated id / argument guards including `doc_id=[]`), an apostrophe inside a quoted name next to a bare `<doc=…>` tag, full-library paging, a listing without `total` that re-serves a document after an upload shifted the window, shared-name refusal, a 403 block kept and a 500 re-raised, request wiring, and local mode's page-level result plus the cloud-only refusal on `get_block` and the bbox-less block entry. Full suite 619 green, pyright clean.

Docs (`chat.mdx` / `documents.mdx`) and the release note follow with the release.
